### PR TITLE
General: Add global ID to MVS::Image

### DIFF
--- a/apps/InterfaceCOLMAP/InterfaceCOLMAP.cpp
+++ b/apps/InterfaceCOLMAP/InterfaceCOLMAP.cpp
@@ -475,6 +475,7 @@ bool ImportScene(const String& strFolder, Interface& scene)
 			image.name = OPT::strImageFolder+it.first.name;
 			image.platformID = mapCameras.at(it.first.idCamera);
 			image.cameraID = 0;
+			image.ID = it.first.ID;
 			Interface::Platform& platform = scene.platforms[image.platformID];
 			image.poseID = (uint32_t)platform.poses.size();
 			platform.poses.push_back(pose);

--- a/apps/InterfaceOpenMVG/InterfaceOpenMVG.cpp
+++ b/apps/InterfaceOpenMVG/InterfaceOpenMVG.cpp
@@ -602,6 +602,7 @@ int main(int argc, LPCTSTR* argv)
 			const String srcImage(MAKE_PATH_FULL(WORKING_FOLDER_FULL, pathRoot+image.name));
 			image.name = MAKE_PATH_FULL(WORKING_FOLDER_FULL, OPT::strOutputImageFolder+image.name);
 			Util::ensureDirectory(image.name);
+			image.ID = static_cast<uint32_t>(view.first);
 			image.platformID = map_intrinsic.at(view.second->id_intrinsic);
 			MVS::Platform& platform = scene.platforms[image.platformID];
 			image.cameraID = 0;
@@ -688,6 +689,7 @@ int main(int argc, LPCTSTR* argv)
 			image.name = imageBAF.name;
 			Util::ensureUnifySlash(image.name);
 			image.name = MAKE_PATH_FULL(WORKING_FOLDER_FULL, image.name);
+			image.ID = imageBAF.id_camera;
 			image.platformID = imageBAF.id_camera;
 			MVS::Platform& platform = scene.platforms[image.platformID];
 			image.cameraID = 0;

--- a/apps/InterfacePhotoScan/InterfacePhotoScan.cpp
+++ b/apps/InterfacePhotoScan/InterfacePhotoScan.cpp
@@ -344,6 +344,7 @@ bool ParseImageListXML(MVS::Scene& scene, PlatformDistCoeffs& pltDistCoeffs, siz
 		imageData.name = MAKE_PATH_FULL(strPath, imageData.name);
 		imageData.platformID = camera->UnsignedAttribute(_T("sensor_id"));
 		imageData.cameraID = 0; // only one camera per platform supported by this format
+		imageData.ID = ID;
 		if (!camera->BoolAttribute(_T("enabled"))) {
 			imageData.poseID = NO_ID;
 			DEBUG_EXTRA("warning: uncalibrated image '%s'", name);

--- a/apps/InterfaceVisualSFM/InterfaceVisualSFM.cpp
+++ b/apps/InterfaceVisualSFM/InterfaceVisualSFM.cpp
@@ -308,6 +308,7 @@ int ImportSceneVSFM()
 		MVS::Platform& platform = scene.platforms.AddEmpty();
 		MVS::Platform::Camera& camera = platform.cameras.AddEmpty();
 		image.cameraID = 0;
+		image.ID = static_cast<uint32_t>(idx);
 		const PBA::Camera& cameraNVM = cameras[idx];
 		camera.K = MVS::Platform::Camera::ComposeK<REAL,REAL>(cameraNVM.GetFocalLength(), cameraNVM.GetFocalLength(), image.width, image.height);
 		camera.R = RMatrix::IDENTITY;

--- a/libs/Common/Types.h
+++ b/libs/Common/Types.h
@@ -100,6 +100,7 @@ namespace boost { void throw_exception(std::exception const&); }
 #include <boost/serialization/list.hpp>
 #include <boost/serialization/map.hpp>
 #include <boost/serialization/set.hpp>
+#include <boost/serialization/version.hpp>
 #if (BOOST_VERSION / 100000) > 1 || (BOOST_VERSION / 100 % 1000) > 55
 #include <boost/serialization/unordered_map.hpp>
 #include <boost/serialization/unordered_set.hpp>

--- a/libs/MVS/Image.h
+++ b/libs/MVS/Image.h
@@ -88,7 +88,7 @@ public:
 	float avgDepth; // average depth of the points seen by this camera
 
 public:
-	inline Image() {
+	inline Image(): ID(NO_ID) {
 		#ifndef _RELEASE
 		width = height = 0;
 		#endif
@@ -124,7 +124,7 @@ public:
 		ar & platformID;
 		ar & cameraID;
 		ar & poseID;
-		if (version > 2) {
+		if (version > 1) {
 			ar & ID;
 		}
 		const String relName(MAKE_PATH_REL(WORKING_FOLDER_FULL, name));
@@ -139,7 +139,7 @@ public:
 		ar & cameraID;
 		ar & poseID;
 		ar & poseID;
-		if (version > 2) {
+		if (version > 1) {
 			ar & ID;
 		}
 		ar & name;
@@ -155,5 +155,10 @@ typedef MVS_API CLISTDEF2IDX(Image,IIndex) ImageArr;
 /*----------------------------------------------------------------*/
 
 } // namespace MVS
+
+#ifdef _USE_BOOST
+// Set class version. This must be global
+BOOST_CLASS_VERSION(MVS::Image, 1);
+#endif
 
 #endif // _MVS_VIEW_H_

--- a/libs/MVS/Image.h
+++ b/libs/MVS/Image.h
@@ -78,6 +78,7 @@ public:
 	uint32_t platformID; // ID of the associated platform
 	uint32_t cameraID; // ID of the associated camera on the associated platform
 	uint32_t poseID; // ID of the pose of the associated platform
+	uint32_t ID; // Global ID of the image
 	String name; // image file name (relative path)
 	Camera camera; // view's pose
 	uint32_t width, height; // image size
@@ -119,10 +120,13 @@ public:
 	#ifdef _USE_BOOST
 	// implement BOOST serialization
 	template<class Archive>
-	void save(Archive& ar, const unsigned int /*version*/) const {
+	void save(Archive& ar, const unsigned int version) const {
 		ar & platformID;
 		ar & cameraID;
 		ar & poseID;
+		if (version > 2) {
+			ar & ID;
+		}
 		const String relName(MAKE_PATH_REL(WORKING_FOLDER_FULL, name));
 		ar & relName;
 		ar & width & height;
@@ -130,10 +134,14 @@ public:
 		ar & avgDepth;
 	}
 	template<class Archive>
-	void load(Archive& ar, const unsigned int /*version*/) {
+	void load(Archive& ar, const unsigned int version) {
 		ar & platformID;
 		ar & cameraID;
 		ar & poseID;
+		ar & poseID;
+		if (version > 2) {
+			ar & ID;
+		}
 		ar & name;
 		name = MAKE_PATH_FULL(WORKING_FOLDER_FULL, name);
 		ar & width & height;

--- a/libs/MVS/Image.h
+++ b/libs/MVS/Image.h
@@ -124,7 +124,7 @@ public:
 		ar & platformID;
 		ar & cameraID;
 		ar & poseID;
-		if (version > 1) {
+		if (version > 0) {
 			ar & ID;
 		}
 		const String relName(MAKE_PATH_REL(WORKING_FOLDER_FULL, name));
@@ -139,7 +139,7 @@ public:
 		ar & cameraID;
 		ar & poseID;
 		ar & poseID;
-		if (version > 1) {
+		if (version > 0) {
 			ar & ID;
 		}
 		ar & name;

--- a/libs/MVS/Scene.cpp
+++ b/libs/MVS/Scene.cpp
@@ -123,6 +123,7 @@ bool Scene::LoadInterface(const String & fileName)
 		}
 		imageData.platformID = image.platformID;
 		imageData.cameraID = image.cameraID;
+		imageData.ID = image.ID;
 		// init camera
 		const Interface::Platform::Camera& camera = obj.platforms[image.platformID].cameras[image.cameraID];
 		if (camera.HasResolution()) {
@@ -231,6 +232,7 @@ bool Scene::SaveInterface(const String & fileName) const
 		image.poseID = imageData.poseID;
 		image.platformID = imageData.platformID;
 		image.cameraID = imageData.cameraID;
+		image.ID = imageData.ID;
 	}
 
 	// export 3D points


### PR DESCRIPTION
See #438 (and https://github.com/cdcseacave/openMVS/issues/438#issuecomment-504864399)

- Added the global `ID` to `MVS::Image`
- Added Global ID management in `Scene::LoadInterface(`) and `Scene::SaveInterface() `
- Tried to use the most plausible global `ID` in each interface.

