### PR TITLE
Mesh vertex coloring as an alternative to mesh texturing

### DIFF
--- a/apps/TextureMesh/TextureMesh.cpp
+++ b/apps/TextureMesh/TextureMesh.cpp
@@ -53,6 +53,7 @@ float fOutlierThreshold;
 float fRatioDataSmoothness;
 bool bGlobalSeamLeveling;
 bool bLocalSeamLeveling;
+bool bColorVertices;
 unsigned nTextureSizeMultiple;
 unsigned nRectPackingHeuristic;
 uint32_t nColEmpty;
@@ -108,6 +109,8 @@ bool Initialize(size_t argc, LPCTSTR* argv)
 		("patch-packing-heuristic", boost::program_options::value<unsigned>(&OPT::nRectPackingHeuristic)->default_value(3), "specify the heuristic used when deciding where to place a new patch (0 - best fit, 3 - good speed, 100 - best speed)")
 		("empty-color", boost::program_options::value<uint32_t>(&OPT::nColEmpty)->default_value(0x00FF7F27), "color used for faces not covered by any image")
 		("orthographic-image-resolution", boost::program_options::value<unsigned>(&OPT::nOrthoMapResolution)->default_value(0), "orthographic image resolution to be generated from the textured mesh - the mesh is expected to be already geo-referenced or at least properly oriented (0 - disabled)")
+		("color-vertices", boost::program_options::value<bool>(&OPT::bColorVertices)->default_value(false), "set color for mesh vertices and do not generate a texture")
+
 		;
 
 	// hidden options, allowed both on command line and
@@ -226,7 +229,7 @@ int main(int argc, LPCTSTR* argv)
 	{
 	// compute mesh texture
 	TD_TIMER_START();
-	if (!scene.TextureMesh(OPT::nResolutionLevel, OPT::nMinResolution, OPT::fOutlierThreshold, OPT::fRatioDataSmoothness, OPT::bGlobalSeamLeveling, OPT::bLocalSeamLeveling, OPT::nTextureSizeMultiple, OPT::nRectPackingHeuristic, Pixel8U(OPT::nColEmpty)))
+	if (!scene.TextureMesh(OPT::nResolutionLevel, OPT::nMinResolution, OPT::fOutlierThreshold, OPT::fRatioDataSmoothness, OPT::bGlobalSeamLeveling, OPT::bLocalSeamLeveling, OPT::bColorVertices, OPT::nTextureSizeMultiple, OPT::nRectPackingHeuristic, Pixel8U(OPT::nColEmpty)))
 		return EXIT_FAILURE;
 	VERBOSE("Mesh texturing completed: %u vertices, %u faces (%s)", scene.mesh.vertices.GetSize(), scene.mesh.faces.GetSize(), TD_TIMER_GET_FMT().c_str());
 

--- a/libs/MVS/Mesh.h
+++ b/libs/MVS/Mesh.h
@@ -65,6 +65,9 @@ public:
 	typedef cList<VertexIdxArr> VertexVerticesArr;
 	typedef cList<FaceIdxArr> VertexFacesArr;
 
+	typedef Pixel8U Color;
+	typedef CLISTDEF0(Color) VertexColorArr;
+
 	typedef TPoint3<Type> Normal;
 	typedef cList<Normal,const Normal&,0,8192,FIndex> NormalArr;
 
@@ -90,6 +93,8 @@ public:
 	VertexVerticesArr vertexVertices; // for each vertex, the list of adjacent vertices (optional)
 	VertexFacesArr vertexFaces; // for each vertex, the list of faces containing it (optional)
 	BoolArr vertexBoundary; // for each vertex, stores if it is at the boundary or not (optional)
+	VertexColorArr vertexColors; // for each vertex, stores its assigned color (optional)
+
 
 	NormalArr faceNormals; // for each face, the normal to it (optional)
 	TexCoordArr faceTexcoords; // for each face, the texture-coordinates corresponding to the contained vertices (optional)

--- a/libs/MVS/Scene.h
+++ b/libs/MVS/Scene.h
@@ -95,7 +95,7 @@ public:
 	#endif
 
 	// Mesh texturing
-	bool TextureMesh(unsigned nResolutionLevel, unsigned nMinResolution, float fOutlierThreshold=0.f, float fRatioDataSmoothness=0.3f, bool bGlobalSeamLeveling=true, bool bLocalSeamLeveling=true, unsigned nTextureSizeMultiple=0, unsigned nRectPackingHeuristic=3, Pixel8U colEmpty=Pixel8U(255,127,39));
+	bool TextureMesh(unsigned nResolutionLevel, unsigned nMinResolution, float fOutlierThreshold=0.f, float fRatioDataSmoothness=0.3f, bool bGlobalSeamLeveling=true, bool bLocalSeamLeveling=true, bool bColorVertices=false, unsigned nTextureSizeMultiple=0, unsigned nRectPackingHeuristic=3, Pixel8U colEmpty=Pixel8U(255,127,39));
 
 	#ifdef _USE_BOOST
 	// implement BOOST serialization


### PR DESCRIPTION
- Added an option to TextureMesh NOT to generate a texture image but rather assign colors to vertices after seam leveling
- Added vertex color support in Mesh class to be able to hold these colors and save them into a PLY file

This feature is a nice-have when working with large collections of images (say, 500). With the default TextureMesh behavior, the PNG texture tends to take forever to generate and in the end is not loadable anyway. Vertex coloring is an alternative that at least gives the mesh some coloring, even if not that beautiful. Taking the colors from texture patches rather than the dense point cloud benefits from seam leveling, which is very important in case of photos taken under diverse lighting conditions (in my case it is in caves).

