### PR TITLE
Fix build break caused by libvcg

### DIFF
--- a/libs/MVS/Mesh.cpp
+++ b/libs/MVS/Mesh.cpp
@@ -42,6 +42,7 @@
 // VCG: mesh reconstruction post-processing
 #define _SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS
 #include <vcg/complex/complex.h>
+#include <vcg/simplex/face/jumping_pos.h>
 #include <vcg/complex/algorithms/create/platonic.h>
 #include <vcg/complex/algorithms/stat.h>
 #include <vcg/complex/algorithms/clean.h>
@@ -2200,16 +2201,16 @@ static int ImproveVertexValence(Polyhedron& p, int valence_mode=2)
 
 static void UpdateMeshData(Polyhedron& p);
 
-// Description: 
+// Description:
 //  It iterates through all the mesh vertices and it tries to fix degenerate triangles.
 //  There are conditions that check for large and small angles.
 // Parameters:
-//  - degenerateAngleDeg 
+//  - degenerateAngleDeg
 //     - for large angles: if an angle is bigger than degenerateAngleDeg.
 //     - a good values to use is typically 170
-//  - collapseRatio 
+//  - collapseRatio
 //     - for small angles: given the corresponding edges (a,b,c) in all permutations, if (a/b < collapseRatio) & (a/c < collapseRatio)
-//     - a good value to use is 0.1 
+//     - a good value to use is 0.1
 static int FixDegeneracy(Polyhedron& p, double collapseRatio, double degenerateAngleDeg)
 {
 	DEBUG_LEVEL(3, "Fix degeneracy: %g collapse-ratio, %g degenerate-angle", collapseRatio, degenerateAngleDeg);
@@ -2419,7 +2420,7 @@ static void Smooth(Polyhedron& p, double delta, int mode=0)
 }
 
 
-// Description: 
+// Description:
 // - The goal of this method is to ensure that all the edges of the mesh are within the interval [epsilonMin,epsilonMax].
 //   In order to do so, edge collapses and edge split operations are performed.
 // - The method also attempts to fix degeneracies by invoking FixDegeneracy(collapseRatio,degenerate_angle_deg) and performs some local smoothing, based on the operating mode.
@@ -2430,7 +2431,7 @@ static void Smooth(Polyhedron& p, double delta, int mode=0)
 //          1 - fixDegeneracy=Yes smoothing=Yes; (default)
 //         10 - fixDegeneracy=Yes smoothing=No;
 // - max_iter (default=30) - maximum number of iterations to be performed; since there is no guarantee that one operations (such as a collapse, for example)
-//   will not in turn generate new degeneracies, operations are being performed on the mesh in an iterative fashion. 
+//   will not in turn generate new degeneracies, operations are being performed on the mesh in an iterative fashion.
 static void EnsureEdgeSize(Polyhedron& p, double epsilonMin, double epsilonMax, double collapseRatio, double degenerate_angle_deg, int mode, int max_iters, int comp_size_threshold)
 {
 	if (mode>0)
@@ -2525,7 +2526,7 @@ static void EnsureEdgeSize(Polyhedron& p, double epsilonMin, double epsilonMax, 
 		ComputeStatsEdge(p, edge);
 		VERBOSE("Edge size in [%g, %g] (requested in [%g, %g]): %d ops, %d iters", edge.min, edge.max, epsilonMin, epsilonMax, total_no_ops, iters);
 	}
-	#endif	
+	#endif
 }
 
 static void ComputeVertexNormals(Polyhedron& p)
@@ -2558,7 +2559,7 @@ static std::vector< std::pair<Vertex*, int> > GetRingNeighbourhood(Vertex& v, in
 	std::queue<Vertex*> elems;
 	std::vector< std::pair<Vertex*, int> > result;
 
-	// add base level	
+	// add base level
 	elems.push(&v);
 	neigh_map[&v]=0;
 
@@ -2669,7 +2670,7 @@ static void UpdateMeshData(Polyhedron& p)
 	// compute vertex normal
 	ComputeVertexNormals(p);
 	#if ROBUST_NORMALS>0
-	// compute robust vertex normal		
+	// compute robust vertex normal
 	for (Vertex_iterator vi=p.vertices_begin(); vi!=p.vertices_end(); vi++)
 		ComputeVertexRobustNormal(*vi, ROBUST_NORMALS);
 	#endif
@@ -2688,7 +2689,7 @@ static void UpdateMeshData(Polyhedron& p)
 		ComputeVertexLaplacianDeriv(*vi);
 	}
 
-	// set border edges	
+	// set border edges
 	for (Halfedge_iterator hi=p.border_halfedges_begin(); hi!=p.halfedges_end(); hi++)
 		hi->vertex()->setBorder();
 }
@@ -2708,7 +2709,7 @@ public:
 		typedef typename HDS::Vertex::Point Point;
 		CGAL::Polyhedron_incremental_builder_3<HDS> B(hds, false);
 		B.begin_surface(vertices.GetSize(), faces.GetSize());
-		// add the vertices		
+		// add the vertices
 		FOREACH(i, vertices) {
 			const Mesh::Vertex& v = vertices[i];
 			B.add_vertex(Point(v.x, v.y, v.z));


### PR DESCRIPTION
There is a build break at mesh.cpp:1092, vcg::face::JumpingPos<CLEAN::Face> declaration.
It seems caused by the recent vcg changes.

Including the header file solves the issue.