### PR TITLE
Fix ReconstructMesh crash #303

### DIFF
--- a/libs/Common/Plane.inl
+++ b/libs/Common/Plane.inl
@@ -390,7 +390,7 @@ template <typename TYPE, int DIMS>
 void TFrustum<TYPE,DIMS>::Set(const MATRIX3x4& m, TYPE w, TYPE h, TYPE n, TYPE f)
 {
 	MATRIX4x4 M(MATRIX4x4::Identity());
-	M.template topLeftCorner<3,4>() = m;
+	M.template topLeftCorner(3,4) = m;
 	Set(M, w, h, n, f);
 } // Set
 /*----------------------------------------------------------------*/


### PR DESCRIPTION
Eigen>=3.3.x segfaults on Linux with gcc

Using dynamic (runtime) version of topLeftCorner works