### PR TITLE
fix incorrect comparison in BufferedOutputStream

### DIFF
--- a/libs/Common/Filters.h
+++ b/libs/Common/Filters.h
@@ -103,7 +103,7 @@ public:
 				if (this->s->write(buf, bufSize) == STREAM_ERROR)
 					return STREAM_ERROR;
 				pos = 0;
-				if (len >= bufSize) {
+				if (len < bufSize) {
 					if (this->s->write(b, len) == STREAM_ERROR)
 						return STREAM_ERROR;
 					break;


### PR DESCRIPTION
This bug was causing some unintuitive behavior such as a maximum file size of 2 GiB on POSIX systems which I mentioned in https://github.com/cdcseacave/openMVS/discussions/1008#discussioncomment-6222112

Intuitively, imagine if `len = 5676725273` and `bufSize = 131072`. Previously, the loop would iterate once. 

* On the first iteration, `n = MIN(bufSize - pos, len)` gets evaluated to `bufSize`. After copying 131072 bytes to the buffer, it goes onto the next iteration.
* On the second iteration, `pos == bufSize`. It writes the 131072 bytes and resets `pos` to zero. Now, `len` (which is `5676725273 - 131072 = 5676594201`) is much bigger than `bufSize` so it calls `this->s->write(b, len)`. This is an invalid operation since the len is much bigger than the buffer. In fact, the [linux `write` function can only write 2147479552 bytes](https://stackoverflow.com/questions/70368651/why-cant-linux-write-more-than-2147479552-bytes). So in `File.h`, the [`if (x < (ssize_t)len)` fails with `STREAM_ERROR`](https://github.com/cdcseacave/openMVS/blob/develop/libs/Common/File.h#L511). 

The loop quits with `STREAM_ERROR` but we never check the return status of `ostream->write` [here in PLY.cpp](https://github.com/cdcseacave/openMVS/blob/develop/libs/IO/PLY.cpp#L333) so we end up with a mysterious 2 GB file.


This PR fixes it to the intended behavior where we write the buffer size and then this branch only writes whatever straggler is left behind on the last iteration. I've verified that it works by printing out debug statements and running `DensifyPointCloud --estimate-scale 1` it on a large point cloud. 

With this fix, densified point clouds with scale can now go over 2^31 bytes. For example:

```
$ ls -al
total 17169804
drwxrwsr-x 1 dllu    dllu          0 Jun 19 18:04 .
drwxrwsr-x 1 dllu    dllu          0 Jun 15 17:53 ..
-rw-rw-r-- 1 dllu    dllu   42759713 Jun 15 21:40 asdf.mvs
-rw-rw-r-- 1 dllu    dllu 7482937566 Jun 15 22:55 asdf_dense.mvs
-rw-rw-r-- 1 dllu    dllu 4379289198 Jun 15 22:55 asdf_dense.ply
-rw-r--r-- 1 dllu    dllu 5676856345 Jun 19 18:07 asdf_dense_dense_scale.ply
$ head asdf_dense.ply
ply
format binary_little_endian 1.0
element vertex 162195887
property float32 x
property float32 y
property float32 z
property uint8 red
property uint8 green
property uint8 blue
property float32 nx
$ head asdf_dense_dense_scale.ply
ply
format binary_little_endian 1.0
element vertex 162195887
property float32 x
property float32 y
property float32 z
property uint8 red
property uint8 green
property uint8 blue
property float32 nx
```