### PR TITLE
boost lowdepth propagation for textureles areas

### DIFF
--- a/libs/MVS/DepthMap.cpp
+++ b/libs/MVS/DepthMap.cpp
@@ -89,7 +89,7 @@ MDEFVAR_OPTDENSE_float(fMinArea, "Min Area", "Min shared area for accepting the 
 MDEFVAR_OPTDENSE_float(fMinAngle, "Min Angle", "Min angle for accepting the depth triangulation", "3.0")
 MDEFVAR_OPTDENSE_float(fOptimAngle, "Optim Angle", "Optimal angle for computing the depth triangulation", "12.0")
 MDEFVAR_OPTDENSE_float(fMaxAngle, "Max Angle", "Max angle for accepting the depth triangulation", "65.0")
-MDEFVAR_OPTDENSE_float(fDescriptorMinMagnitudeThreshold, "Descriptor Min Magnitude Threshold", "minimum texture variance accepted when matching two patches (0 - disabled)", "0.02")
+MDEFVAR_OPTDENSE_float(fDescriptorMinMagnitudeThreshold, "Descriptor Min Magnitude Threshold", "minimum texture variance accepted when matching two patches (0 - disabled)", "0.02") // 0.02=> ncc pixelscore squared below 0.0004 will be removed from depthmap; 0.02=> texture variance below 0.12 is considered texture-less
 MDEFVAR_OPTDENSE_float(fDepthDiffThreshold, "Depth Diff Threshold", "maximum variance allowed for the depths during refinement", "0.01")
 MDEFVAR_OPTDENSE_float(fNormalDiffThreshold, "Normal Diff Threshold", "maximum variance allowed for the normal during fusion (degrees)", "25")
 MDEFVAR_OPTDENSE_float(fPairwiseMul, "Pairwise Mul", "pairwise cost scale to match the unary cost", "0.3")
@@ -549,10 +549,10 @@ float DepthEstimator::ScorePixelImage(const DepthData::ViewData& image1, Depth d
 	if (!lowResDepthMap.empty()) {
 		const Depth d0 = lowResDepthMap(x0);
 		if (d0 > 0) {
-			const float deltaDepth = MINF(DepthSimilarity(d0, depth), 0.5f);
+			const float deltaDepth(MINF(DepthSimilarity(d0, depth), 0.5f));
 			const float smoothSigmaDepth(-1.f / (1.f * 0.02f));
-			const float factorDeltaDepth = DENSE_EXP(normSq0 * smoothSigmaDepth);
-			score += deltaDepth * factorDeltaDepth;
+			const float factorDeltaDepth(DENSE_EXP(normSq0 * smoothSigmaDepth));
+			score = (1.f-factorDeltaDepth)*score + factorDeltaDepth*deltaDepth;
 		}
 	}
 	ASSERT(ISFINITE(score));

--- a/libs/MVS/DepthMap.cpp
+++ b/libs/MVS/DepthMap.cpp
@@ -89,7 +89,7 @@ MDEFVAR_OPTDENSE_float(fMinArea, "Min Area", "Min shared area for accepting the 
 MDEFVAR_OPTDENSE_float(fMinAngle, "Min Angle", "Min angle for accepting the depth triangulation", "3.0")
 MDEFVAR_OPTDENSE_float(fOptimAngle, "Optim Angle", "Optimal angle for computing the depth triangulation", "12.0")
 MDEFVAR_OPTDENSE_float(fMaxAngle, "Max Angle", "Max angle for accepting the depth triangulation", "65.0")
-MDEFVAR_OPTDENSE_float(fDescriptorMinMagnitudeThreshold, "Descriptor Min Magnitude Threshold", "minimum texture variance accepted when matching two patches (0 - disabled)", "0.02") // 0.02=> ncc pixelscore squared below 0.0004 will be removed from depthmap; 0.02=> texture variance below 0.12 is considered texture-less
+MDEFVAR_OPTDENSE_float(fDescriptorMinMagnitudeThreshold, "Descriptor Min Magnitude Threshold", "minimum patch texture variance accepted when matching two patches (0 - disabled)", "0.02") // 0.02: pixels with patch texture variance below 0.0004 (0.02^2) will be removed from depthmap; 0.12: patch texture variance below 0.02 (0.12^2) is considered texture-less
 MDEFVAR_OPTDENSE_float(fDepthDiffThreshold, "Depth Diff Threshold", "maximum variance allowed for the depths during refinement", "0.01")
 MDEFVAR_OPTDENSE_float(fNormalDiffThreshold, "Normal Diff Threshold", "maximum variance allowed for the normal during fusion (degrees)", "25")
 MDEFVAR_OPTDENSE_float(fPairwiseMul, "Pairwise Mul", "pairwise cost scale to match the unary cost", "0.3")
@@ -550,7 +550,7 @@ float DepthEstimator::ScorePixelImage(const DepthData::ViewData& image1, Depth d
 		const Depth d0 = lowResDepthMap(x0);
 		if (d0 > 0) {
 			const float deltaDepth(MINF(DepthSimilarity(d0, depth), 0.5f));
-			const float smoothSigmaDepth(-1.f / (1.f * 0.02f));
+			const float smoothSigmaDepth(-1.f / (1.f * 0.02f)); // 0.12: patch texture variance below 0.02 (0.12^2) is considered texture-less
 			const float factorDeltaDepth(DENSE_EXP(normSq0 * smoothSigmaDepth));
 			score = (1.f-factorDeltaDepth)*score + factorDeltaDepth*deltaDepth;
 		}

--- a/libs/MVS/PatchMatchCUDA.cu
+++ b/libs/MVS/PatchMatchCUDA.cu
@@ -348,11 +348,11 @@ __device__ float ScorePlane(const ImagePixels refImage, const PatchMatchCUDA::Ca
 
 	// apply depth prior weight based on patch textureless
 	if (lowDepth > 0) {
+		const float depth(plane.w());
+		const float deltaDepth(MIN((abs(lowDepth-depth) / lowDepth), 0.5f));
 		constexpr float smoothSigmaDepth(-1.f / (1.f * 0.02f));
-		const float depth = plane.w();
-		const float deltaDepth = MIN((abs(lowDepth - depth) / lowDepth), 0.5f);
-		const float factorDeltaDepth = exp(varRef * smoothSigmaDepth);
-		ncc += deltaDepth * factorDeltaDepth;
+		const float factorDeltaDepth(exp(varRef * smoothSigmaDepth));
+		ncc = (1.f-factorDeltaDepth)*ncc + factorDeltaDepth*deltaDepth;
 	}
 	return max(0.f, min(2.f, ncc));
 }

--- a/libs/MVS/PatchMatchCUDA.cu
+++ b/libs/MVS/PatchMatchCUDA.cu
@@ -350,7 +350,7 @@ __device__ float ScorePlane(const ImagePixels refImage, const PatchMatchCUDA::Ca
 	if (lowDepth > 0) {
 		const float depth(plane.w());
 		const float deltaDepth(MIN((abs(lowDepth-depth) / lowDepth), 0.5f));
-		constexpr float smoothSigmaDepth(-1.f / (1.f * 0.02f));
+		constexpr float smoothSigmaDepth(-1.f / (1.f * 0.02f)); // 0.12: patch texture variance below 0.02 (0.12^2) is considered texture-less
 		const float factorDeltaDepth(exp(varRef * smoothSigmaDepth));
 		ncc = (1.f-factorDeltaDepth)*ncc + factorDeltaDepth*deltaDepth;
 	}


### PR DESCRIPTION
Textureless areas get a bad score at high resolution, so we need to assign a score below the threshold if low resolution estimated a depth in that position