### PR TITLE
Do not divide by z twice when projecting.

### DIFF
--- a/libs/MVS/Camera.h
+++ b/libs/MVS/Camera.h
@@ -237,12 +237,12 @@ public:
 	template <typename TYPE>
 	inline TPoint2<TYPE> ProjectPointRT(const TPoint3<TYPE>& X) const {
 		const TPoint3<TYPE> q(R * (X - C));
-		return ((const TPoint2<TYPE>&)q)*INVERT(q.z);
+		return TPoint2<TYPE>(q.x/q.z, q.y/q.z);
 	}
 	template <typename TYPE>
 	inline TPoint2<TYPE> ProjectPoint(const TPoint3<TYPE>& X) const {
 		const TPoint3<TYPE> q(K * (R * (X - C)));
-		return ((const TPoint2<TYPE>&)q)*INVERT(q.z);
+		return TPoint2<TYPE>(q.x/q.z, q.y/q.z);
 	}
 	template <typename TYPE>
 	inline TPoint3<TYPE> ProjectPointP3(const TPoint3<TYPE>& X) const {
@@ -255,7 +255,7 @@ public:
 	template <typename TYPE>
 	inline TPoint2<TYPE> ProjectPointP(const TPoint3<TYPE>& X) const {
 		const TPoint3<TYPE> q(ProjectPointP3(X));
-		return ((const TPoint2<TYPE>&)q)*INVERT(q.z);
+		return TPoint2<TYPE>(q.x/q.z, q.y/q.z);
 	}
 
 	// transform from image pixel coords to view plane coords


### PR DESCRIPTION
As commented in #109, on a mac, the conversion from cv::Point3_ to TPoint2 is dividing x and y by z, so there is no need to divide by z a second time.

Creating TPoint2 using numbers instead of a cv::Point3_ avoids dividing twice.
