### PR TITLE
Fix --filter-point-cloud usage

### DIFF
--- a/apps/DensifyPointCloud/DensifyPointCloud.cpp
+++ b/apps/DensifyPointCloud/DensifyPointCloud.cpp
@@ -245,7 +245,7 @@ int main(int argc, LPCTSTR* argv)
 		VERBOSE("error: empty initial point-cloud");
 		return EXIT_FAILURE;
 	}
-	if (OPT::thFilterPointCloud < 0) {
+	if (OPT::thFilterPointCloud > 0) {
 		// filter point-cloud based on camera-point visibility intersections
 		scene.PointCloudFilter(OPT::thFilterPointCloud);
 		const String baseFileName(MAKE_PATH_SAFE(Util::getFileFullName(OPT::strOutputFileName))+_T("_filtered"));


### PR DESCRIPTION
The check for the arg `--filter-point-cloud` appears to be flipped, only running `scene.PointCloudFilter(...)` with a negative number. This means that nothing ends up being filtered as every point has greater than 0 views.

There's a remaining bug where verbose mode segfaults in `PointCloudFilter`, but I wasn't able to see a quick fix:
```
Point visibility checks 129977 (100%, 42s971ms)           
03:36:11 [App     ] Visibility lengths (129977 points):
	  0 -    129391
	  2 -       229
	  3 -        41
	  4 -        18
	  5 -        10
	  6 -         2
	  7 -         1
	  8 -         2
	  9 -         1
DensifyPointCloud: /openMVS/openMVS/libs/MVS/../Common/List.h:354: TYPE& SEACAVE::cList<TYPE, ARG_TYPE, useConstruct, grow, IDX_TYPE>::operator[](SEACAVE::cList<TYPE, ARG_TYPE, useConstruct, grow, IDX_TYPE>::IDX) [with TYPE = SEACAVE::TPixel<unsigned char>; ARG_TYPE = const SEACAVE::TPixel<unsigned char>&; int useConstruct = 0; int grow = 16; IDX_TYPE = long unsigned int; SEACAVE::cList<TYPE, ARG_TYPE, useConstruct, grow, IDX_TYPE>::IDX = long unsigned int]: Assertion `index < _size' failed.

Thread 1 "DensifyPointClo" received signal SIGABRT, Aborted.
__GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
51	../sysdeps/unix/sysv/linux/raise.c: No such file or directory.
(gdb) bt
[SNIP]
    at /openMVS/openMVS/libs/MVS/../Common/List.h:354
#5  0x0000555555ccf4a6 in MVS::Scene::PointCloudFilter (this=0x7fffffffe360, thRemove=20)
    at /openMVS/openMVS/libs/MVS/SceneDensify.cpp:2112
#6  0x0000555555a98e3c in main (argc=6, argv=0x7fffffffe608)
    at /openMVS/openMVS/apps/DensifyPointCloud/DensifyPointCloud.cpp:250
```

