### PR TITLE
Automatic region-of-interest detection

### DIFF
--- a/apps/DensifyPointCloud/DensifyPointCloud.cpp
+++ b/apps/DensifyPointCloud/DensifyPointCloud.cpp
@@ -137,7 +137,7 @@ bool Initialize(size_t argc, LPCTSTR* argv)
 		("fusion-mode", boost::program_options::value(&OPT::nFusionMode)->default_value(0), "depth map fusion mode (-2 - fuse disparity-maps, -1 - export disparity-maps only, 0 - depth-maps & fusion, 1 - export depth-maps only)")
 		("filter-point-cloud", boost::program_options::value(&OPT::thFilterPointCloud)->default_value(0), "filter dense point-cloud based on visibility (0 - disabled)")
 		("export-number-views", boost::program_options::value(&OPT::nExportNumViews)->default_value(0), "export points with >= number of views (0 - disabled)")
-        ("roi-mode", boost::program_options::value(&OPT::nROIMode)->default_value(-1), "set region-of-interest mode for scene trim (-1 - unbounded scene, 0 - wrap-around scene)")
+        ("roi-mode", boost::program_options::value(&OPT::nROIMode)->default_value(0), "set region-of-interest mode (-1 - unbounded scene without trim, 0 - wrap-around scene with auto trim)")
         ;
 
 	// hidden options, allowed both on command line and

--- a/apps/DensifyPointCloud/DensifyPointCloud.cpp
+++ b/apps/DensifyPointCloud/DensifyPointCloud.cpp
@@ -57,6 +57,7 @@ String strDenseConfigFileName;
 String strExportDepthMapsName;
 float fMaxSubsceneArea;
 float fSampleMesh;
+int nROIMode;
 int nFusionMode;
 int thFilterPointCloud;
 int nExportNumViews;
@@ -136,7 +137,8 @@ bool Initialize(size_t argc, LPCTSTR* argv)
 		("fusion-mode", boost::program_options::value(&OPT::nFusionMode)->default_value(0), "depth map fusion mode (-2 - fuse disparity-maps, -1 - export disparity-maps only, 0 - depth-maps & fusion, 1 - export depth-maps only)")
 		("filter-point-cloud", boost::program_options::value(&OPT::thFilterPointCloud)->default_value(0), "filter dense point-cloud based on visibility (0 - disabled)")
 		("export-number-views", boost::program_options::value(&OPT::nExportNumViews)->default_value(0), "export points with >= number of views (0 - disabled)")
-		;
+        ("roi-mode", boost::program_options::value(&OPT::nROIMode)->default_value(-1), "set region-of-interest mode for scene trim (-1 - unbounded scene, 0 - wrap-around scene)")
+        ;
 
 	// hidden options, allowed both on command line and
 	// in config file, but will not be shown to the user
@@ -281,6 +283,11 @@ int main(int argc, LPCTSTR* argv)
 	// load and estimate a dense point-cloud
 	if (!scene.Load(MAKE_PATH_SAFE(OPT::strInputFileName)))
 		return EXIT_FAILURE;
+    if (OPT::nROIMode != -1) {
+        // detect region-of-interest
+        if(!scene.DetectROI())
+            return EXIT_FAILURE;
+    }
 	if (!OPT::strExportROIFileName.empty() && scene.IsBounded()) {
 		std::ofstream fs(MAKE_PATH_SAFE(OPT::strExportROIFileName));
 		if (!fs)

--- a/apps/DensifyPointCloud/DensifyPointCloud.cpp
+++ b/apps/DensifyPointCloud/DensifyPointCloud.cpp
@@ -57,7 +57,7 @@ String strDenseConfigFileName;
 String strExportDepthMapsName;
 float fMaxSubsceneArea;
 float fSampleMesh;
-int nROIMode;
+bool bEstimateROI;
 int nFusionMode;
 int thFilterPointCloud;
 int nExportNumViews;
@@ -137,7 +137,7 @@ bool Initialize(size_t argc, LPCTSTR* argv)
 		("fusion-mode", boost::program_options::value(&OPT::nFusionMode)->default_value(0), "depth map fusion mode (-2 - fuse disparity-maps, -1 - export disparity-maps only, 0 - depth-maps & fusion, 1 - export depth-maps only)")
 		("filter-point-cloud", boost::program_options::value(&OPT::thFilterPointCloud)->default_value(0), "filter dense point-cloud based on visibility (0 - disabled)")
 		("export-number-views", boost::program_options::value(&OPT::nExportNumViews)->default_value(0), "export points with >= number of views (0 - disabled)")
-        ("roi-mode", boost::program_options::value(&OPT::nROIMode)->default_value(0), "set region-of-interest mode (-1 - unbounded scene without trim, 0 - wrap-around scene with auto trim)")
+        ("estimate-roi", boost::program_options::value(&OPT::bEstimateROI)->default_value(true), "estimate region-of-interest (0 - disabled)")
         ;
 
 	// hidden options, allowed both on command line and
@@ -283,9 +283,9 @@ int main(int argc, LPCTSTR* argv)
 	// load and estimate a dense point-cloud
 	if (!scene.Load(MAKE_PATH_SAFE(OPT::strInputFileName)))
 		return EXIT_FAILURE;
-    if (OPT::nROIMode != -1) {
-        // detect region-of-interest
-        if(!scene.DetectROI())
+    if (OPT::bEstimateROI) {
+        // estimate region-of-interest
+        if (!scene.EstimateROI())
             return EXIT_FAILURE;
     }
 	if (!OPT::strExportROIFileName.empty() && scene.IsBounded()) {

--- a/libs/MVS/Scene.cpp
+++ b/libs/MVS/Scene.cpp
@@ -1382,7 +1382,7 @@ bool Scene::EstimateROI(float scale)
 {
     CameraArr cameras;
     FOREACH(i, images) {
-        const Image &imageData = images[i];
+        const Image& imageData = images[i];
         if (!imageData.IsValid())
             continue;
         cameras.emplace_back(imageData.camera);
@@ -1406,7 +1406,7 @@ bool Scene::EstimateROI(float scale)
     }
     const CMatrix camCenter(x.GetMedian(), y.GetMedian(), z.GetMedian());
     CMatrix camDirectMed(nx.GetMedian(), ny.GetMedian(), nz.GetMedian());
-    const auto camDirectMedLen = (float)norm(camDirectMed);
+    const float camDirectMedLen = (float)norm(camDirectMed);
     camDirectMed /= camDirectMedLen;
     #if TD_VERBOSE != TD_VERBOSE_OFF
     if (VERBOSITY_LEVEL > 2)
@@ -1422,10 +1422,10 @@ bool Scene::EstimateROI(float scale)
     const CMatrix sceneCenter = camCenter + camShiftCoeff * depthMedian * camDirectMed;
     uint32_t nNegDepth = 0;
     FOREACH(i, cameras) {
-        const auto camDepth = (float)cameras[i].PointDepth(sceneCenter);
-        cameraDepths[i] = fabs(camDepth);
+        const float camDepth = (float)cameras[i].PointDepth(sceneCenter);
+        cameraDepths[i] = ABS(camDepth);
         if (camDepth <= 0)
-            nNegDepth++;
+            ++nNegDepth;
     }
     // return if ROI cannot be estimated accurately
     if (nNegDepth >= cameras.size() / 3) {
@@ -1441,13 +1441,13 @@ bool Scene::EstimateROI(float scale)
     // select points in the ROI
     Point3fArr ptsInROI;
     FOREACH(i, pointcloud.points) {
-        const PointCloud::Point &point = pointcloud.points[i];
-        const PointCloud::ViewArr &views = pointcloud.pointViews[i];
+        const PointCloud::Point& point = pointcloud.points[i];
+        const PointCloud::ViewArr& views = pointcloud.pointViews[i];
         FOREACH(j, views) {
-            const Image &imageData = images[views[j]];
+            const Image& imageData = images[views[j]];
             if (!imageData.IsValid())
                 continue;
-            const Camera &camera = imageData.camera;
+            const Camera& camera = imageData.camera;
             if (camera.PointDepth(point) < sceneRadius * 2.0f * scale) {
                 ptsInROI.emplace_back(point);
                 break;
@@ -1460,7 +1460,7 @@ bool Scene::EstimateROI(float scale)
         VERBOSE("Set the ROI by the estimated core points");
     } else {
         aabbROI.Set((const Point3f::EVec) Point3f(sceneCenter), sceneRadius * scale);
-        VERBOSE("Set the ROI obb by the estimated scene center and radius");
+        VERBOSE("Set the ROI by the estimated scene center and radius");
     }
     obb.Set(aabbROI);
     return true;

--- a/libs/MVS/Scene.h
+++ b/libs/MVS/Scene.h
@@ -104,6 +104,9 @@ public:
 	bool Scale(const REAL* pScale = NULL);
 	bool ScaleImages(unsigned nMaxResolution = 0, REAL scale = 0, const String& folderName = String());
 
+    // detect and set region-of-interest
+    bool DetectROI(float scale=1.f);
+
 	// Dense reconstruction
 	bool DenseReconstruction(int nFusionMode=0);
 	bool ComputeDepthMaps(DenseDepthMapData& data);

--- a/libs/MVS/Scene.h
+++ b/libs/MVS/Scene.h
@@ -104,8 +104,8 @@ public:
 	bool Scale(const REAL* pScale = NULL);
 	bool ScaleImages(unsigned nMaxResolution = 0, REAL scale = 0, const String& folderName = String());
 
-    // detect and set region-of-interest
-    bool DetectROI(float scale=1.f);
+    // Estimate and set region-of-interest
+    bool EstimateROI(float scale=1.f);
 
 	// Dense reconstruction
 	bool DenseReconstruction(int nFusionMode=0);


### PR DESCRIPTION
The common two types of scenes are unbounded scenes and wrap-around scenes, in terms of indoor and outdoor. For wrap-around scenes, the majority point-clouds are outside the ROI. There are several relevant issues [https://github.com/cdcseacave/openMVS/issues/329](https://github.com/cdcseacave/openMVS/issues/329), [https://github.com/cdcseacave/openMVS/issues/787](https://github.com/cdcseacave/openMVS/issues/787).

This work provides methods and codes for detecting ROI automatically, which is motivated by @cdcseacave [https://github.com/cdcseacave/openMVS/issues/330](https://github.com/cdcseacave/openMVS/issues/330).

### Methods

Region-of-Interest(ROI) detection is equivalent to searching the center and the radius of the scene. ROI can be easily trimmed with these parameters.

1. Calculate the average camera position $P_{avg}$ , and the average camera direction $D_{avg}$ . (use median rather than mean because of higher robustness under skewed distribution.)
2. Consider $P_{avg}$ as the initial scene center, and calculate the average distance from all cameras to $P_{avg}$ as the initial scene radius $r$ .
3. The distribution of camera directions is likely to be skewed, that is, the scene could be statistically on one side of the cameras. Therefore, the scene center $C$ is calculated with $D_{avg}$ and $P_{avg}$ . The scene radius $r$ is updated accordingly.

$$
C = P_{avg} + \tan(\arcsin(D_{avg})) \times  r
$$

4. Since the imported SfM results usually contain sparse point-clouds and the corresponding visibility information, the OBB construction methods are divided into two cases:
    1. If contains: filter the point-clouds within a reasonable depth range according to scene radius and use them to fit a more accurate AABB (as the ROI).
    2. Else: directly construct an AABB (as the ROI) based on the estimated scene center and radius.

### Tests

The test data is the 'family' scenario of the Tanks-and-Temples dataset. Full, half, and quarter wrap-around scenes are tested to verify the robustness of the method.

#### Wrap-around scenario

![family_circle_cameras](https://user-images.githubusercontent.com/26993056/172021552-17488da3-d149-48a7-a523-a345465f5e94.png)
cameras + point-clouds trimmed with ROI

![family_circle_roi](https://user-images.githubusercontent.com/26993056/172021566-22b8764e-9ae4-4f27-8fc0-4f33c51544c6.png)
point-clouds trimmed with ROI

![family_circle_unbounded](https://user-images.githubusercontent.com/26993056/172021573-bf8acbcc-9578-40f4-a8bb-eb082b01bcb9.png)
Unbounded point-clouds

#### Half wrap-around scenario

![family_oneside_cameras](https://user-images.githubusercontent.com/26993056/172021582-6bea3031-c874-4515-a8f9-f1887fc0bcb2.png)
cameras + point-clouds trimmed with ROI

![family_oneside_roi](https://user-images.githubusercontent.com/26993056/172021593-5e6201cb-a590-43ac-b73a-78b475d439b4.png)
point-clouds trimmed with ROI

![family_oneside_unbounded](https://user-images.githubusercontent.com/26993056/172021597-0253ca14-dfcd-4d1e-a222-9c60b4328d21.png)
Unbounded point-clouds

#### Quarter wrap-around scenario

![family_sparse_cameras](https://user-images.githubusercontent.com/26993056/172021606-b9aceddd-159a-4467-88c2-8f6a01daacec.png)
cameras + point-clouds trimmed with ROI

![family_sparse_roi](https://user-images.githubusercontent.com/26993056/172021616-abef3100-d292-4136-a25c-dd78719bc2eb.png)
point-clouds trimmed with ROI

![family_sparse_unbounded](https://user-images.githubusercontent.com/26993056/172021617-c6084f2f-7c58-4e01-9261-8aaf69961aaf.png)
unbounded point-clouds