### PR TITLE
Set internal linkage for all apps functions and variables

### DIFF
--- a/apps/DensifyPointCloud/DensifyPointCloud.cpp
+++ b/apps/DensifyPointCloud/DensifyPointCloud.cpp
@@ -40,6 +40,7 @@ using namespace MVS;
 
 #define APPNAME _T("DensifyPointCloud")
 
+namespace {
 
 // S T R U C T S ///////////////////////////////////////////////////
 
@@ -215,6 +216,8 @@ void Finalize()
 	CLOSE_LOGCONSOLE();
 	CLOSE_LOG();
 }
+
+} // unnamed namespace
 
 int main(int argc, LPCTSTR* argv)
 {

--- a/apps/InterfaceCOLMAP/InterfaceCOLMAP.cpp
+++ b/apps/InterfaceCOLMAP/InterfaceCOLMAP.cpp
@@ -60,6 +60,7 @@ using namespace MVS;
 #define COLMAP_STEREO_DEPTHMAPS_FOLDER COLMAP_STEREO_FOLDER _T("depth_maps/")
 #define COLMAP_STEREO_NORMALMAPS_FOLDER COLMAP_STEREO_FOLDER _T("normal_maps/")
 
+namespace {
 
 // S T R U C T S ///////////////////////////////////////////////////
 
@@ -1081,6 +1082,7 @@ bool ExportImagesCamera(const String& pathName, const Interface& scene)
 	return true;
 }
 
+} // unnamed namespace
 
 int main(int argc, LPCTSTR* argv)
 {

--- a/apps/InterfaceOpenMVG/InterfaceOpenMVG.cpp
+++ b/apps/InterfaceOpenMVG/InterfaceOpenMVG.cpp
@@ -50,6 +50,7 @@
 #define MVG2_EXT _T(".json")
 #define MVG3_EXT _T(".bin")
 
+namespace {
 
 // S T R U C T S ///////////////////////////////////////////////////
 
@@ -470,6 +471,8 @@ void Finalize()
 	CLOSE_LOGCONSOLE();
 	CLOSE_LOG();
 }
+
+} // unnamed namespace
 
 int main(int argc, LPCTSTR* argv)
 {

--- a/apps/InterfacePhotoScan/InterfacePhotoScan.cpp
+++ b/apps/InterfacePhotoScan/InterfacePhotoScan.cpp
@@ -41,6 +41,7 @@
 #define XML_EXT _T(".xml")
 #define PLY_EXT _T(".ply")
 
+namespace {
 
 // S T R U C T S ///////////////////////////////////////////////////
 
@@ -523,6 +524,8 @@ void AssignPoints(const MVS::Image& imageData, uint32_t ID, MVS::PointCloud& poi
 
 	DEBUG_ULTIMATE("\tview %3u sees %u points", ID, nNumPoints);
 }
+
+} // unnamed namespace
 
 int main(int argc, LPCTSTR* argv)
 {

--- a/apps/InterfaceVisualSFM/InterfaceVisualSFM.cpp
+++ b/apps/InterfaceVisualSFM/InterfaceVisualSFM.cpp
@@ -45,6 +45,7 @@
 #define BUNDLE_EXT _T(".out")
 #define CMPMVS_EXT _T(".lst")
 
+namespace {
 
 // S T R U C T S ///////////////////////////////////////////////////
 
@@ -186,6 +187,8 @@ void Finalize()
 	CLOSE_LOGCONSOLE();
 	CLOSE_LOG();
 }
+
+} // unnamed namespace
 
 #define PBA_PRECISION float
 

--- a/apps/ReconstructMesh/ReconstructMesh.cpp
+++ b/apps/ReconstructMesh/ReconstructMesh.cpp
@@ -45,6 +45,7 @@ using namespace MVS;
 #define RECMESH_USE_OPENMP
 #endif
 
+namespace {
 
 // S T R U C T S ///////////////////////////////////////////////////
 
@@ -208,6 +209,8 @@ void Finalize()
 	CLOSE_LOGCONSOLE();
 	CLOSE_LOG();
 }
+
+} // unnamed namespace
 
 int main(int argc, LPCTSTR* argv)
 {

--- a/apps/RefineMesh/RefineMesh.cpp
+++ b/apps/RefineMesh/RefineMesh.cpp
@@ -40,6 +40,7 @@ using namespace MVS;
 
 #define APPNAME _T("RefineMesh")
 
+namespace {
 
 // S T R U C T S ///////////////////////////////////////////////////
 
@@ -212,6 +213,8 @@ void Finalize()
 	CLOSE_LOGCONSOLE();
 	CLOSE_LOG();
 }
+
+} // unnamed namespace
 
 int main(int argc, LPCTSTR* argv)
 {

--- a/apps/TextureMesh/TextureMesh.cpp
+++ b/apps/TextureMesh/TextureMesh.cpp
@@ -40,6 +40,7 @@ using namespace MVS;
 
 #define APPNAME _T("TextureMesh")
 
+namespace {
 
 // S T R U C T S ///////////////////////////////////////////////////
 
@@ -200,6 +201,8 @@ void Finalize()
 	CLOSE_LOGCONSOLE();
 	CLOSE_LOG();
 }
+
+} // unnamed namespace
 
 int main(int argc, LPCTSTR* argv)
 {

--- a/apps/Viewer/Viewer.cpp
+++ b/apps/Viewer/Viewer.cpp
@@ -41,6 +41,7 @@ using namespace VIEWER;
 
 #define APPNAME _T("Viewer")
 
+namespace {
 
 // S T R U C T S ///////////////////////////////////////////////////
 
@@ -199,6 +200,8 @@ void Finalize()
 	CLOSE_LOGCONSOLE();
 	CLOSE_LOG();
 }
+
+} // unnamed namespace
 
 int main(int argc, LPCTSTR* argv)
 {


### PR DESCRIPTION
I'm trying to integrate my module into openMVS apps.

I found that the global functions and variables conflict with my module, e.g., Initialize/Finalize and OPT::nMaxThreads.

The name of my (external project) is really needed to be global functions and variables.

But openMVS's is not. It can / must be local.

To solve such a problem, could you set linkages of them internal as much as possible?

Thanks.