### PR TITLE
Fix API of pca_estimate_normals for CGAL version > 4.13

### DIFF
--- a/libs/MVS/DepthMap.cpp
+++ b/libs/MVS/DepthMap.cpp
@@ -1071,25 +1071,24 @@ void MVS::EstimatePointNormals(const ImageArr& images, PointCloud& pointcloud, i
 	// estimates normals direction;
 	// Note: pca_estimate_normals() requires an iterator over points
 	// as well as property maps to access each point's position and normal.
-        #if CGAL_VERSION_NR < 1041301000
-          #if CGAL_VERSION_NR < 1040800000
-          CGAL::pca_estimate_normals(
-          #else
-          CGAL::pca_estimate_normals<CGAL::Sequential_tag>(
-          #endif
-                pointvectors.begin(), pointvectors.end(),
-                CGAL::First_of_pair_property_map<PointVectorPair>(),
-                CGAL::Second_of_pair_property_map<PointVectorPair>(),
-                numNeighbors
-          );
-        #else
-        CGAL::pca_estimate_normals<CGAL::Sequential_tag>(
-              pointvectors,
-              numNeighbors,
-              CGAL::parameters::point_map(CGAL::First_of_pair_property_map<PointVectorPair>())
-              .normal_map(CGAL::Second_of_pair_property_map<PointVectorPair>())
-              );
-        #endif
+	#if CGAL_VERSION_NR < 1041301000
+	#if CGAL_VERSION_NR < 1040800000
+	CGAL::pca_estimate_normals(
+	#else
+	CGAL::pca_estimate_normals<CGAL::Sequential_tag>(
+	#endif
+		pointvectors.begin(), pointvectors.end(),
+		CGAL::First_of_pair_property_map<PointVectorPair>(),
+		CGAL::Second_of_pair_property_map<PointVectorPair>(),
+		numNeighbors
+	);
+	#else
+	CGAL::pca_estimate_normals<CGAL::Sequential_tag>(
+		pointvectors, numNeighbors,
+		CGAL::parameters::point_map(CGAL::First_of_pair_property_map<PointVectorPair>())
+		.normal_map(CGAL::Second_of_pair_property_map<PointVectorPair>())
+	);
+	#endif
 	// store the point normals
 	pointcloud.normals.Resize(pointcloud.points.GetSize());
 	FOREACH(i, pointcloud.normals) {

--- a/libs/MVS/DepthMap.cpp
+++ b/libs/MVS/DepthMap.cpp
@@ -1071,16 +1071,25 @@ void MVS::EstimatePointNormals(const ImageArr& images, PointCloud& pointcloud, i
 	// estimates normals direction;
 	// Note: pca_estimate_normals() requires an iterator over points
 	// as well as property maps to access each point's position and normal.
-	#if CGAL_VERSION_NR < 1040800000
-	CGAL::pca_estimate_normals(
-	#else
-	CGAL::pca_estimate_normals<CGAL::Sequential_tag>(
-	#endif
-		pointvectors.begin(), pointvectors.end(),
-		CGAL::First_of_pair_property_map<PointVectorPair>(),
-		CGAL::Second_of_pair_property_map<PointVectorPair>(),
-		numNeighbors
-	);
+        #if CGAL_VERSION_NR < 1041301000
+          #if CGAL_VERSION_NR < 1040800000
+          CGAL::pca_estimate_normals(
+          #else
+          CGAL::pca_estimate_normals<CGAL::Sequential_tag>(
+          #endif
+                pointvectors.begin(), pointvectors.end(),
+                CGAL::First_of_pair_property_map<PointVectorPair>(),
+                CGAL::Second_of_pair_property_map<PointVectorPair>(),
+                numNeighbors
+          );
+        #else
+        CGAL::pca_estimate_normals<CGAL::Sequential_tag>(
+              pointvectors,
+              numNeighbors,
+              CGAL::parameters::point_map(CGAL::First_of_pair_property_map<PointVectorPair>())
+              .normal_map(CGAL::Second_of_pair_property_map<PointVectorPair>())
+              );
+        #endif
 	// store the point normals
 	pointcloud.normals.Resize(pointcloud.points.GetSize());
 	FOREACH(i, pointcloud.normals) {


### PR DESCRIPTION
Hello,
We are about to upgrade CGAL version on vcpkg to 5.0, and in that version some deprecated code has been removed, which causes the build of openMVS to fail. I propose this PR to fix the calls for recent versions of CGAL, and in parallel I propose [a patch](https://github.com/microsoft/vcpkg/pull/8659/files#diff-9046912f3fa504b1f13c5e717992fd8b) for vcpg in [my PR](https://github.com/microsoft/vcpkg/pull/8659).
