### PR TITLE
Optimize the completeness of the estimated ROI

### DIFF
--- a/apps/DensifyPointCloud/DensifyPointCloud.cpp
+++ b/apps/DensifyPointCloud/DensifyPointCloud.cpp
@@ -286,9 +286,9 @@ int main(int argc, LPCTSTR* argv)
 	// load and estimate a dense point-cloud
 	if (!scene.Load(MAKE_PATH_SAFE(OPT::strInputFileName)))
 		return EXIT_FAILURE;
-    if (!scene.EstimateROI(OPT::nEstimateROI, 1.f))
-        return EXIT_FAILURE;
-    if (!OPT::strExportROIFileName.empty() && scene.IsBounded()) {
+	if (!scene.EstimateROI(OPT::nEstimateROI, 1.1f))
+		return EXIT_FAILURE;
+	if (!OPT::strExportROIFileName.empty() && scene.IsBounded()) {
 		std::ofstream fs(MAKE_PATH_SAFE(OPT::strExportROIFileName));
 		if (!fs)
 			return EXIT_FAILURE;

--- a/libs/Common/AABB.inl
+++ b/libs/Common/AABB.inl
@@ -108,11 +108,11 @@ inline TAABB<TYPE,DIMS>& TAABB<TYPE,DIMS>::Enlarge(TYPE x)
 template <typename TYPE, int DIMS>
 inline TAABB<TYPE,DIMS>& TAABB<TYPE,DIMS>::EnlargePercent(TYPE x)
 {
-    POINT ptSize;
-    GetSize(ptSize);
-    ptSize *= (x - TYPE(1.)) / TYPE(2.);
-    ptMin -= ptSize;
-    ptMax += ptSize;
+	POINT ptSize;
+	GetSize(ptSize);
+	ptSize *= (x - TYPE(1.)) / TYPE(2.);
+	ptMin -= ptSize;
+	ptMax += ptSize;
 	return *this;
 } // Enlarge
 /*----------------------------------------------------------------*/

--- a/libs/Common/AABB.inl
+++ b/libs/Common/AABB.inl
@@ -108,8 +108,11 @@ inline TAABB<TYPE,DIMS>& TAABB<TYPE,DIMS>::Enlarge(TYPE x)
 template <typename TYPE, int DIMS>
 inline TAABB<TYPE,DIMS>& TAABB<TYPE,DIMS>::EnlargePercent(TYPE x)
 {
-	ptMin *= x;
-	ptMax *= x;
+    POINT ptSize;
+    GetSize(ptSize);
+    ptSize *= (x - TYPE(1.)) / TYPE(2.);
+    ptMin -= ptSize;
+    ptMax += ptSize;
 	return *this;
 } // Enlarge
 /*----------------------------------------------------------------*/

--- a/libs/MVS/Scene.cpp
+++ b/libs/MVS/Scene.cpp
@@ -1381,7 +1381,7 @@ bool Scene::ScaleImages(unsigned nMaxResolution, REAL scale, const String& folde
 // scale specifies the ratio of the ROI's diameter
 bool Scene::EstimateROI(int nEstimateROI, float scale)
 {
-	ASSERT(nEstimateROI >= 0 || nEstimateROI <= 2 || scale > 0);
+	ASSERT(nEstimateROI >= 0 && nEstimateROI <= 2 && scale > 0);
 	if (nEstimateROI == 0) {
 		DEBUG_ULTIMATE("The scene will be considered as unbounded (no ROI)");
 		return true;
@@ -1451,14 +1451,13 @@ bool Scene::EstimateROI(int nEstimateROI, float scale)
 			if (!imageData.IsValid())
 				continue;
 			const Camera& camera = imageData.camera;
-			if (camera.PointDepth(point) < sceneRadius * 2.0f * scale) {
+			if (camera.PointDepth(point) < sceneRadius * 2.0f) {
 				ptsInROI.emplace_back(point);
 				break;
 			}
 		}
 	}
-	;
-	obb.Set(AABB3f(ptsInROI.begin(), ptsInROI.size()));
+	obb.Set(AABB3f(ptsInROI.begin(), ptsInROI.size()).EnlargePercent(scale));
 	#if TD_VERBOSE != TD_VERBOSE_OFF
 	if (VERBOSITY_LEVEL > 2) {
 		VERBOSE("Set the ROI with the AABB of position (%f,%f,%f) and extent (%f,%f,%f)",

--- a/libs/MVS/Scene.h
+++ b/libs/MVS/Scene.h
@@ -104,8 +104,8 @@ public:
 	bool Scale(const REAL* pScale = NULL);
 	bool ScaleImages(unsigned nMaxResolution = 0, REAL scale = 0, const String& folderName = String());
 
-    // Estimate and set region-of-interest
-    bool EstimateROI(int nEstimateROI=0, float scale=1.f);
+	// Estimate and set region-of-interest
+	bool EstimateROI(int nEstimateROI=0, float scale=1.f);
 
 	// Dense reconstruction
 	bool DenseReconstruction(int nFusionMode=0);


### PR DESCRIPTION
The region of sparse point-cloud generated from SfM is likely to be slightly smaller than the dense point-cloud. This inconsistency between sparse and dense point-cloud causes a tiny part of core points trimmed. As shown in the figure, the orange point-cloud should not be trimmed.

To solve this problem, I add a `scale=1.1` to enlarge the estimated ROI by default. 

![https://user-images.githubusercontent.com/26993056/174437768-80d1ab41-9598-4707-90ad-6b10f827ba0b.png](https://user-images.githubusercontent.com/26993056/174437768-80d1ab41-9598-4707-90ad-6b10f827ba0b.png)

Moreover, I modify the implementation of `TAABB::EnlargePercent()` function because the center of the AABB should not shift after transformation.

## Test results

I use orange/green colors to show the point-cloud with ROI estimation disabled/enabled.

| nROIMode     | will be trimmed                       | color of point-cloud |
| ------------ | --------------------------------- | ----------------- |
| 0 - disabled | no, the scene is considered unbounded   | Orange            |
| 1 - enabled  | yes,  the scene is considered wrap-around | Green             |
| 2 - adaptive | depending on the safety check |     |

### The scenes considered wrap-around by safety-check

The scenes below will be trimmed when selecting `2 - adaptive` (equivalent to selecting `1 - enabled` ).

Family

![Screenshot from 2022-06-18 22-31-38](https://user-images.githubusercontent.com/26993056/174445148-d00f9912-95db-4889-ba00-a679fe3841ce.png)

Francis

![Screenshot from 2022-06-18 19-31-48](https://user-images.githubusercontent.com/26993056/174445171-9c7500f9-1d88-4060-a3c6-d7c7b7fe12ac.png)

Horse

![Screenshot from 2022-06-18 19-32-09](https://user-images.githubusercontent.com/26993056/174445175-4a94fcc3-111b-4217-85e6-bad66e2a0ea4.png)

Lighthouse

![Screenshot from 2022-06-18 19-32-46](https://user-images.githubusercontent.com/26993056/174445176-04324783-af74-411f-95b9-5e3d4c07774d.png)

M60

![Screenshot from 2022-06-18 19-35-54](https://user-images.githubusercontent.com/26993056/174445177-821f50ca-617c-4539-90ec-520e89212c95.png)

Panther

![Screenshot from 2022-06-18 19-37-54](https://user-images.githubusercontent.com/26993056/174445183-e2296cea-e751-43f9-abac-68b937384a4e.png)

Playground

![Screenshot from 2022-06-18 23-21-28](https://user-images.githubusercontent.com/26993056/174445153-306df8de-c979-495e-addd-1507ebc23d14.png)

Train

![Screenshot from 2022-06-18 19-39-49](https://user-images.githubusercontent.com/26993056/174445210-e63ba109-8673-465f-8699-3322114a161a.png)

### The scenes considered unbounded by safety-check

The scenes below will not be trimmed when selecting `2 - adaptive`. Users should select `1 - enabled` to enforce trimming the scene by ROI estimation.

As shown in the figures, some non-wrap-around scenes cannot be trimmed correctly. However, the safety check will not make it happen.

auditorium_pano

![https://user-images.githubusercontent.com/26993056/174438986-1c57f9f7-2b01-4e46-9b29-88e1fb655988.png](https://user-images.githubusercontent.com/26993056/174438986-1c57f9f7-2b01-4e46-9b29-88e1fb655988.png)

family_half

![https://user-images.githubusercontent.com/26993056/174438988-f2285a00-574e-4667-80db-2534750faa29.png](https://user-images.githubusercontent.com/26993056/174438988-f2285a00-574e-4667-80db-2534750faa29.png)

family_quarter

![https://user-images.githubusercontent.com/26993056/174438989-93dfeeee-f506-49ad-8857-e42d5d7fbab3.png](https://user-images.githubusercontent.com/26993056/174438989-93dfeeee-f506-49ad-8857-e42d5d7fbab3.png)

palace_pano

![https://user-images.githubusercontent.com/26993056/174438994-66dc8c9e-4713-48a8-ab39-4239e14a98ca.png](https://user-images.githubusercontent.com/26993056/174438994-66dc8c9e-4713-48a8-ab39-4239e14a98ca.png)

run3

![https://user-images.githubusercontent.com/26993056/174438995-4fa04b17-ff3a-4eb5-bcd0-eef3819de417.png](https://user-images.githubusercontent.com/26993056/174438995-4fa04b17-ff3a-4eb5-bcd0-eef3819de417.png)

sceaux_castle

![https://user-images.githubusercontent.com/26993056/174439018-70e94f8f-69a8-4cf7-9cf0-c3e5446353cf.png](https://user-images.githubusercontent.com/26993056/174439018-70e94f8f-69a8-4cf7-9cf0-c3e5446353cf.png)

DTU MVS

![Screenshot from 2022-06-18 21-41-17](https://user-images.githubusercontent.com/26993056/174445059-039e7a92-4ee0-4000-940f-dd16858a535f.png)

![Screenshot from 2022-06-18 21-41-37](https://user-images.githubusercontent.com/26993056/174445064-64a9634b-cc77-4515-8f89-6a3905d2e076.png)

![Screenshot from 2022-06-18 21-41-53](https://user-images.githubusercontent.com/26993056/174445065-46b80fbf-978f-43f4-8e99-377640101259.png)

![Screenshot from 2022-06-18 21-42-09](https://user-images.githubusercontent.com/26993056/174445067-834e1fe8-6c21-42eb-ab4f-68903fa5dfb4.png)

![Screenshot from 2022-06-18 21-42-24](https://user-images.githubusercontent.com/26993056/174445071-5020cb57-4a17-438a-9efc-4d8f78ae6e03.png)

![Screenshot from 2022-06-18 21-42-48](https://user-images.githubusercontent.com/26993056/174445073-d5af5ae8-bdcd-4f3d-9074-91b8c44ffe4f.png)

![Screenshot from 2022-06-18 21-43-00](https://user-images.githubusercontent.com/26993056/174445074-2c9bd5e3-1d01-4282-87f8-5010125d6287.png)

![Screenshot from 2022-06-18 21-43-44](https://user-images.githubusercontent.com/26993056/174445964-f1831edb-a86b-4dcb-b497-8ad3c46c0a99.png)

![Screenshot from 2022-06-18 21-44-16](https://user-images.githubusercontent.com/26993056/174445969-cc71a6d2-9283-4131-8cde-de9ab7fa9128.png)

![Screenshot from 2022-06-18 21-44-29](https://user-images.githubusercontent.com/26993056/174445971-f8dac8e6-7846-4835-b3e0-3e11c19e4509.png)
