### PR TITLE
Build libCommon/IO/Math as shared if BUILD_SHARED_LIBS=ON

### DIFF
--- a/libs/Common/CMakeLists.txt
+++ b/libs/Common/CMakeLists.txt
@@ -9,7 +9,7 @@ FILE(GLOB LIBRARY_FILES_H "*.h" "*.inl")
 LIST(REMOVE_ITEM LIBRARY_FILES_C ${PCH_C})
 SET(LIBRARY_FILES_C "${PCH_C};${LIBRARY_FILES_C}")
 
-cxx_library_with_type_no_pch(Common "Libs" "STATIC" "${cxx_default}"
+cxx_library_with_type_no_pch(Common "Libs" "" "${cxx_default}"
 	${LIBRARY_FILES_C} ${LIBRARY_FILES_H}
 )
 

--- a/libs/IO/CMakeLists.txt
+++ b/libs/IO/CMakeLists.txt
@@ -35,7 +35,7 @@ FILE(GLOB LIBRARY_FILES_H "*.h" "*.inl")
 LIST(REMOVE_ITEM LIBRARY_FILES_C ${PCH_C})
 SET(LIBRARY_FILES_C "${PCH_C};${LIBRARY_FILES_C}")
 
-cxx_library_with_type_no_pch(IO "Libs" "STATIC" "${cxx_default}"
+cxx_library_with_type_no_pch(IO "Libs" "" "${cxx_default}"
 	${LIBRARY_FILES_C} ${LIBRARY_FILES_H}
 )
 

--- a/libs/Math/CMakeLists.txt
+++ b/libs/Math/CMakeLists.txt
@@ -23,7 +23,7 @@ SOURCE_GROUP("TRWS" FILES ${TRWS_LIBRARY_FILES_C} ${TRWS_LIBRARY_FILES_H})
 LIST(REMOVE_ITEM LIBRARY_FILES_C ${PCH_C})
 SET(LIBRARY_FILES_C "${PCH_C};${LIBRARY_FILES_C}")
 
-cxx_library_with_type_no_pch(Math "Libs" "STATIC" "${cxx_default}"
+cxx_library_with_type_no_pch(Math "Libs" "" "${cxx_default}"
 	${LIBRARY_FILES_C} ${LIBRARY_FILES_H}
 	${IBFS_LIBRARY_FILES_C} ${IBFS_LIBRARY_FILES_H}
 	${LMFit_LIBRARY_FILES_C} ${LMFit_LIBRARY_FILES_H}


### PR DESCRIPTION
My project needs them as external libs.

Note that nothing is changed on the default setting i.e. BUILD_SHARED_LIBS=OFF.