### PR TITLE
Include BUNDLE_EXT when importing VSFM scene

### DIFF
--- a/apps/InterfaceVisualSFM/InterfaceVisualSFM.cpp
+++ b/apps/InterfaceVisualSFM/InterfaceVisualSFM.cpp
@@ -43,6 +43,7 @@
 #define MVS_EXT _T(".mvs")
 #define VSFM_EXT _T(".nvm")
 #define CMPMVS_EXT _T(".lst")
+#define BUNDLE_EXT _T(".out")
 
 
 // S T R U C T S ///////////////////////////////////////////////////
@@ -508,7 +509,7 @@ int main(int argc, LPCTSTR* argv)
 		return EXIT_FAILURE;
 
 	const String strInputFileNameExt(Util::getFileExt(OPT::strInputFileName).ToLower());
-	if (strInputFileNameExt == VSFM_EXT) {
+	if ((strInputFileNameExt == VSFM_EXT) || (strInputFileNameExt == BUNDLE_EXT)) {
 		if (!ImportSceneVSFM())
 			return EXIT_FAILURE;
 	} else


### PR DESCRIPTION
Once [file loader supports .nvm format and bundler format](https://github.com/cdcseacave/openMVS/blob/063e5cd7f1139aceaf882f9f6ae3f0de26c59138/apps/InterfaceVisualSFM/Util.h#L33), I just added an option to call [LoadBundlerOut()](https://github.com/cdcseacave/openMVS/blob/063e5cd7f1139aceaf882f9f6ae3f0de26c59138/apps/InterfaceVisualSFM/Util.h#L184) making possible convert "bundle files" (.out + .txt) into mvs project.

See: https://github.com/cdcseacave/openMVS/blob/063e5cd7f1139aceaf882f9f6ae3f0de26c59138/apps/InterfaceVisualSFM/Util.h#L414