### PR TITLE
Bug in MeshTexture::FaceOutlierDetection

### DIFF
--- a/libs/MVS/SceneTexture.cpp
+++ b/libs/MVS/SceneTexture.cpp
@@ -821,6 +821,7 @@ bool MeshTexture::FaceOutlierDetection(FaceDataArr& faceDatas, float thOutlier) 
 		// (all views with a gauss value above the threshold)
 		bool bChanged(false);
 		size_t numInliers(0);
+		colors.conservativeResize(3, faceDatas.GetSize());
 		FOREACH(i, faceDatas) {
 			const Eigen::Vector3d color(((const Color::EVec)faceDatas[i].color).cast<double>());
 			const double gaussValue(MultiGaussUnnormalized<double,3>(color, mean, covarianceInv));
@@ -828,13 +829,13 @@ bool MeshTexture::FaceOutlierDetection(FaceDataArr& faceDatas, float thOutlier) 
 			if (gaussValue > thOutlier) {
 				// set as inlier
 				colors.col(numInliers++) = color;
-				if (inlier != true) {
+				if (inlier == false) {
 					inlier = true;
 					bChanged = true;
 				}
 			} else {
 				// set as outlier
-				if (inlier != false) {
+				if (inlier == true) {
 					inlier = false;
 					bChanged = true;
 				}


### PR DESCRIPTION
This PR fix a tiny bug encountered on Linux and GCC.

In MeshTexture::FaceOutlierDetection you consider to detect the outliers in an iterative manner, using an array called colors that have a changing size during the iteration process.

At the start the colors array is of size (3, faceDatas.GetSize())
at the end of each iteration only the inliers are kept using the conservativeResize
colors.conservativeResize(3, numInliers);

Often inliers count only decrease, but if the inlier count could also increase.
The decrease and increasing make the crash appear.
Eigen crash mentioning you access to a row index that is greater than the row count.

For example there is 20 faceData, the first iteration will find 6 inliers and use conservativeResize to emulate there is only 6 cols to be used (despite there is 20 allocated row).
When you classify again the inlier, you go from 0 to faceData again, so when you access to element 7 for Eigen it does not exist since the number of cols of the used matrix is 6.
In order to fix that I reset the col count to faceData count at each iteration... and the inlier classification will do the job to resize to the good value each time.

So when required I have called
```
colors.conservativeResize(3, faceDatas.GetSize());
// to make
colors.col(numInliers++)
// work in the range 0 -> faceDatas.GetSize()
```

This fix helps on some scenes.
But TextureMesh is still crashing on some other. I saw that the new crash only happens in Release mode (Debug mode runs fine). It make me think about some variables that could be not correctly initialized...

