### PR TITLE
dense: check and resize the existed dmap file to image

### DIFF
--- a/libs/MVS/DepthMap.cpp
+++ b/libs/MVS/DepthMap.cpp
@@ -2107,6 +2107,28 @@ bool MVS::ImportDepthDataRaw(const String& fileName, String& imageFileName,
 } // ImportDepthDataRaw
 /*----------------------------------------------------------------*/
 
+bool MVS::GetDepthMapHeaderSize(const String& fileName, cv::Size& size)
+{
+	FILE* f = fopen(fileName, "rb");
+	if (f == NULL) {
+		DEBUG("error: opening file '%s' for reading depth-data", fileName.c_str());
+		return false;
+	}
+	// read header
+	HeaderDepthDataRaw header;
+	if (fread(&header, sizeof(HeaderDepthDataRaw), 1, f) != 1 ||
+		header.name != HeaderDepthDataRaw::HeaderDepthDataRawName() ||
+		(header.type & HeaderDepthDataRaw::HAS_DEPTH) == 0 ||
+		header.depthWidth <= 0 || header.depthHeight <= 0 ||
+		header.imageWidth < header.depthWidth || header.imageHeight < header.depthHeight)
+	{
+		DEBUG("error: invalid depth-data file '%s'", fileName.c_str());
+		return false;
+	}
+	size = cv::Size(header.depthWidth, header.depthHeight);
+	fclose(f);
+	return true;
+}
 
 // compare the estimated and ground-truth depth-maps
 void MVS::CompareDepthMaps(const DepthMap& depthMap, const DepthMap& depthMapGT, uint32_t idxImage, float threshold)

--- a/libs/MVS/DepthMap.h
+++ b/libs/MVS/DepthMap.h
@@ -519,6 +519,8 @@ MVS_API bool ImportDepthDataRaw(const String&, String& imageFileName,
 	Depth& dMin, Depth& dMax,
 	DepthMap&, NormalMap&, ConfidenceMap&, ViewsMap&, unsigned flags=15);
 
+MVS_API bool GetDepthMapHeaderSize(const String& fileName, cv::Size& size);
+
 MVS_API void CompareDepthMaps(const DepthMap& depthMap, const DepthMap& depthMapGT, uint32_t idxImage, float threshold=0.01f);
 MVS_API void CompareNormalMaps(const NormalMap& normalMap, const NormalMap& normalMapGT, uint32_t idxImage);
 /*----------------------------------------------------------------*/

--- a/libs/MVS/SceneDensify.cpp
+++ b/libs/MVS/SceneDensify.cpp
@@ -1962,6 +1962,14 @@ void Scene::DenseReconstructionEstimate(void* pData)
 			}
 			// try to load already compute depth-map for this image
 			if (depthmapComputed && data.nFusionMode >= 0) {
+				if (depthData.Load(ComposeDepthFilePath(depthData.GetView().GetID(), "dmap"))) {
+					DepthMap& depthMap = depthData.depthMap;
+					Image& image = images[idx];
+					if(image.width != static_cast<uint32_t>(depthMap.width()) || image.height != static_cast<uint32_t>(depthMap.height())){
+						cv::resize(depthMap, depthMap, cv::Size(image.width, image.height), 0, 0, cv::INTER_CUBIC);
+						depthData.Save(ComposeDepthFilePath(depthData.GetView().GetID(), "dmap"));						
+					}
+				}
 				if (OPTDENSE::nOptimize & OPTDENSE::OPTIMIZE) {
 					if (!depthData.Load(ComposeDepthFilePath(depthData.GetView().GetID(), "dmap"))) {
 						VERBOSE("error: invalid depth-map '%s'", ComposeDepthFilePath(depthData.GetView().GetID(), "dmap").c_str());

--- a/libs/MVS/SceneDensify.cpp
+++ b/libs/MVS/SceneDensify.cpp
@@ -33,6 +33,7 @@
 #include "Scene.h"
 #include "SceneDensify.h"
 #include "PatchMatchCUDA.h"
+#include "DepthMap.h"
 // MRF: view selection
 #include "../Math/TRWS/MRFEnergy.h"
 
@@ -1962,17 +1963,17 @@ void Scene::DenseReconstructionEstimate(void* pData)
 			}
 			// try to load already compute depth-map for this image
 			if (depthmapComputed && data.nFusionMode >= 0) {
-				if (depthData.Load(ComposeDepthFilePath(depthData.GetView().GetID(), "dmap"))) {
+				const std::string depthMapName(ComposeDepthFilePath(data.scene.images[idx].ID, "dmap"));
+				cv::Size depthMapSize;
+				if (GetDepthMapHeaderSize(depthMapName, depthMapSize) && depthMapSize != data.scene.images[idx].GetSize()) {
+					depthData.Load(depthMapName);
 					DepthMap& depthMap = depthData.depthMap;
-					Image& image = images[idx];
-					if(image.width != static_cast<uint32_t>(depthMap.width()) || image.height != static_cast<uint32_t>(depthMap.height())){
-						cv::resize(depthMap, depthMap, cv::Size(image.width, image.height), 0, 0, cv::INTER_CUBIC);
-						depthData.Save(ComposeDepthFilePath(depthData.GetView().GetID(), "dmap"));						
-					}
+					cv::resize(depthMap, depthMap, data.scene.images[idx].GetSize(), 0, 0, cv::INTER_NEAREST);
+					depthData.Save(depthMapName);
 				}
 				if (OPTDENSE::nOptimize & OPTDENSE::OPTIMIZE) {
-					if (!depthData.Load(ComposeDepthFilePath(depthData.GetView().GetID(), "dmap"))) {
-						VERBOSE("error: invalid depth-map '%s'", ComposeDepthFilePath(depthData.GetView().GetID(), "dmap").c_str());
+					if (!depthData.Load(depthMapName)) {
+						VERBOSE("error: invalid depth-map '%s'", depthMapName.c_str());
 						exit(EXIT_FAILURE);
 					}
 					// optimize depth-map


### PR DESCRIPTION
for issue #1014 : add size check for existed depthmap and image. If their size not match, resize the depthmap to image size.