### PR TITLE
Automatic region-of-interest detection

### DIFF
--- a/apps/DensifyPointCloud/DensifyPointCloud.cpp
+++ b/apps/DensifyPointCloud/DensifyPointCloud.cpp
@@ -57,6 +57,7 @@ String strDenseConfigFileName;
 String strExportDepthMapsName;
 float fMaxSubsceneArea;
 float fSampleMesh;
+int nROIMode;
 int nFusionMode;
 int thFilterPointCloud;
 int nExportNumViews;
@@ -130,7 +131,8 @@ bool Initialize(size_t argc, LPCTSTR* argv)
 		("fusion-mode", boost::program_options::value(&OPT::nFusionMode)->default_value(0), "depth map fusion mode (-2 - fuse disparity-maps, -1 - export disparity-maps only, 0 - depth-maps & fusion, 1 - export depth-maps only)")
 		("filter-point-cloud", boost::program_options::value(&OPT::thFilterPointCloud)->default_value(0), "filter dense point-cloud based on visibility (0 - disabled)")
 		("export-number-views", boost::program_options::value(&OPT::nExportNumViews)->default_value(0), "export points with >= number of views (0 - disabled)")
-		;
+        ("roi-mode", boost::program_options::value(&OPT::nROIMode)->default_value(-1), "set region-of-interest mode for scene trim (-1 - unbounded scene, 0 - wrap-around scene)")
+        ;
 
 	// hidden options, allowed both on command line and
 	// in config file, but will not be shown to the user
@@ -273,6 +275,11 @@ int main(int argc, LPCTSTR* argv)
 	// load and estimate a dense point-cloud
 	if (!scene.Load(MAKE_PATH_SAFE(OPT::strInputFileName)))
 		return EXIT_FAILURE;
+    if (OPT::nROIMode != -1) {
+        // detect region-of-interest
+        if(!scene.DetectROI())
+            return EXIT_FAILURE;
+    }
 	if (!OPT::strExportROIFileName.empty() && scene.IsBounded()) {
 		std::ofstream fs(MAKE_PATH_SAFE(OPT::strExportROIFileName));
 		if (!fs)

--- a/libs/MVS/Scene.cpp
+++ b/libs/MVS/Scene.cpp
@@ -451,7 +451,7 @@ bool Scene::SaveViewNeighbors(const String& fileName) const
 	ASSERT(ImagesHaveNeighbors());
 
 	TD_TIMER_STARTD();
-	
+
 	File file(fileName, File::WRITE, File::CREATE | File::TRUNCATE);
 	if (!file.isOpen()) {
 		VERBOSE("error: unable to write file '%s'", fileName.c_str());
@@ -1361,4 +1361,90 @@ bool Scene::ScaleImages(unsigned nMaxResolution, REAL scale, const String& folde
 	}
 	return true;
 } // ScaleImages
+
+/*----------------------------------------------------------------*/
+// detect region-of-interest based on camera positions, directions and sparse points
+// scale specifies the ratio of the ROI's diameter
+bool Scene::DetectROI(float scale)
+{
+    typedef CLISTDEF0IDX(Camera, uint32_t) CamArr;
+    CamArr camArr;
+    FOREACH(i, images) {
+        const Image &imageData = images[i];
+        if (!imageData.IsValid())
+            continue;
+        camArr.emplace_back(imageData.camera);
+    }
+    unsigned nCams = camArr.size();
+    if (nCams < 3)
+        return false;
+
+    // compute the camera center and the direction median
+    typedef CLISTDEF0IDX(float, IDX) Scalars;
+    Scalars x(nCams), y(nCams), z(nCams), nx(nCams), ny(nCams), nz(nCams);
+    FOREACH(i, camArr) {
+        Point3f camC(camArr[i].C);
+        x[i] = camC.x;
+        y[i] = camC.y;
+        z[i] = camC.z;
+        Point3f camDirect(camArr[i].Direction());
+        nx[i] = camDirect.x;
+        ny[i] = camDirect.y;
+        nz[i] = camDirect.z;
+    }
+    CMatrix camCenter(x.GetMedian(), y.GetMedian(), z.GetMedian());
+    Point3f camDirectMed(nx.GetMedian(), ny.GetMedian(), nz.GetMedian());
+    VERBOSE("The median camera position (%f,%f,%f), direction (%f,%f,%f)",
+            camCenter.x, camCenter.y, camCenter.z, camDirectMed.x, camDirectMed.y, camDirectMed.z);
+
+    // estimate scene center and radius by the camera center and the median of camera directions
+    Scalars camDepthArr(nCams);
+    FOREACH(i, camArr) {
+        Point3f ptCam(camArr[i].R * (camCenter - camArr[i].C));
+        camDepthArr[i] = ptCam.z;
+    }
+    float depthMedian = camDepthArr.GetMedian();
+    CMatrix camShiftCoeff;
+    for (uint32_t i = 0; i < 3; ++i)
+        camShiftCoeff[i] = TAN(ASIN(CLAMP(camDirectMed[i], -0.99f, 0.99f)));
+    CMatrix sceneCenter = camCenter + camShiftCoeff * depthMedian;
+    VERBOSE("The estimated scene center is (%f,%f,%f)",
+            sceneCenter.x, sceneCenter.y, sceneCenter.z);
+    FOREACH(i, camArr) {
+        Point3f ptCam(camArr[i].R * (sceneCenter - camArr[i].C));
+        camDepthArr[i] = ptCam.z;
+    }
+    depthMedian = camDepthArr.GetMedian();
+    VERBOSE("The estimated scene radius is %f", depthMedian);
+
+    // select points in the ROI
+    Point3fArr ptsInROI;
+    FOREACH(i, pointcloud.points) {
+        const PointCloud::Point &point = pointcloud.points[i];
+        const PointCloud::ViewArr &views = pointcloud.pointViews[i];
+        FOREACH(j, views) {
+            const Image &imageData = images[views[j]];
+            if (!imageData.IsValid())
+                continue;
+            const Camera &camera = imageData.camera;
+            Point3f ptCam(camera.R * (CMatrix(point) - camera.C));
+            if (ptCam.z < depthMedian * 2.0f * scale) {
+                ptsInROI.emplace_back(point);
+                break;
+            }
+        }
+    }
+    AABB3f aabbROI;
+    if (!ptsInROI.empty()) {
+        aabbROI.Set(ptsInROI.begin(), ptsInROI.size());
+        VERBOSE("Set the ROI by the estimated core points");
+    } else {
+        aabbROI.Set((const Point3f::EVec) Point3f(sceneCenter), depthMedian * scale);
+        VERBOSE("Set the ROI obb by the estimated scene center (%f,%f,%f) and radius %f",
+                sceneCenter.x, sceneCenter.y, sceneCenter.z, depthMedian);
+    }
+    obb.Set(aabbROI);
+
+    return true;
+} // DetectROI
 /*----------------------------------------------------------------*/

--- a/libs/MVS/Scene.h
+++ b/libs/MVS/Scene.h
@@ -104,6 +104,9 @@ public:
 	bool Scale(const REAL* pScale = NULL);
 	bool ScaleImages(unsigned nMaxResolution = 0, REAL scale = 0, const String& folderName = String());
 
+    // detect and set region-of-interest
+    bool DetectROI(float scale=1.f);
+
 	// Dense reconstruction
 	bool DenseReconstruction(int nFusionMode=0);
 	bool ComputeDepthMaps(DenseDepthMapData& data);


### PR DESCRIPTION
The common two types of scenes are unbounded scenes and wrap-around scenes, in terms of indoor and outdoor. For wrap-around scenes, the majority point-clouds are outside the ROI. There are several relevant issues [https://github.com/cdcseacave/openMVS/issues/329](https://github.com/cdcseacave/openMVS/issues/329), [https://github.com/cdcseacave/openMVS/issues/787](https://github.com/cdcseacave/openMVS/issues/787).

This work provides methods and codes for detecting ROI automatically, which is motivated by @cdcseacave [https://github.com/cdcseacave/openMVS/issues/330](https://github.com/cdcseacave/openMVS/issues/330).

### Methods

Region-of-Interest(ROI) detection is equivalent to searching the center and the radius of the scene. ROI can be easily trimmed with these parameters.

1. Calculate the average camera position $P_{avg}$ , and the average camera direction $D_{avg}$ . (use median rather than mean because of higher robustness under skewed distribution.)
2. Consider $P_{avg}$ as the initial scene center, and calculate the average distance from all cameras to $P_{avg}$ as the initial scene radius $r$ .
3. The distribution of camera directions is likely to be skewed, that is, the scene could be statistically on one side of the cameras. Therefore, the scene center $C$ is calculated with $D_{avg}$ and $P_{avg}$ . The scene radius $r$ is updated accordingly.

$$
C = P_{avg} + \tan(\arcsin(D_{avg})) \times  r
$$

4. Since the imported SfM results usually contain sparse point-clouds and the corresponding visibility information, the OBB construction methods are divided into two cases:
    1. If contains: filter the point-clouds within a reasonable depth range according to scene radius and use them to fit a more accurate AABB (as the ROI).
    2. Else: directly construct an AABB (as the ROI) based on the estimated scene center and radius.

### Tests

The test data is the 'family' scenario of the Tanks-and-Temples dataset. Full, half, and quarter wrap-around scenes are tested to verify the robustness of the method.

#### Wrap-around scenario

![family_circle_cameras](https://user-images.githubusercontent.com/26993056/172021552-17488da3-d149-48a7-a523-a345465f5e94.png)
cameras + point-clouds trimmed with ROI

![family_circle_roi](https://user-images.githubusercontent.com/26993056/172021566-22b8764e-9ae4-4f27-8fc0-4f33c51544c6.png)
point-clouds trimmed with ROI

![family_circle_unbounded](https://user-images.githubusercontent.com/26993056/172021573-bf8acbcc-9578-40f4-a8bb-eb082b01bcb9.png)
Unbounded point-clouds

#### Half wrap-around scenario

![family_oneside_cameras](https://user-images.githubusercontent.com/26993056/172021582-6bea3031-c874-4515-a8f9-f1887fc0bcb2.png)
cameras + point-clouds trimmed with ROI

![family_oneside_roi](https://user-images.githubusercontent.com/26993056/172021593-5e6201cb-a590-43ac-b73a-78b475d439b4.png)
point-clouds trimmed with ROI

![family_oneside_unbounded](https://user-images.githubusercontent.com/26993056/172021597-0253ca14-dfcd-4d1e-a222-9c60b4328d21.png)
Unbounded point-clouds

#### Quarter wrap-around scenario

![family_sparse_cameras](https://user-images.githubusercontent.com/26993056/172021606-b9aceddd-159a-4467-88c2-8f6a01daacec.png)
cameras + point-clouds trimmed with ROI

![family_sparse_roi](https://user-images.githubusercontent.com/26993056/172021616-abef3100-d292-4136-a25c-dd78719bc2eb.png)
point-clouds trimmed with ROI

![family_sparse_unbounded](https://user-images.githubusercontent.com/26993056/172021617-c6084f2f-7c58-4e01-9261-8aaf69961aaf.png)
unbounded point-clouds