### PR TITLE
Check Points for NaN

### DIFF
--- a/libs/MVS/SceneReconstruct.cpp
+++ b/libs/MVS/SceneReconstruct.cpp
@@ -807,6 +807,7 @@ bool Scene::ReconstructMesh(float distInsert, bool bUseFreeSpaceSupport, unsigne
 		int li, lj;
 		std::for_each(indices.cbegin(), indices.cend(), [&](size_t idx) {
 			const point_t& p = vertices[idx];
+			if (std::isnan(p.hx())) { return; }
 			const PointCloud::Point& point = pointcloud.points[idx];
 			const PointCloud::ViewArr& views = pointcloud.pointViews[idx];
 			ASSERT(!views.IsEmpty());


### PR DESCRIPTION
Points which resolve as NaN for any dimension, fail the Delaunay tetrahedralization process in CGAL.  Added check for NaN to at least 1 dimension (X).  More information here, https://github.com/cdcseacave/openMVS/issues/161