### PR TITLE
Fix image masks on GPU

### DIFF
--- a/libs/MVS/PatchMatchCUDA.cpp
+++ b/libs/MVS/PatchMatchCUDA.cpp
@@ -399,6 +399,15 @@ void PatchMatchCUDA::EstimateDepthMap(DepthData& depthData)
 			lowResNormalMap = depthData.normalMap;
 			lowResViewsMap = depthData.viewsMap;
 		}
+		
+		// Apply ignore mask
+		if (OPTDENSE::nIgnoreMaskLabel >= 0) {
+			const DepthData::ViewData& view = depthData.GetView();
+
+			BitMatrix mask;
+			if (OPTDENSE::nIgnoreMaskLabel >= 0 && DepthEstimator::ImportIgnoreMask(*view.pImageData, depthData.depthMap.size(), mask, (uint16_t)OPTDENSE::nIgnoreMaskLabel))
+				depthData.ApplyIgnoreMask(mask);
+		}
 	}
 
 	DEBUG_EXTRA("Depth-map for image %3u %s: %dx%d (%s)", depthData.images.front().GetID(),

--- a/libs/MVS/PatchMatchCUDA.cpp
+++ b/libs/MVS/PatchMatchCUDA.cpp
@@ -399,15 +399,14 @@ void PatchMatchCUDA::EstimateDepthMap(DepthData& depthData)
 			lowResNormalMap = depthData.normalMap;
 			lowResViewsMap = depthData.viewsMap;
 		}
-		
-		// Apply ignore mask
-		if (OPTDENSE::nIgnoreMaskLabel >= 0) {
-			const DepthData::ViewData& view = depthData.GetView();
+	}
 
-			BitMatrix mask;
-			if (OPTDENSE::nIgnoreMaskLabel >= 0 && DepthEstimator::ImportIgnoreMask(*view.pImageData, depthData.depthMap.size(), mask, (uint16_t)OPTDENSE::nIgnoreMaskLabel))
-				depthData.ApplyIgnoreMask(mask);
-		}
+	// apply ignore mask
+	if (OPTDENSE::nIgnoreMaskLabel >= 0) {
+		const DepthData::ViewData& view = depthData.GetView();
+		BitMatrix mask;
+		if (DepthEstimator::ImportIgnoreMask(*view.pImageData, depthData.depthMap.size(), mask, (uint16_t)OPTDENSE::nIgnoreMaskLabel))
+			depthData.ApplyIgnoreMask(mask);
 	}
 
 	DEBUG_EXTRA("Depth-map for image %3u %s: %dx%d (%s)", depthData.images.front().GetID(),


### PR DESCRIPTION
Hello :wave: 

This PR fixes masking when using the GPU. Currently image masks are ignored (broken?) when using CUDA.

I think I did this correctly, but please advise if changes are needed :pray: 