### PR TITLE
interface: Fix the pointcloud is always cleared.

### DIFF
--- a/apps/InterfaceMetashape/InterfaceMetashape.cpp
+++ b/apps/InterfaceMetashape/InterfaceMetashape.cpp
@@ -803,7 +803,7 @@ int main(int argc, LPCTSTR* argv)
 
 	// undistort images
 	const String pathData(MAKE_PATH_FULL(WORKING_FOLDER_FULL, OPT::strOutputImageFolder));
-	const bool bAssignPoints(!scene.pointcloud.IsEmpty() && !scene.pointcloud.IsValid());
+	const bool bAssignPoints(!scene.pointcloud.IsEmpty() && scene.pointcloud.IsValid());
 	Util::Progress progress(_T("Processed images"), scene.images.size());
 	GET_LOGCONSOLE().Pause();
 	#ifdef _USE_OPENMP


### PR DESCRIPTION
```cpp
if (!OPT::strPointsFileName.empty()) {
	if (!scene.pointcloud.Load(MAKE_PATH_SAFE(OPT::strPointsFileName)))
		return EXIT_FAILURE;
	ASSERT(!scene.pointcloud.IsValid());
	scene.pointcloud.pointViews.Resize(scene.pointcloud.points.GetSize());
}
...
const bool bAssignPoints(!scene.pointcloud.IsEmpty() && !scene.pointcloud.IsValid());
...
FOREACH(ID, scene.images) {
	...
	if (bAssignPoints)
		AssignPoints(imageData, ID, scene.pointcloud);
}
...
if (!scene.pointcloud.IsEmpty()) {
	RFOREACH(i, scene.pointcloud.points)
		if (scene.pointcloud.pointViews[i].size() < 2)
			scene.pointcloud.RemovePoint(i);
}
```
When I load a pointcloud file, the AssignPoints() will never be called, eventually all points are removed.
```cpp
const bool bAssignPoints(!scene.pointcloud.IsEmpty() && scene.pointcloud.IsValid());
I remove the not operator before scene.pointcloud.IsValid(), it works fine.