### PR TITLE
common: improve MvsScalablePipeline.py to support existing modules and resuming

### DIFF
--- a/MvsScalablePipeline.py
+++ b/MvsScalablePipeline.py
@@ -24,7 +24,7 @@ DensifyPointCloud scene_0000.mvs --dense-config-file Densify.ini
 ............
 DensifyPointCloud scene_000n.mvs --dense-config-file Densify.ini
 
-This script hepls to automate the process of calling DensifyPointCloud/ReconstructMesh on all sub-scenes.
+This script helps to automate the process of calling DensifyPointCloud/ReconstructMesh on all sub-scenes.
 
 usage: MvsScalablePipeline.py openMVS_module input_scene <options>
 
@@ -138,10 +138,13 @@ PARSER.add_argument('passthrough', nargs=argparse.REMAINDER, help="Option to be 
 
 PARSER.parse_args(namespace=CONF)  # store args in the ConfContainer
 
+suffix = os.path.basename(CONF.input_scene).replace('scene_XXXX','')
+CONF.input_scene = CONF.input_scene.replace('_dense','').replace('_mesh','').replace('_refine','').replace('_texture','')
+
 # Absolute path for input directory
 if len(CONF.input_scene) < 10 or CONF.input_scene[-9:] != '_XXXX.mvs':
-    sys.exit("%s: incalid scene name" % CONF.input_scene)
-CONF.input_scene = os.path.abspath(CONF.input_scene[:-9]+'_{counter:04d}.mvs')
+    sys.exit("%s: invalid scene name" % CONF.input_scene)
+CONF.input_scene = os.path.abspath(CONF.input_scene[:-9]+'_{counter:04d}'+suffix)
 
 for module_name in CONF.openMVS_modules.split(','):
     printout("# Module {} start #".format(module_name), colour=RED, effect=BOLD)

--- a/MvsScalablePipeline.py
+++ b/MvsScalablePipeline.py
@@ -35,6 +35,7 @@ import os
 import subprocess
 import sys
 import argparse
+import glob
 
 DEBUG = False
 
@@ -130,7 +131,7 @@ PARSER = argparse.ArgumentParser(
     description="Scalable MVS reconstruction with these steps: \r\n" +
     "MvsScalablePipeline.py openMVS_module input_scene <options>\r\n"
     )
-PARSER.add_argument('openMVS_modules',
+PARSER.add_argument('openMVS_module',
                     help="the OpenMVS module to use: DensifyPointCloud, ReconstructMesh, etc.")
 PARSER.add_argument('input_scene',
                     help="the scene name reg to process: scene_XXXX.mvs")
@@ -144,31 +145,36 @@ CONF.input_scene = CONF.input_scene.replace('_dense','').replace('_mesh','').rep
 # Absolute path for input directory
 if len(CONF.input_scene) < 10 or CONF.input_scene[-9:] != '_XXXX.mvs':
     sys.exit("%s: invalid scene name" % CONF.input_scene)
-CONF.input_scene = os.path.abspath(CONF.input_scene[:-9]+'_{counter:04d}'+suffix)
 
-for module_name in CONF.openMVS_modules.split(','):
-    printout("# Module {} start #".format(module_name), colour=RED, effect=BOLD)
-    i = 0
-    while os.path.exists(CONF.input_scene.format(counter=i)):
-        scene_name = CONF.input_scene.format(counter=i)
-        printout("# Process: %s" % os.path.basename(scene_name), colour=GREEN, effect=NO_EFFECT)
+match CONF.openMVS_module:
+  case 'ReconstructMesh':
+    moduleSuffix = '_mesh.mvs'
+  case 'RefineMesh':
+    moduleSuffix = '_refine.mvs'
+  case 'TextureMesh':
+    moduleSuffix = '_texture.mvs'
+  case _:
+    moduleSuffix = '_dense.mvs'
 
-        # create a commandline for the current step
-        cmdline = [os.path.join(OPENMVS_BIN, module_name), scene_name] + CONF.passthrough
-        print('Cmd: ' + ' '.join(cmdline))
+printout("# Module {} start #".format(CONF.openMVS_module), colour=RED, effect=BOLD)
+for scene_name in glob.glob(os.path.abspath(os.path.join(os.path.dirname(CONF.input_scene), 'scene_[0-9][0-9][0-9][0-9]'+suffix))):
+  if os.path.exists(os.path.splitext(scene_name)[0] + moduleSuffix) == False:
+    printout("# Process: %s" % os.path.basename(scene_name), colour=GREEN, effect=NO_EFFECT)
 
-        if not DEBUG:
-            # Launch the current step
-            try:
-                pStep = subprocess.Popen(cmdline)
-                pStep.wait()
-                if pStep.returncode != 0:
-                    printout("# Warning: step failed", colour=RED, effect=BOLD)
-                    break
-            except KeyboardInterrupt:
-                sys.exit('\r\nProcess canceled by user, all files remains')
-        else:
-            print('\t'.join(cmdline))
+    # create a commandline for the current step
+    cmdline = [os.path.join(OPENMVS_BIN, CONF.openMVS_module), scene_name] + CONF.passthrough
+    print('Cmd: ' + ' '.join(cmdline))
 
-        i += 1
-    printout("# Module {} end #".format(module_name), colour=RED, effect=BOLD)
+    if not DEBUG:
+        # Launch the current step
+        try:
+            pStep = subprocess.Popen(cmdline)
+            pStep.wait()
+            if pStep.returncode != 0:
+                printout("# Warning: step failed", colour=RED, effect=BOLD)
+        except KeyboardInterrupt:
+            sys.exit('\r\nProcess canceled by user, all files remains')
+    else:
+        print('\t'.join(cmdline))
+
+printout("# Module {} end #".format(CONF.openMVS_module), colour=RED, effect=BOLD)


### PR DESCRIPTION
- Fixed typos
- Stripped suffix from scene input then append back after valid name check to grab the wanted scene file
- Removed the use of multiple modules separated by comma
- Replaced the incremental counter and exit on first error with a check for sub scene files ending with the stripped suffix
- Added resume feature by checking if the scene has already been processed with the module suffix