### PR TITLE
Allow Masks Subsets

### DIFF
--- a/libs/MVS/DepthMap.cpp
+++ b/libs/MVS/DepthMap.cpp
@@ -298,6 +298,10 @@ unsigned DepthData::DecRef()
 bool DepthEstimator::ImportIgnoreMask(const Image& image0, const Image8U::Size& size, BitMatrix& bmask, uint16_t nIgnoreMaskLabel)
 {
 	ASSERT(image0.IsValid() && !image0.image.empty());
+
+	bmask.create(size);
+	bmask.memset(0xFF);
+
 	if (image0.maskName.empty())
 		return false;
 	Image16U mask;
@@ -306,8 +310,6 @@ bool DepthEstimator::ImportIgnoreMask(const Image& image0, const Image8U::Size& 
 		return false;
 	}
 	cv::resize(mask, mask, size, 0, 0, cv::INTER_NEAREST);
-	bmask.create(size);
-	bmask.memset(0xFF);
 	for (int r=0; r<size.height; ++r) {
 		for (int c=0; c<size.width; ++c) {
 			if (mask(r,c) == nIgnoreMaskLabel)

--- a/libs/MVS/SceneDensify.cpp
+++ b/libs/MVS/SceneDensify.cpp
@@ -671,8 +671,10 @@ bool DepthMapsData::EstimateDepthMap(IIndex idxImage, int nGeometricIter)
 		#endif
 		if (prevDepthMapSize != size) {
 			BitMatrix mask;
-			if (OPTDENSE::nIgnoreMaskLabel >= 0 && DepthEstimator::ImportIgnoreMask(*depthData.GetView().pImageData, depthData.depthMap.size(), mask, (uint16_t)OPTDENSE::nIgnoreMaskLabel))
+			if (OPTDENSE::nIgnoreMaskLabel >= 0){
+				DepthEstimator::ImportIgnoreMask(*depthData.GetView().pImageData, depthData.depthMap.size(), mask, (uint16_t)OPTDENSE::nIgnoreMaskLabel);
 				depthData.ApplyIgnoreMask(mask);
+			}
 			DepthEstimator::MapMatrix2ZigzagIdx(size, coords, mask, MAXF(64,(int)nMaxThreads*8));
 			#if 0
 			// show pixels to be processed


### PR DESCRIPTION
This PR tries to improve the logic of the image masks by allowing masks subset (masks for only a subset of the input images) to be provided.

Currently OpenMVS requires that an image mask is provided for each image in a dataset (all images must have an image mask when turning on --ignore-mask-label). The program was either crashing or returning some odd-looking point clouds when providing a masks subset.

Hope this can be useful to others. :pray:
