### PR TITLE
Compute texture patch

### DIFF
--- a/apps/Viewer/Scene.cpp
+++ b/apps/Viewer/Scene.cpp
@@ -706,7 +706,7 @@ void Scene::TogleSceneBox()
 }
 
 
-void Scene::CastRay(const Ray3& ray, int action)
+void Scene::CastRay(const Ray3& ray, int action, int mods)
 {
 	if (!IsOctreeValid())
 		return;
@@ -747,6 +747,19 @@ void Scene::CastRay(const Ray3& ray, int action)
 				face[1], window.selectionPoints[1].x, window.selectionPoints[1].y, window.selectionPoints[1].z,
 				face[2], window.selectionPoints[2].x, window.selectionPoints[2].y, window.selectionPoints[2].z
 			);
+			if ((mods&(GLFW_MOD_CONTROL|GLFW_MOD_SHIFT)) && scene.mesh.HasTexture()) {
+				String dbgOut;
+				cv::Mat dbgImg;
+				scene.mesh.ListIncidenteFaces();
+				scene.mesh.ListIncidenteFaceFaces();
+				const bool bSaveToFile = (mods&GLFW_MOD_ALT);
+				dbgOut = scene.mesh.PlotTexturePatch((MVS::Mesh::FIndex)intRay.pick.idx, face_patch_ids, dbgImg, bSaveToFile);
+				if (!dbgOut.IsEmpty()) {
+					DEBUG_EXTRA("Saved texture patch as %s", dbgOut.c_str());
+				} else {
+					cv::imshow(dbgOut, dbgImg);	
+				}
+			}
 		} else {
 			window.selectionType = Window::SEL_NA;
 		}

--- a/apps/Viewer/Scene.h
+++ b/apps/Viewer/Scene.h
@@ -60,6 +60,7 @@ public:
 	Window window;
 	ImageArr images; // scene photos
 	ImageArr textures; // mesh textures
+	MVS::Mesh::FaceIdxArr face_patch_ids;
 
 	OctreePoints octPoints;
 	OctreeMesh octMesh;
@@ -97,7 +98,7 @@ public:
 
 	void Center();
 	void TogleSceneBox();
-	void CastRay(const Ray3&, int);
+	void CastRay(const Ray3&, int, int);
 protected:
 	static void* ThreadWorker(void*);
 };

--- a/apps/Viewer/Window.cpp
+++ b/apps/Viewer/Window.cpp
@@ -366,7 +366,7 @@ void Window::Key(GLFWwindow* window, int k, int scancode, int action, int mod)
 	g_mapWindows[window]->Key(k, scancode, action, mod);
 }
 
-void Window::MouseButton(int button, int action, int /*mods*/)
+void Window::MouseButton(int button, int action, int mods)
 {
 	switch (button) {
 	case GLFW_MOUSE_BUTTON_LEFT: {
@@ -394,7 +394,7 @@ void Window::MouseButton(int button, int action, int /*mods*/)
 			const Eigen::Vector3d start(invV.topRightCorner<3,1>());
 			const Eigen::Vector4d ray_wor(invV*ray_eye);
 			const Eigen::Vector3d dir(ray_wor.topRows<3>().normalized());
-			clbkRayScene(Ray3d(start, dir), action);
+			clbkRayScene(Ray3d(start, dir), action, mods);
 		}
 	} break;
 	case GLFW_MOUSE_BUTTON_MIDDLE: {

--- a/apps/Viewer/Window.h
+++ b/apps/Viewer/Window.h
@@ -100,7 +100,7 @@ public:
 	ClbkExportScene clbkExportScene;
 	typedef DELEGATE<void (void)> ClbkCenterScene;
 	ClbkCenterScene clbkCenterScene;
-	typedef DELEGATE<void (const Ray3&, int)> ClbkRayScene;
+	typedef DELEGATE<void (const Ray3&, int, int)> ClbkRayScene;
 	ClbkRayScene clbkRayScene;
 	typedef DELEGATE<void (void)> ClbkCompilePointCloud;
 	ClbkCompilePointCloud clbkCompilePointCloud;

--- a/libs/IO/OBJ.cpp
+++ b/libs/IO/OBJ.cpp
@@ -191,6 +191,7 @@ bool ObjModel::Save(const String& fileName, unsigned precision, bool texLossless
 bool ObjModel::Load(const String& fileName)
 {
 	ASSERT(vertices.empty() && groups.empty() && material_lib.materials.empty());
+	const String path(Util::getFilePath(fileName));
 	std::ifstream fin(fileName.c_str());
 	String line, keyword;
 	std::istringstream in;
@@ -254,7 +255,7 @@ bool ObjModel::Load(const String& fileName)
 		} else
 		if (keyword == "mtllib") {
 			in >> keyword;
-			if (!material_lib.Load(keyword))
+			if (!material_lib.Load(MAKE_PATH_FULL(path, keyword)))
 				return false;
 		} else
 		if (keyword == "usemtl") {

--- a/libs/MVS/Mesh.h
+++ b/libs/MVS/Mesh.h
@@ -210,7 +210,7 @@ public:
 	REAL ComputeArea() const;
 	REAL ComputeVolume() const;
 
-	String PlotTexturePatch(const FIndex dbgFaceId) const;
+	String PlotTexturePatch(const FIndex dbgFaceId, FaceIdxArr& face_patch_ids=FaceIdxArr(), cv::Mat& imgOut=cv::Mat(), const bool bSaveToFile=true) const;
 
 	void SamplePoints(unsigned numberOfPoints, PointCloud&) const;
 	void SamplePoints(REAL samplingDensity, PointCloud&) const;

--- a/libs/MVS/Mesh.h
+++ b/libs/MVS/Mesh.h
@@ -161,6 +161,7 @@ public:
 	void ListBoundaryVertices();
 	void ComputeNormalFaces();
 	void ComputeNormalVertices();
+	uint32_t ComputeTexturePatchFaces(FaceIdxArr& face_patch_ids) const;
 
 	void SmoothNormalFaces(float fMaxGradient=25.f, float fOriginalWeight=0.5f, unsigned nIterations=3);
 

--- a/libs/MVS/Mesh.h
+++ b/libs/MVS/Mesh.h
@@ -210,6 +210,8 @@ public:
 	REAL ComputeArea() const;
 	REAL ComputeVolume() const;
 
+	String PlotTexturePatch(const FIndex dbgFaceId) const;
+
 	void SamplePoints(unsigned numberOfPoints, PointCloud&) const;
 	void SamplePoints(REAL samplingDensity, PointCloud&) const;
 	void SamplePoints(REAL samplingDensity, unsigned mumPointsTheoretic, PointCloud&) const;


### PR DESCRIPTION
Add a method to calculate texture patches and added a feature in Viewer to visualize the texture for a selected face.
In Viewer open a scene with cameras, then drag and drop the obj file for textured mesh.
 - hold Ctrl+Shift and click on a face to see the texture patch in a new window
 - hold Ctrl+Alt+Shift and click on a face to save the texture patch for that face in a jpg file