### PR TITLE
ROI estimation with robust safety check

### DIFF
--- a/apps/DensifyPointCloud/DensifyPointCloud.cpp
+++ b/apps/DensifyPointCloud/DensifyPointCloud.cpp
@@ -137,7 +137,7 @@ bool Initialize(size_t argc, LPCTSTR* argv)
 		("fusion-mode", boost::program_options::value(&OPT::nFusionMode)->default_value(0), "depth map fusion mode (-2 - fuse disparity-maps, -1 - export disparity-maps only, 0 - depth-maps & fusion, 1 - export depth-maps only)")
 		("filter-point-cloud", boost::program_options::value(&OPT::thFilterPointCloud)->default_value(0), "filter dense point-cloud based on visibility (0 - disabled)")
 		("export-number-views", boost::program_options::value(&OPT::nExportNumViews)->default_value(0), "export points with >= number of views (0 - disabled)")
-        ("roi-mode", boost::program_options::value(&OPT::nROIMode)->default_value(-1), "set region-of-interest mode for scene trim (-1 - unbounded scene, 0 - wrap-around scene)")
+        ("roi-mode", boost::program_options::value(&OPT::nROIMode)->default_value(0), "set region-of-interest mode (-1 - unbounded scene without trim, 0 - wrap-around scene with auto trim)")
         ;
 
 	// hidden options, allowed both on command line and

--- a/apps/DensifyPointCloud/DensifyPointCloud.cpp
+++ b/apps/DensifyPointCloud/DensifyPointCloud.cpp
@@ -57,7 +57,7 @@ String strDenseConfigFileName;
 String strExportDepthMapsName;
 float fMaxSubsceneArea;
 float fSampleMesh;
-bool bEstimateROI;
+int nEstimateROI;
 int nFusionMode;
 int thFilterPointCloud;
 int nExportNumViews;
@@ -137,7 +137,7 @@ bool Initialize(size_t argc, LPCTSTR* argv)
 		("fusion-mode", boost::program_options::value(&OPT::nFusionMode)->default_value(0), "depth map fusion mode (-2 - fuse disparity-maps, -1 - export disparity-maps only, 0 - depth-maps & fusion, 1 - export depth-maps only)")
 		("filter-point-cloud", boost::program_options::value(&OPT::thFilterPointCloud)->default_value(0), "filter dense point-cloud based on visibility (0 - disabled)")
 		("export-number-views", boost::program_options::value(&OPT::nExportNumViews)->default_value(0), "export points with >= number of views (0 - disabled)")
-        ("estimate-roi", boost::program_options::value(&OPT::bEstimateROI)->default_value(true), "estimate region-of-interest (0 - disabled)")
+        ("estimate-roi", boost::program_options::value(&OPT::nEstimateROI)->default_value(2), "estimate and set region-of-interest (0 - disabled, 1 - enabled, 2 - adaptive)")
         ;
 
 	// hidden options, allowed both on command line and
@@ -283,12 +283,9 @@ int main(int argc, LPCTSTR* argv)
 	// load and estimate a dense point-cloud
 	if (!scene.Load(MAKE_PATH_SAFE(OPT::strInputFileName)))
 		return EXIT_FAILURE;
-    if (OPT::bEstimateROI) {
-        // estimate region-of-interest
-        if (!scene.EstimateROI())
-            return EXIT_FAILURE;
-    }
-	if (!OPT::strExportROIFileName.empty() && scene.IsBounded()) {
+    if (!scene.EstimateROI(OPT::nEstimateROI, 1.f))
+        return EXIT_FAILURE;
+    if (!OPT::strExportROIFileName.empty() && scene.IsBounded()) {
 		std::ofstream fs(MAKE_PATH_SAFE(OPT::strExportROIFileName));
 		if (!fs)
 			return EXIT_FAILURE;

--- a/apps/DensifyPointCloud/DensifyPointCloud.cpp
+++ b/apps/DensifyPointCloud/DensifyPointCloud.cpp
@@ -57,6 +57,7 @@ String strDenseConfigFileName;
 String strExportDepthMapsName;
 float fMaxSubsceneArea;
 float fSampleMesh;
+int nROIMode;
 int nFusionMode;
 int thFilterPointCloud;
 int nExportNumViews;
@@ -136,7 +137,8 @@ bool Initialize(size_t argc, LPCTSTR* argv)
 		("fusion-mode", boost::program_options::value(&OPT::nFusionMode)->default_value(0), "depth map fusion mode (-2 - fuse disparity-maps, -1 - export disparity-maps only, 0 - depth-maps & fusion, 1 - export depth-maps only)")
 		("filter-point-cloud", boost::program_options::value(&OPT::thFilterPointCloud)->default_value(0), "filter dense point-cloud based on visibility (0 - disabled)")
 		("export-number-views", boost::program_options::value(&OPT::nExportNumViews)->default_value(0), "export points with >= number of views (0 - disabled)")
-		;
+        ("roi-mode", boost::program_options::value(&OPT::nROIMode)->default_value(-1), "set region-of-interest mode for scene trim (-1 - unbounded scene, 0 - wrap-around scene)")
+        ;
 
 	// hidden options, allowed both on command line and
 	// in config file, but will not be shown to the user
@@ -281,6 +283,11 @@ int main(int argc, LPCTSTR* argv)
 	// load and estimate a dense point-cloud
 	if (!scene.Load(MAKE_PATH_SAFE(OPT::strInputFileName)))
 		return EXIT_FAILURE;
+    if (OPT::nROIMode != -1) {
+        // detect region-of-interest
+        if(!scene.DetectROI())
+            return EXIT_FAILURE;
+    }
 	if (!OPT::strExportROIFileName.empty() && scene.IsBounded()) {
 		std::ofstream fs(MAKE_PATH_SAFE(OPT::strExportROIFileName));
 		if (!fs)

--- a/apps/DensifyPointCloud/DensifyPointCloud.cpp
+++ b/apps/DensifyPointCloud/DensifyPointCloud.cpp
@@ -57,7 +57,7 @@ String strDenseConfigFileName;
 String strExportDepthMapsName;
 float fMaxSubsceneArea;
 float fSampleMesh;
-int nROIMode;
+bool bEstimateROI;
 int nFusionMode;
 int thFilterPointCloud;
 int nExportNumViews;
@@ -137,7 +137,7 @@ bool Initialize(size_t argc, LPCTSTR* argv)
 		("fusion-mode", boost::program_options::value(&OPT::nFusionMode)->default_value(0), "depth map fusion mode (-2 - fuse disparity-maps, -1 - export disparity-maps only, 0 - depth-maps & fusion, 1 - export depth-maps only)")
 		("filter-point-cloud", boost::program_options::value(&OPT::thFilterPointCloud)->default_value(0), "filter dense point-cloud based on visibility (0 - disabled)")
 		("export-number-views", boost::program_options::value(&OPT::nExportNumViews)->default_value(0), "export points with >= number of views (0 - disabled)")
-        ("roi-mode", boost::program_options::value(&OPT::nROIMode)->default_value(0), "set region-of-interest mode (-1 - unbounded scene without trim, 0 - wrap-around scene with auto trim)")
+        ("estimate-roi", boost::program_options::value(&OPT::bEstimateROI)->default_value(true), "estimate region-of-interest (0 - disabled)")
         ;
 
 	// hidden options, allowed both on command line and
@@ -283,9 +283,9 @@ int main(int argc, LPCTSTR* argv)
 	// load and estimate a dense point-cloud
 	if (!scene.Load(MAKE_PATH_SAFE(OPT::strInputFileName)))
 		return EXIT_FAILURE;
-    if (OPT::nROIMode != -1) {
-        // detect region-of-interest
-        if(!scene.DetectROI())
+    if (OPT::bEstimateROI) {
+        // estimate region-of-interest
+        if (!scene.EstimateROI())
             return EXIT_FAILURE;
     }
 	if (!OPT::strExportROIFileName.empty() && scene.IsBounded()) {

--- a/libs/MVS/Scene.cpp
+++ b/libs/MVS/Scene.cpp
@@ -1378,8 +1378,17 @@ bool Scene::ScaleImages(unsigned nMaxResolution, REAL scale, const String& folde
 
 // estimate region-of-interest based on camera positions, directions and sparse points
 // scale specifies the ratio of the ROI's diameter
-bool Scene::EstimateROI(float scale)
+bool Scene::EstimateROI(int nEstimateROI, float scale)
 {
+    ASSERT(nEstimateROI >= 0 || nEstimateROI <= 2 || scale > 0);
+    if (nEstimateROI == 0) {
+        VERBOSE("The scene will be considered as unbounded (no ROI)");
+        return true;
+    }
+    if (!pointcloud.IsValid()) {
+        VERBOSE("error: no valid point-cloud for the ROI estimation");
+        return false;
+    }
     CameraArr cameras;
     FOREACH(i, images) {
         const Image& imageData = images[i];
@@ -1395,74 +1404,68 @@ bool Scene::EstimateROI(float scale)
     // compute the camera center and the direction median
     FloatArr x(nCameras), y(nCameras), z(nCameras), nx(nCameras), ny(nCameras), nz(nCameras);
     FOREACH(i, cameras) {
-        Point3f camC(cameras[i].C);
+        const Point3f camC(cameras[i].C);
         x[i] = camC.x;
         y[i] = camC.y;
         z[i] = camC.z;
-        Point3f camDirect(cameras[i].Direction());
+        const Point3f camDirect(cameras[i].Direction());
         nx[i] = camDirect.x;
         ny[i] = camDirect.y;
         nz[i] = camDirect.z;
     }
     const CMatrix camCenter(x.GetMedian(), y.GetMedian(), z.GetMedian());
-    CMatrix camDirectMed(nx.GetMedian(), ny.GetMedian(), nz.GetMedian());
-    const float camDirectMedLen = (float)norm(camDirectMed);
-    camDirectMed /= camDirectMedLen;
-    #if TD_VERBOSE != TD_VERBOSE_OFF
-    if (VERBOSITY_LEVEL > 2)
-        VERBOSE("The camera positions median is (%f,%f,%f), directions median and norm is (%f,%f,%f), %f",
-                camCenter.x, camCenter.y, camCenter.z, camDirectMed.x, camDirectMed.y, camDirectMed.z, camDirectMedLen);
-    #endif
-    FloatArr cameraDepths(nCameras);
-    FOREACH(i, cameras)
-        cameraDepths[i] = (float)cameras[i].PointDepth(camCenter);
-    // estimate scene center and radius
-    const float depthMedian = cameraDepths.GetMedian();
-    const float camShiftCoeff = TAN(ASIN(CLAMP(camDirectMedLen, -0.999f, 0.999f)));
-    const CMatrix sceneCenter = camCenter + camShiftCoeff * depthMedian * camDirectMed;
-    uint32_t nNegDepth = 0;
-    FOREACH(i, cameras) {
-        const float camDepth = (float)cameras[i].PointDepth(sceneCenter);
-        cameraDepths[i] = ABS(camDepth);
-        if (camDepth <= 0)
-            ++nNegDepth;
-    }
-    // return if ROI cannot be estimated accurately
-    if (nNegDepth >= cameras.size() / 3) {
-        VERBOSE("Inaccurate ROI estimation. The scene will be treated as unbounded (no ROI)");
+    CMatrix camDirectMean(nx.GetMean(), ny.GetMean(), nz.GetMean());
+    const float camDirectMeanLen = (float)norm(camDirectMean);
+    if (!ISZERO(camDirectMeanLen))
+        camDirectMean /= camDirectMeanLen;
+    if (camDirectMeanLen > FSQRT_2 / 2.f && nEstimateROI == 2) {
+        VERBOSE("The camera directions mean is unbalanced. The scene will be considered as unbounded (no ROI)");
         return true;
     }
-    const float sceneRadius = cameraDepths.GetMedian();
+    #if TD_VERBOSE != TD_VERBOSE_OFF
+    if (VERBOSITY_LEVEL > 2)
+        VERBOSE("The camera positions median is (%f,%f,%f), directions mean and norm are (%f,%f,%f), %f",
+                camCenter.x, camCenter.y, camCenter.z, camDirectMean.x, camDirectMean.y, camDirectMean.z, camDirectMeanLen);
+    #endif
+    FloatArr cameraDistances(nCameras);
+    FOREACH(i, cameras)
+        cameraDistances[i] = (float)cameras[i].Distance(camCenter);
+    // estimate scene center and radius
+    const float camDistMed = cameraDistances.GetMedian();
+    const float camShiftCoeff = TAN(ASIN(CLAMP(camDirectMeanLen, 0.f, 0.999f)));
+    const CMatrix sceneCenter = camCenter + camShiftCoeff * camDistMed * camDirectMean;
+    FOREACH(i, cameras) {
+        if (cameras[i].PointDepth(sceneCenter) <= 0 && nEstimateROI == 2) {
+            VERBOSE("Find a camera not pointing towards the scene center. The scene will be considered as unbounded (no ROI)");
+            return true;
+        }
+        cameraDistances[i] = (float)cameras[i].Distance(sceneCenter);
+    }
+    const float sceneRadius = cameraDistances.GetMax();
     #if TD_VERBOSE != TD_VERBOSE_OFF
     if (VERBOSITY_LEVEL > 2)
         VERBOSE("The estimated scene center is (%f,%f,%f), radius is %f",
                 sceneCenter.x, sceneCenter.y, sceneCenter.z, sceneRadius);
     #endif
-    // select points in the ROI
     Point3fArr ptsInROI;
     FOREACH(i, pointcloud.points) {
-        const PointCloud::Point& point = pointcloud.points[i];
-        const PointCloud::ViewArr& views = pointcloud.pointViews[i];
+        const PointCloud::Point &point = pointcloud.points[i];
+        const PointCloud::ViewArr &views = pointcloud.pointViews[i];
         FOREACH(j, views) {
-            const Image& imageData = images[views[j]];
+            const Image &imageData = images[views[j]];
             if (!imageData.IsValid())
                 continue;
-            const Camera& camera = imageData.camera;
+            const Camera &camera = imageData.camera;
             if (camera.PointDepth(point) < sceneRadius * 2.0f * scale) {
                 ptsInROI.emplace_back(point);
                 break;
             }
         }
     }
-    AABB3f aabbROI;
-    if (!ptsInROI.empty()) {
-        aabbROI.Set(ptsInROI.begin(), ptsInROI.size());
-        VERBOSE("Set the ROI by the estimated core points");
-    } else {
-        aabbROI.Set((const Point3f::EVec) Point3f(sceneCenter), sceneRadius * scale);
-        VERBOSE("Set the ROI by the estimated scene center and radius");
-    }
+    AABB3f aabbROI(ptsInROI.begin(), ptsInROI.size());
     obb.Set(aabbROI);
+    VERBOSE("Set the ROI with the AABB of position (%f,%f,%f) and extent (%f,%f,%f)",
+            obb.m_pos[0], obb.m_pos[1], obb.m_pos[2], obb.m_ext[0], obb.m_ext[1], obb.m_ext[2]);
     return true;
 } // EstimateROI
 /*----------------------------------------------------------------*/

--- a/libs/MVS/Scene.cpp
+++ b/libs/MVS/Scene.cpp
@@ -1382,7 +1382,7 @@ bool Scene::EstimateROI(float scale)
 {
     CameraArr cameras;
     FOREACH(i, images) {
-        const Image &imageData = images[i];
+        const Image& imageData = images[i];
         if (!imageData.IsValid())
             continue;
         cameras.emplace_back(imageData.camera);
@@ -1406,7 +1406,7 @@ bool Scene::EstimateROI(float scale)
     }
     const CMatrix camCenter(x.GetMedian(), y.GetMedian(), z.GetMedian());
     CMatrix camDirectMed(nx.GetMedian(), ny.GetMedian(), nz.GetMedian());
-    const auto camDirectMedLen = (float)norm(camDirectMed);
+    const float camDirectMedLen = (float)norm(camDirectMed);
     camDirectMed /= camDirectMedLen;
     #if TD_VERBOSE != TD_VERBOSE_OFF
     if (VERBOSITY_LEVEL > 2)
@@ -1422,10 +1422,10 @@ bool Scene::EstimateROI(float scale)
     const CMatrix sceneCenter = camCenter + camShiftCoeff * depthMedian * camDirectMed;
     uint32_t nNegDepth = 0;
     FOREACH(i, cameras) {
-        const auto camDepth = (float)cameras[i].PointDepth(sceneCenter);
-        cameraDepths[i] = fabs(camDepth);
+        const float camDepth = (float)cameras[i].PointDepth(sceneCenter);
+        cameraDepths[i] = ABS(camDepth);
         if (camDepth <= 0)
-            nNegDepth++;
+            ++nNegDepth;
     }
     // return if ROI cannot be estimated accurately
     if (nNegDepth >= cameras.size() / 3) {
@@ -1441,13 +1441,13 @@ bool Scene::EstimateROI(float scale)
     // select points in the ROI
     Point3fArr ptsInROI;
     FOREACH(i, pointcloud.points) {
-        const PointCloud::Point &point = pointcloud.points[i];
-        const PointCloud::ViewArr &views = pointcloud.pointViews[i];
+        const PointCloud::Point& point = pointcloud.points[i];
+        const PointCloud::ViewArr& views = pointcloud.pointViews[i];
         FOREACH(j, views) {
-            const Image &imageData = images[views[j]];
+            const Image& imageData = images[views[j]];
             if (!imageData.IsValid())
                 continue;
-            const Camera &camera = imageData.camera;
+            const Camera& camera = imageData.camera;
             if (camera.PointDepth(point) < sceneRadius * 2.0f * scale) {
                 ptsInROI.emplace_back(point);
                 break;
@@ -1460,7 +1460,7 @@ bool Scene::EstimateROI(float scale)
         VERBOSE("Set the ROI by the estimated core points");
     } else {
         aabbROI.Set((const Point3f::EVec) Point3f(sceneCenter), sceneRadius * scale);
-        VERBOSE("Set the ROI obb by the estimated scene center and radius");
+        VERBOSE("Set the ROI by the estimated scene center and radius");
     }
     obb.Set(aabbROI);
     return true;

--- a/libs/MVS/Scene.h
+++ b/libs/MVS/Scene.h
@@ -104,6 +104,9 @@ public:
 	bool Scale(const REAL* pScale = NULL);
 	bool ScaleImages(unsigned nMaxResolution = 0, REAL scale = 0, const String& folderName = String());
 
+    // detect and set region-of-interest
+    bool DetectROI(float scale=1.f);
+
 	// Dense reconstruction
 	bool DenseReconstruction(int nFusionMode=0);
 	bool ComputeDepthMaps(DenseDepthMapData& data);

--- a/libs/MVS/Scene.h
+++ b/libs/MVS/Scene.h
@@ -105,7 +105,7 @@ public:
 	bool ScaleImages(unsigned nMaxResolution = 0, REAL scale = 0, const String& folderName = String());
 
     // Estimate and set region-of-interest
-    bool EstimateROI(float scale=1.f);
+    bool EstimateROI(int nEstimateROI=0, float scale=1.f);
 
 	// Dense reconstruction
 	bool DenseReconstruction(int nFusionMode=0);

--- a/libs/MVS/Scene.h
+++ b/libs/MVS/Scene.h
@@ -104,8 +104,8 @@ public:
 	bool Scale(const REAL* pScale = NULL);
 	bool ScaleImages(unsigned nMaxResolution = 0, REAL scale = 0, const String& folderName = String());
 
-    // detect and set region-of-interest
-    bool DetectROI(float scale=1.f);
+    // Estimate and set region-of-interest
+    bool EstimateROI(float scale=1.f);
 
 	// Dense reconstruction
 	bool DenseReconstruction(int nFusionMode=0);


### PR DESCRIPTION
### More robust safety check

This ROI estimation method is designed for wrap-around scenes, leading to unreliability in non-warp scenes.

For non-warp-around scenes, it is difficult to estimate the ROI based on the cameras and point-clouds. As shown in the figure below, scenes A1 and A2 have the same camera distribution, but the distance $d$ from the ROI to the cameras is different. Observing scene A3, there is point-clouds noise between the cameras and the ROI (which is likely to happen), so we cannot just determine the ROI from the closest point cloud. In short, in non-warp-around scenes, it is difficult to estimate the ROI without other prior conditions given.

<img width="960" alt="image" src="https://user-images.githubusercontent.com/26993056/173249213-59de0f0d-d8eb-487b-828d-0c45eb47c444.png">

In general, partial wrap-around, orthoimage, and panorama-like scenes all have the same problems, that is, such scenes are difficult to be trimmed safely.

<img width="960" alt="image" src="https://user-images.githubusercontent.com/26993056/173249250-6aeef763-360d-422e-a9bb-61329d073c2a.png">

For wrap-around scenes, it is necessary to filter corner cases. As shown in the figure below, the overall camera distribution is warp-around, but some of the cameras are facing out of the scene center. It is difficult to determine whether the point clouds reconstructed by these cameras are inside or outside the ROI, and thus the accurate ROI cannot be estimated.

<img width="960" alt="image" src="https://user-images.githubusercontent.com/26993056/173249277-9e153ab6-f390-4e39-9265-ee08cf77b550.png">

In summary, scenes should satisfy the following two constraints for accurate ROI estimation.

- The scene is >180º wrap-around.
- All the cameras are pointing inside the scene center.

<img width="960" alt="image" src="https://user-images.githubusercontent.com/26993056/173249285-91c52c95-46fa-4893-9894-309501b10b43.png">

### Three options for users

- **adaptive**: ROI estimation with the safety check. (default setting recommended for most users).
- **enabled**: ROI estimation without the safety check. (The user specifies the input is a wrap-around scene)
- **disabled**: No ROI estimation. (The user specifies the input is an unbounded scene)

> The safety check of the `adaptive` option filters out some scenes that can be handled by the method (some are shown in the figure below). Thus, we have to add the new `enable` option that always trims the scene.

<img width="960" alt="image" src="https://user-images.githubusercontent.com/26993056/173249334-7d0794ed-8a81-4235-8549-ea37bf0df165.png">

### Tests

The latest codes have been tested on the scenes:
- the majority of scenes of Tanks-and-Temples dataset
- all the scenes of DTU MVS dataset
- the scenes provided by @cdcseacave in [#823](https://github.com/cdcseacave/openMVS/pull/823)