### PR TITLE
(Image) Support .jpeg file extension

### DIFF
--- a/libs/IO/Image.cpp
+++ b/libs/IO/Image.cpp
@@ -893,7 +893,7 @@ CImage* CImage::Create(LPCTSTR szName, IMCREATE mode)
 		pImage = new CImagePNG();
 	#endif
 	#ifdef _IMAGE_JPG
-	else if (_tcsncicmp(fext, _T(".jpg"), 4) == 0)
+	else if (_tcsncicmp(fext, _T(".jpg"), 4) == 0 || _tcsncicmp(fext, _T(".jpeg"), 5) == 0)
 		pImage = new CImageJPG();
 	#endif
 	#ifdef _IMAGE_TIFF


### PR DESCRIPTION
Solves the issue where files with the `.jpeg` extension aren't recognized as JPEG files:

```
20:40:00 [IO      ] error: unknown image format '/some/path//mvs/undistorted_images/DSC09064.jpeg'
```

While most JPEG loading issues are caused by incompatibilities between the OpenMVG and OpenCV JPEG libs, I just encountered this issue while using a containerized build that I've been successfully using with `.jpg` files for a few months. I can only find one other reported issue (#258) that seems to have had this same problem.

Thanks to @antonyscerri for pointing out the likely cause in that issue.