### PR TITLE
Fix compilation.

### DIFF
--- a/libs/Common/Hash.h
+++ b/libs/Common/Hash.h
@@ -243,7 +243,7 @@ public:
 	}
 	static inline Key HashKey(const uint8_t* data, UINT size) { return HashKeyFNV(data, size); }
 	static inline Key HashKey(LPCTSTR sz) { return HashKey((const uint8_t*)sz, _tcslen(sz)); }
-	static inline Key HashKey(const String& str) { return HashKey(str.c_str(), str.size()); }
+	static inline Key HashKey(const String& str) { return HashKey((const uint8_t*)str.c_str(), (UINT)str.size()); }
 
 	// Convenience functions
 	inline		 Type*	Find		(LPCTSTR		key)			{ return  Find  ( HashKey(key) );			}

--- a/libs/Common/Hash.h
+++ b/libs/Common/Hash.h
@@ -242,7 +242,7 @@ public:
 		return key;
 	}
 	static inline Key HashKey(const uint8_t* data, UINT size) { return HashKeyFNV(data, size); }
-	static inline Key HashKey(LPCTSTR sz) { return HashKey((const uint8_t*)sz, _tcslen(sz)); }
+	static inline Key HashKey(LPCTSTR sz) { return HashKey((const uint8_t*)sz, (UINT)_tcslen(sz)); }
 	static inline Key HashKey(const String& str) { return HashKey((const uint8_t*)str.c_str(), (UINT)str.size()); }
 
 	// Convenience functions

--- a/libs/Common/Types.inl
+++ b/libs/Common/Types.inl
@@ -2060,7 +2060,7 @@ void TImage<TYPE>::toGray(TImage<T>& out, int code, bool bNormalize) const
 	const T &cb(coeffs[0]), &cg(coeffs[1]), &cr(coeffs[2]);
 	if (out.rows!=rows || out.cols!=cols)
 		out.create(rows, cols);
-	ASSERT(cv::Mat::isContinuous());
+	ASSERT(this->isContinuous());
 	ASSERT(out.cv::Mat::isContinuous());
 	const int scn(this->channels());
 	T* dst = out.cv::Mat::template ptr<T>();
@@ -2274,7 +2274,7 @@ inline void _ProcessScanLine(int y, const TPoint3<T>& pa, const TPoint3<T>& pb, 
 	}
 }
 // Raster the given triangle and output the position and depth of each pixel of the triangle;
-// based on "Learning how to write a 3D software engine – Rasterization & Z-Buffering" by Nick (David Rousset)
+// based on "Learning how to write a 3D software engine Â– Rasterization & Z-Buffering" by Nick (David Rousset)
 // http://blogs.msdn.com/b/davrous/archive/2013/06/21/tutorial-part-4-learning-how-to-write-a-3d-software-engine-in-c-ts-or-js-rasterization-amp-z-buffering.aspx
 template <typename TYPE>
 template <typename T, typename PARSER>

--- a/libs/Common/Types.inl
+++ b/libs/Common/Types.inl
@@ -2062,7 +2062,7 @@ void TImage<TYPE>::toGray(TImage<T>& out, int code, bool bNormalize) const
 		out.create(rows, cols);
 	ASSERT(cv::Mat::isContinuous());
 	ASSERT(out.cv::Mat::isContinuous());
-	const int scn(cv::Mat::channels());
+	const int scn(this->channels());
 	T* dst = out.cv::Mat::template ptr<T>();
 	T* const dstEnd = dst + out.area();
 	typedef typename cv::DataType<TYPE>::channel_type ST;


### PR DESCRIPTION
Should resolve #311.

Not sure if you other folks need to build in an environment where the `cv` change would break things, but I had to do this stuff to get openMVS to build on Arch with GCC 7.3.1 and OpenCV 3.4.1.