### PR TITLE
add "cd .." to openMVG install

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -91,6 +91,7 @@ mkdir openMVG_build
 cd openMVG_build
 cmake -DCMAKE_BUILD_TYPE=RELEASE . ../openMVG/src/ -DCMAKE_INSTALL_PREFIX=$main_path/openMVG_build/openMVG_install
 make
+cd ..
 
 #OpenMVS
 git clone https://github.com/cdcseacave/openMVS.git openMVS


### PR DESCRIPTION
as openMVG is optional, we might need to cd back to the home folder to build openMVG.

Otherwise folder structure is:
~/openMVG
~/openMVG_build
~/openMVG_build/openMVS
~/openMVG_build/openMVS_build