### PR TITLE
Add an A100 CUDA parameter

### DIFF
--- a/libs/Common/UtilCUDA.cpp
+++ b/libs/Common/UtilCUDA.cpp
@@ -50,6 +50,7 @@ int _convertSMVer2Cores(int major, int minor)
 		{0x70, 64 }, // Volta Generation (SM 7.0) GV100 class
 		{0x72, 64 }, // Volta Generation (SM 7.2) GV10B class
 		{0x75, 64 }, // Turing Generation (SM 7.5) TU1xx class
+		{0x80, 64 }, // Ampere Generation (SM 8.0) GA100 class
 		{-1, -1}
 	};
 


### PR DESCRIPTION
Add an Ampere A100 parameter

Reference: https://images.nvidia.com/aem-dam/en-zz/Solutions/data-center/nvidia-ampere-architecture-whitepaper.pdf
p.19
> The NVIDIA A100 Tensor Core GPU implementation of the GA100 GPU includes the following units:
> ...
> 64 FP32 CUDA Cores/SM, 6912 FP32 CUDA Cores per GPU

https://developer.nvidia.com/cuda-gpus

<img width="565" alt="capability" src="https://github.com/cdcseacave/openMVS/assets/46693526/4ab3dfd3-aedd-496f-b900-e671fc0cfe71">
