### PR TITLE
(DensifyPointCloud) Fix crash when working directory is provided 

### DIFF
--- a/apps/DensifyPointCloud/DensifyPointCloud.cpp
+++ b/apps/DensifyPointCloud/DensifyPointCloud.cpp
@@ -167,7 +167,7 @@ bool Initialize(size_t argc, LPCTSTR* argv)
 		OPT::strOutputFileName = Util::getFileFullName(OPT::strInputFileName) + _T("_dense.mvs");
 
 	// init dense options
-	if (!Util::isFullPath(OPT::strDenseConfigFileName))
+	if (!OPT::strDenseConfigFileName.IsEmpty() && !Util::isFullPath(OPT::strDenseConfigFileName))
 		OPT::strDenseConfigFileName = MAKE_PATH(OPT::strDenseConfigFileName);
 	OPTDENSE::init();
 	const bool bValidConfig(OPTDENSE::oConfig.Load(OPT::strDenseConfigFileName));

--- a/apps/DensifyPointCloud/DensifyPointCloud.cpp
+++ b/apps/DensifyPointCloud/DensifyPointCloud.cpp
@@ -167,8 +167,8 @@ bool Initialize(size_t argc, LPCTSTR* argv)
 		OPT::strOutputFileName = Util::getFileFullName(OPT::strInputFileName) + _T("_dense.mvs");
 
 	// init dense options
-	if (!OPT::strDenseConfigFileName.IsEmpty() && !Util::isFullPath(OPT::strDenseConfigFileName))
-		OPT::strDenseConfigFileName = MAKE_PATH(OPT::strDenseConfigFileName);
+	if (!OPT::strDenseConfigFileName.IsEmpty())
+		OPT::strDenseConfigFileName = MAKE_PATH_SAFE(OPT::strDenseConfigFileName);
 	OPTDENSE::init();
 	const bool bValidConfig(OPTDENSE::oConfig.Load(OPT::strDenseConfigFileName));
 	OPTDENSE::update();
@@ -180,7 +180,7 @@ bool Initialize(size_t argc, LPCTSTR* argv)
 	OPTDENSE::nOptimize = nOptimize;
 	OPTDENSE::nEstimateColors = nEstimateColors;
 	OPTDENSE::nEstimateNormals = nEstimateNormals;
-	if (!bValidConfig)
+	if (!bValidConfig && !OPT::strDenseConfigFileName.IsEmpty())
 		OPTDENSE::oConfig.Save(OPT::strDenseConfigFileName);
 
 	// initialize global options


### PR DESCRIPTION
Fixes an exception that was being thrown when the working directory option `-w` is provided. 

Problem: `MAKE_PATH` appends working directory to dense config file path (`OPT::strDenseConfigFileName`). When this path is empty (which is the default) and when working directory is provided, the config loader effectively tries to load the working directory path as a config file. This fails deep inside the config loader.

Solution: Make sure the config file path is non-empty before appending the working directory and trying to load the config info.

Fixes #445 