### PR TITLE
Fix various typos

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -145,7 +145,7 @@ make && sudo make install
 Library usage
 -------------------
 
-In order to use *OpenMVS* as a third-party libray in your project, first compile it as described above or simply use `vcpgk`:
+In order to use *OpenMVS* as a third-party library in your project, first compile it as described above or simply use `vcpgk`:
 ```
 vcpkg install openmvs
 ```

--- a/MvgMvsPipeline.py
+++ b/MvgMvsPipeline.py
@@ -36,8 +36,8 @@ Photogrammetry reconstruction with these steps:
     17. Fuse disparity-maps            DensifyPointCloud
 
 positional arguments:
-  input_dir                 the directory wich contains the pictures set.
-  output_dir                the directory wich will contain the resulting files.
+  input_dir                 the directory which contains the pictures set.
+  output_dir                the directory which will contain the resulting files.
 
 optional arguments:
   -h, --help                show this help message and exit
@@ -270,9 +270,9 @@ PARSER = argparse.ArgumentParser(
     "\r\n".join(("\t%i. %s\t %s" % (t, STEPS[t].info, STEPS[t].cmd) for t in range(STEPS.length())))
     )
 PARSER.add_argument('input_dir',
-                    help="the directory wich contains the pictures set.")
+                    help="the directory which contains the pictures set.")
 PARSER.add_argument('output_dir',
-                    help="the directory wich will contain the resulting files.")
+                    help="the directory which will contain the resulting files.")
 PARSER.add_argument('--steps',
                     type=int,
                     nargs="+",
@@ -297,7 +297,7 @@ def mkdir_ine(dirname):
         os.mkdir(dirname)
 
 
-# Absolute path for input and ouput dirs
+# Absolute path for input and output dirs
 CONF.input_dir = os.path.abspath(CONF.input_dir)
 CONF.output_dir = os.path.abspath(CONF.output_dir)
 
@@ -324,7 +324,7 @@ elif CONF.preset:
     try:
         CONF.steps = PRESET[CONF.preset]
     except KeyError:
-        sys.exit("Unkown preset %s, choose %s" % (CONF.preset, ' or '.join([s for s in PRESET])))
+        sys.exit("Unknown preset %s, choose %s" % (CONF.preset, ' or '.join([s for s in PRESET])))
 elif not CONF.steps:
     CONF.steps = PRESET[PRESET_DEFAULT]
 

--- a/apps/InterfaceVisualSFM/Util.h
+++ b/apps/InterfaceVisualSFM/Util.h
@@ -125,7 +125,7 @@ bool LoadNVM(std::ifstream& in, std::vector<CameraT>& camera_data, std::vector<P
             camidx.push_back(cidx);    //camera index
             ptidx.push_back(i);        //point index
 
-            //add a measurment to the vector
+            //add a measurement to the vector
             measurements.push_back(Point2D(imx, imy));
             nproj ++;
         }
@@ -268,7 +268,7 @@ bool LoadBundlerOut(const char* name, std::ifstream& in, std::vector<CameraT>& c
             camidx.push_back(cidx);    //camera index
             ptidx.push_back(i);        //point index
 
-            //add a measurment to the vector
+            //add a measurement to the vector
             measurements.push_back(Point2D(imx, -imy));
             nproj ++;
         }
@@ -638,7 +638,7 @@ bool RemoveInvisiblePoints( std::vector<CameraT>& camera_data, std::vector<Point
     if(points_removed == 0) return false;
     std::vector<int>  cv(camera_data.size(), 0);
     //should any cameras be removed ?
-    int min_observation = 20; //cameras should see at leat 20 points
+    int min_observation = 20; //cameras should see at least 20 points
 
     do
     {

--- a/apps/ReconstructMesh/ReconstructMesh.cpp
+++ b/apps/ReconstructMesh/ReconstructMesh.cpp
@@ -219,7 +219,7 @@ void Finalize()
 } // unnamed namespace
 
 
-// export 3D coordinates corresponding to 2D ccordinates provided by inputFileName:
+// export 3D coordinates corresponding to 2D coordinates provided by inputFileName:
 // parse image point list; first line is the name of the image to project,
 // each consequent line store the xy coordinates to project:
 // <image-name> <number-of-points>
@@ -275,7 +275,7 @@ bool Export3DProjections(Scene& scene, const String& inputFileName) {
 		if (argc > 0 && argv[0][0] == _T('#'))
 			continue;
 		if (argc < 2) {
-			VERBOSE("Invalid image coordonates: %s", line.c_str());
+			VERBOSE("Invalid image coordinates: %s", line.c_str());
 			continue;
 		}
 		const Point2f pt(

--- a/build/Utils.cmake
+++ b/build/Utils.cmake
@@ -492,7 +492,7 @@ macro(optimize_default_compiler_settings)
 	  add_extra_compiler_option(-fdiagnostics-show-option)
 	  add_extra_compiler_option(-ftemplate-backtrace-limit=0)
 	  
-	  # The -Wno-long-long is required in 64bit systems when including sytem headers.
+	  # The -Wno-long-long is required in 64bit systems when including system headers.
 	  if(X86_64)
 		add_extra_compiler_option(-Wno-long-long)
 	  endif()

--- a/libs/Common/Common.h
+++ b/libs/Common/Common.h
@@ -13,7 +13,7 @@
 
 #include "Config.h"
 
-// macors controling the verbosity
+// macros controlling the verbosity
 #define TD_VERBOSE_OFF		0
 #define TD_VERBOSE_ON		1
 #define TD_VERBOSE_DEBUG	2

--- a/libs/Common/FastDelegate.h
+++ b/libs/Common/FastDelegate.h
@@ -302,7 +302,7 @@ struct SimplifyMemFunc<SINGLE_MEMFUNCPTR_SIZE>  {
 	inline static GenericClass *Convert(X *pthis, XFuncType function_to_bind, 
 			GenericMemFuncType &bound_func) {
 #if defined __DMC__  
-		// Digital Mars doesn't allow you to cast between abitrary PMF's, 
+		// Digital Mars doesn't allow you to cast between arbitrary PMF's, 
 		// even though the standard says you can. The 32-bit compiler lets you
 		// static_cast through an int, but the DOS compiler doesn't.
 		bound_func = horrible_cast<GenericMemFuncType>(function_to_bind);
@@ -376,7 +376,7 @@ struct MicrosoftVirtualMFP {
 // returns the 'this' pointer that was used.
 
 // Define a generic class that uses virtual inheritance.
-// It has a trival member function that returns the value of the 'this' pointer.
+// It has a trivial member function that returns the value of the 'this' pointer.
 struct GenericVirtualClass : virtual public GenericClass
 {
 	typedef GenericVirtualClass * (GenericVirtualClass::*ProbePtrType)();
@@ -514,7 +514,7 @@ struct SimplifyMemFunc<SINGLE_MEMFUNCPTR_SIZE + 3*sizeof(int) >
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-// DelegateMemento -- an opaque structure which can hold an arbitary delegate.
+// DelegateMemento -- an opaque structure which can hold an arbitrary delegate.
 // It knows nothing about the calling convention or number of arguments used by
 // the function pointed to.
 // It supplies comparison operators so that it can be stored in STL collections.
@@ -821,7 +821,7 @@ public:
 //   FastDelegate3<int, char *, double>
 // They can cope with any combination of parameters. The max number of parameters
 // allowed is 8, but it is trivial to increase this limit.
-// Note that we need to treat const member functions seperately.
+// Note that we need to treat const member functions separately.
 // All this class does is to enforce type safety, and invoke the delegate with
 // the correct list of parameters.
 
@@ -1979,7 +1979,7 @@ public:
 
 // Also declare overloads of a MakeDelegate() global function to 
 // reduce the need for typedefs.
-// We need seperate overloads for const and non-const member functions.
+// We need separate overloads for const and non-const member functions.
 // Also, because of the weird rule about the class of derived member function pointers,
 // implicit downcasts may need to be applied later to the 'this' pointer.
 // That's why two classes (X and Y) appear in the definitions. Y must be implicitly

--- a/libs/Common/FastDelegateBind.h
+++ b/libs/Common/FastDelegateBind.h
@@ -26,7 +26,7 @@
 //
 // Add another helper, so FastDelegate can be a dropin replacement
 // for boost::bind (in a fair number of cases).
-// Note the elipses, because boost::bind() takes place holders
+// Note the ellipsis, because boost::bind() takes place holders
 // but FastDelegate does not care about them.  Getting the place holder
 // mechanism to work, and play well with boost is a bit tricky, so
 // we do the "easy" thing...

--- a/libs/Common/Rotation.h
+++ b/libs/Common/Rotation.h
@@ -66,7 +66,7 @@ template <typename TYPE> class TRMatrixBase;
 	  where (x, y, z) is the normalized direction vector of the axis
 	  and phi is the angle of rtoation.
 
-	  Some usefull quaternions:
+	  Some useful quaternions:
 	  x 	       y 	        z 	       w          Description
 	  0 	       0 	        0 	       1          Identity quaternion,
 													  no rotation
@@ -123,7 +123,7 @@ public:
 	*/
 	inline void Invert();
 
-	/** makes TQuaternion-representation uniqe, ensuring vector lies
+	/** makes TQuaternion-representation unique, ensuring vector lies
 	in upper (by real part) hemisphere. (inplace)
 	*/
 	inline void MakeUnique();
@@ -141,7 +141,7 @@ public:
 	*/
 	inline void MultLeft(const TQuaternion<TYPE> &quat);
 
-	/** rotates the given Vector qith the quaternion ( q v q* )
+	/** rotates the given Vector with the quaternion ( q v q* )
 	the resulting vector is given in res
 	@returns 0 in case of no error
 	@author Daniel Grest, June 2003

--- a/libs/Common/Rotation.inl
+++ b/libs/Common/Rotation.inl
@@ -374,7 +374,7 @@ TQuaternion<TYPE> TQuaternion<TYPE>::
 	TQuaternion<TYPE> res;
 	TYPE a, b;
 	TYPE cosPhi = (TYPE)p.ScalarProduct(q);
-	//adjust angle if neccessary
+	//adjust angle if necessary
 	if (cosPhi < 0) {
 		q.MultiplyIP(-1.0);
 		cosPhi = -cosPhi;

--- a/libs/Common/SML.cpp
+++ b/libs/Common/SML.cpp
@@ -362,7 +362,7 @@ const SMLVALUE* SML::GetValue(const String& key) const
 
 
 /**
- * Insert or retrieve an item; initializa it if necesary
+ * Insert or retrieve an item; initialize it if necessary
  */
 SMLVALUE& SML::GetValue(const String& key)
 {

--- a/libs/Common/Types.h
+++ b/libs/Common/Types.h
@@ -2718,7 +2718,7 @@ public:
 	/// Construct from an angle.
 	inline SO2(const Precision l) : mat(exp(l)) {}
 
-	/// Assigment operator from a general matrix. This also calls coerce()
+	/// Assignment operator from a general matrix. This also calls coerce()
 	/// to make sure that the matrix is a valid rotation matrix.
 	inline SO2& operator=(const Mat2& rhs) {
 		mat = rhs;

--- a/libs/Common/UtilCUDA.cpp
+++ b/libs/Common/UtilCUDA.cpp
@@ -30,7 +30,7 @@ int _convertSMVer2Cores(int major, int minor)
 
 	// Defines for GPU Architecture types (using the SM version to determine the # of cores per SM
 	struct sSMtoCores {
-		int SM; // 0xMm (hexidecimal notation), M = SM Major version, and m = SM minor version
+		int SM; // 0xMm (hexadecimal notation), M = SM Major version, and m = SM minor version
 		int Cores;
 	};
 	const sSMtoCores nGpuArchCoresPerSM[] = {

--- a/libs/IO/ImageTGA.cpp
+++ b/libs/IO/ImageTGA.cpp
@@ -64,7 +64,7 @@ HRESULT CImageTGA::ReadHeader()
 	((ISTREAM*)m_pStream)->setPos(0);
 	TGAINFOHEADER tgaInfo;
 	m_pStream->read(&tgaInfo, sizeof(TGAINFOHEADER));
-	if (tgaInfo.byCMType != 0) {	// palletted images not supported
+	if (tgaInfo.byCMType != 0) {	// paletted images not supported
 		LOG(LT_IMAGE, "error: invalid TGA image");
 		return _INVALIDFILE;
 	}

--- a/libs/IO/json.hpp
+++ b/libs/IO/json.hpp
@@ -8288,7 +8288,7 @@ class binary_reader
 
     @return whether conversion completed
 
-    @note This function needs to respect the system's endianess, because
+    @note This function needs to respect the system's endianness, because
           bytes in CBOR, MessagePack, and UBJSON are stored in network order
           (big endian) and therefore need reordering on little endian systems.
     */
@@ -8381,7 +8381,7 @@ class binary_reader
     /*!
     @param[in] format   the current format
     @param[in] detail   a detailed error message
-    @param[in] context  further contect information
+    @param[in] context  further contextual information
     @return a message string to use in the parse_error exceptions
     */
     std::string exception_message(const input_format_t format,
@@ -8427,7 +8427,7 @@ class binary_reader
     /// the number of characters read
     std::size_t chars_read = 0;
 
-    /// whether we can assume little endianess
+    /// whether we can assume little endianness
     const bool is_little_endian = little_endianess();
 
     /// the SAX parser
@@ -9707,7 +9707,7 @@ class binary_writer
     @tparam OutputIsLittleEndian Set to true if output data is
                                  required to be little endian
 
-    @note This function needs to respect the system's endianess, because bytes
+    @note This function needs to respect the system's endianness, because bytes
           in CBOR, MessagePack, and UBJSON are stored in network order (big
           endian) and therefore need reordering on little endian systems.
     */
@@ -9770,7 +9770,7 @@ class binary_writer
     }
 
   private:
-    /// whether we can assume little endianess
+    /// whether we can assume little endianness
     const bool is_little_endian = binary_reader<BasicJsonType>::little_endianess();
 
     /// the output

--- a/libs/IO/tiny_gltf.h
+++ b/libs/IO/tiny_gltf.h
@@ -41,7 +41,7 @@
 //  - v2.2.0 Add loading 16bit PNG support. Add Sparse accessor support(Thanks
 //  to @Ybalrid)
 //  - v2.1.0 Add draco compression.
-//  - v2.0.1 Add comparsion feature(Thanks to @Selmar).
+//  - v2.0.1 Add comparison feature(Thanks to @Selmar).
 //  - v2.0.0 glTF 2.0!.
 //
 // Tiny glTF loader is using following third party libraries:
@@ -428,7 +428,7 @@ TINYGLTF_VALUE_GET(Value::Object, object_value_)
 #pragma clang diagnostic ignored "-Wpadded"
 #endif
 
-/// Agregate object for representing a color
+/// Aggregate object for representing a color
 using ColorValue = std::array<double, 4>;
 
 // === legacy interface ====
@@ -465,7 +465,7 @@ struct Parameter {
     if (it != std::end(json_double_value)) {
       return int(it->second);
     }
-    // As per the spec, if texCoord is ommited, this parameter is 0
+    // As per the spec, if texCoord is omitted, this parameter is 0
     return 0;
   }
 
@@ -477,7 +477,7 @@ struct Parameter {
     if (it != std::end(json_double_value)) {
       return it->second;
     }
-    // As per the spec, if scale is ommited, this paramter is 1
+    // As per the spec, if scale is omitted, this parameter is 1
     return 1;
   }
 
@@ -489,7 +489,7 @@ struct Parameter {
     if (it != std::end(json_double_value)) {
       return it->second;
     }
-    // As per the spec, if strenghth is ommited, this parameter is 1
+    // As per the spec, if strenghth is omitted, this parameter is 1
     return 1;
   }
 
@@ -503,7 +503,7 @@ struct Parameter {
   /// material
   ColorValue ColorFactor() const {
     return {
-        {// this agregate intialize the std::array object, and uses C++11 RVO.
+        {// this aggregate initialize the std::array object, and uses C++11 RVO.
          number_array[0], number_array[1], number_array[2],
          (number_array.size() > 3 ? number_array[3] : 1.0)}};
   }
@@ -989,7 +989,7 @@ struct Primitive {
   int indices;   // The index of the accessor that contains the indices.
   int mode;      // one of TINYGLTF_MODE_***
   std::vector<std::map<std::string, int> > targets;  // array of morph targets,
-  // where each target is a dict with attribues in ["POSITION, "NORMAL",
+  // where each target is a dict with attributes in ["POSITION, "NORMAL",
   // "TANGENT"] pointing
   // to their corresponding accessors
   ExtensionMap extensions;
@@ -1124,7 +1124,7 @@ struct Light {
   std::vector<double> color;
   double intensity{1.0};
   std::string type;
-  double range{0.0};  // 0.0 = inifinite
+  double range{0.0};  // 0.0 = infinite
   SpotLight spot;
 
   Light() : intensity(1.0), range(0.0) {}
@@ -1333,7 +1333,7 @@ class TinyGLTF {
                             unsigned int check_sections = REQUIRE_VERSION);
 
   ///
-  /// Write glTF to stream, buffers and images will be embeded
+  /// Write glTF to stream, buffers and images will be embedded
   ///
   bool WriteGltfSceneToStream(Model *model, std::ostream &stream,
                               bool prettyPrint, bool writeBinary);
@@ -1368,7 +1368,7 @@ class TinyGLTF {
   ///
   /// Set serializing default values(default = false).
   /// When true, default values are force serialized to .glTF.
-  /// This may be helpfull if you want to serialize a full description of glTF
+  /// This may be helpful if you want to serialize a full description of glTF
   /// data.
   ///
   /// TODO(LTE): Supply parsing option as function arguments to
@@ -1395,7 +1395,7 @@ class TinyGLTF {
 
   ///
   /// Specify whether preserve image channales when loading images or not.
-  /// (Not effective when the user suppy their own LoadImageData callbacks)
+  /// (Not effective when the user supply their own LoadImageData callbacks)
   ///
   void SetPreserveImageChannels(bool onoff) {
     preserve_image_channels_ = onoff;
@@ -1528,7 +1528,7 @@ class TinyGLTF {
 #endif
 #endif
 
-// Disable GCC warnigs
+// Disable GCC warnings
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wtype-limits"
@@ -1718,7 +1718,7 @@ namespace tinygltf {
 struct LoadImageDataOption {
   // true: preserve image channels(e.g. load as RGB image if the image has RGB
   // channels) default `false`(channels are expanded to RGBA for backward
-  // compatiblity).
+  // compatibility).
   bool preserve_channels{false};
 };
 
@@ -2376,7 +2376,7 @@ bool LoadImageData(Image *image, const int image_idx, std::string *err,
 
   // It is possible that the image we want to load is a 16bit per channel image
   // We are going to attempt to load it as 16bit per channel, and if it worked,
-  // set the image data accodingly. We are casting the returned pointer into
+  // set the image data accordingly. We are casting the returned pointer into
   // unsigned char, because we are representing "bytes". But we are updating
   // the Image metadata to signal that this image uses 2 bytes (16bits) per
   // channel:
@@ -4235,7 +4235,7 @@ static bool ParseSparseAccessor(Accessor *accessor, std::string *err,
   }
 
   if (!FindMember(o, "values", values_iterator)) {
-    (*err) = "the sparse object ob ths accessor doesn't have values";
+    (*err) = "the sparse object ob this accessor doesn't have values";
     return false;
   }
 
@@ -4263,7 +4263,7 @@ static bool ParseSparseAccessor(Accessor *accessor, std::string *err,
   accessor->sparse.values.bufferView = values_buffer_view;
   accessor->sparse.values.byteOffset = values_byte_offset;
 
-  // todo check theses values
+  // todo check these values
 
   return true;
 }
@@ -4860,7 +4860,7 @@ static bool ParseMaterial(Material *material, std::string *err, const json &o,
 
   // Old code path. For backward compatibility, we still store material values
   // as Parameter. This will create duplicated information for
-  // example(pbrMetallicRoughness), but should be neglible in terms of memory
+  // example(pbrMetallicRoughness), but should be negligible in terms of memory
   // consumption.
   // TODO(syoyo): Remove in the next major release.
   material->values.clear();
@@ -5098,7 +5098,7 @@ static bool ParseSampler(Sampler *sampler, std::string *err, const json &o,
   ParseIntegerProperty(&wrapT, err, o, "wrapT", false);
   //ParseIntegerProperty(&wrapR, err, o, "wrapR", false);  // tinygltf extension
 
-  // TODO(syoyo): Check the value is alloed one.
+  // TODO(syoyo): Check the value is allowed one.
   // (e.g. we allow 9728(NEAREST), but don't allow 9727)
 
   sampler->minFilter = minFilter;
@@ -6523,7 +6523,7 @@ static void SerializeGltfBufferData(const std::vector<unsigned char> &data,
     SerializeStringProperty("uri", header + encodedData, o);
   } else {
     // Issue #229
-    // size 0 is allowd. Just emit mime header.
+    // size 0 is allowed. Just emit mime header.
     SerializeStringProperty("uri", header, o);
   }
 }
@@ -7042,7 +7042,7 @@ static void SerializeGltfMesh(Mesh &mesh, json &o) {
       JsonAddMember(primitive, "attributes", std::move(attributes));
     }
 
-    // Indicies is optional
+    // Indices is optional
     if (gltfPrimitive.indices > -1) {
       SerializeNumberProperty<int>("indices", gltfPrimitive.indices, primitive);
     }

--- a/libs/MVS/Mesh.cpp
+++ b/libs/MVS/Mesh.cpp
@@ -2625,7 +2625,7 @@ static void RemoveConnectedComponents(Polyhedron& p, int size_threshold, float e
 	}
 }
 
-// mode : 0 - tangetial; 1 - across the normal
+// mode : 0 - tangential; 1 - across the normal
 inline Vector ComputeVectorComponent(Vector n, Vector v, int mode)
 {
 	ASSERT((mode>=0) && (mode<2));
@@ -2639,7 +2639,7 @@ inline Vector ComputeVectorComponent(Vector n, Vector v, int mode)
 static void Smooth(Polyhedron& p, double delta, int mode=0)
 {
 	// 0 - both components;
-	// 1 - tangetial;
+	// 1 - tangential;
 	// 2 - normal;
 	// 3 - second order;
 	// 4 - combined;

--- a/libs/MVS/SemiGlobalMatcher.cpp
+++ b/libs/MVS/SemiGlobalMatcher.cpp
@@ -1488,7 +1488,7 @@ void SemiGlobalMatcher::ConsistencyCrossCheck(DisparityMap& l2r, const Disparity
 			pixel(-1, r, c);
 }
 
-// Discard disparities that have a hight similarity score
+// Discard disparities that have a high similarity score
 void SemiGlobalMatcher::FilterByCost(DisparityMap& disparityMap, const AccumCostMap& costMap, AccumCost th)
 {
 	ASSERT(th > 0);

--- a/libs/Math/LMFit/CHANGELOG
+++ b/libs/Math/LMFit/CHANGELOG
@@ -14,7 +14,7 @@ Changes in lmfit-4.0, released 16jul13
   - in consequence thereof, new parameter lists for lmcurve and lmmin
 - code cleanup:
   - ensure strict C90 compliance: no C++ comments; replace non-standard
-    struct assignement (reported by Elio Mazzocca, using LCC)
+    struct assignment (reported by Elio Mazzocca, using LCC)
   - revert malloc trick of release 3.4 (readability is more important)
   - source code comment blocks moved around, to reduce duplications
 - build scripts cleanup:
@@ -64,7 +64,7 @@ Changes in lmfit-3.0, released 2mar10 (preview 27feb10):
 - outer iteration counter starting at zero (C style)
 - replace BUG by LMFIT_DEBUG_MESSAGES and .._MATRIX to allow control by -D
 - remove redundant calculation by exchanging workspaces and lm_lmpar output
-- eliminate unncessary wa1 = -wa1 computation
+- eliminate unnecessary wa1 = -wa1 computation
 - avoid passing wa3 to wa1, choose better names for work arrays in lm_par
 - migrate documentation from brain-damaged asciidoc to pod
 - rewrote interface documentation

--- a/libs/Math/LMFit/lmmin.cpp
+++ b/libs/Math/LMFit/lmmin.cpp
@@ -1273,7 +1273,7 @@ void lm_qrsolv(int n, double *r, int ldr, int *ipvt, double *diag,
             qtbpj = -_sin * wa[k] + _cos * qtbpj;
             wa[k] = temp;
 
-            /** accumulate the tranformation in the row of s. **/
+            /** accumulate the transformation in the row of s. **/
 
             for (i = k + 1; i < n; i++) {
                 temp = _cos * r[k * ldr + i] + _sin * sdiag[i];

--- a/libs/Math/LMFit/lmmin.h
+++ b/libs/Math/LMFit/lmmin.h
@@ -18,7 +18,7 @@ typedef struct {
     double epsilon;   /* step used to calculate the jacobian, or 0 for user provided jacobian. */
     double stepbound; /* initial bound to steps in the outer loop. */
     int maxcall;      /* maximum number of iterations. */
-    int scale_diag;   /* UNDOCUMENTED, TESTWISE automatical diag rescaling? */
+    int scale_diag;   /* UNDOCUMENTED, TESTWISE automatic diag rescaling? */
     #ifdef LMFIT_PRINTOUT
     int printflags;   /* OR'ed to produce more noise */
     #endif

--- a/libs/Math/TRWS/MRFEnergy.h
+++ b/libs/Math/TRWS/MRFEnergy.h
@@ -58,7 +58,7 @@ public:
 	// Node i must be NodeId returned by AddNode().
 	void AddNodeData(NodeId i, NodeData data);
 
-	// Adds an edge between i and j. data determins edge parameters
+	// Adds an edge between i and j. data determines edge parameters
 	// (see the corresponding message*.h file for description).
 	// Note: information in data is copied into internal memory.
 	// Cannot be called after energy construction is completed.


### PR DESCRIPTION
Found via `codespell -q 3 -L extit,indext,ist,kinf,nd,planed,rady,te,weigth,witdh`