### PR TITLE
fix CMakeLits.txt for CMake older than 3.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ if(OpenMVS_USE_OPENMP)
 		SET(_USE_OPENMP TRUE)
 		#cmake only check for separate OpenMP library on AppleClang 7+
 		#https://github.com/Kitware/CMake/blob/42212f7539040139ecec092547b7d58ef12a4d72/Modules/FindOpenMP.cmake#L252
-		if (CMAKE_CXX_COMPILER_ID MATCHES "AppleClang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "7.0")
+		if (CMAKE_CXX_COMPILER_ID MATCHES "AppleClang" AND (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS "7.0"))
 			SET(OpenMP_LIBS ${OpenMP_libomp_LIBRARY})
 			LIST(APPEND OpenMVS_EXTRA_LIBS ${OpenMP_LIBS})
 		endif()


### PR DESCRIPTION
Hi.

I tried to build this project on Ubuntu 16.04, using CMake 3.5.1. When I ran cmake, I got this error.

```
CMake Error at CMakeLists.txt:68 (if):
  if given arguments:

    "CMAKE_CXX_COMPILER_ID" "MATCHES" "AppleClang" "AND" "CMAKE_CXX_COMPILER_VERSION" "VERSION_GREATER_EQUAL" "7.0"

  Unknown arguments specified


-- Configuring incomplete, errors occurred!
```

It seems that "VERSION_GREATER_EQUAL" opeation became available only after CMake version 3.7.x.

This pull request, folloing a [precedent](https://bitbucket.org/ompl/ompl/commits/6b661013f090389f691a6bdabe8b61936a52e428), will circumvent the error.