### PR TITLE
Change the default value to use GPU in RefineMesh.cpp

### DIFF
--- a/apps/RefineMesh/RefineMesh.cpp
+++ b/apps/RefineMesh/RefineMesh.cpp
@@ -99,7 +99,7 @@ bool Initialize(size_t argc, LPCTSTR* argv)
 			), "verbosity level")
 		#endif
 		#ifdef _USE_CUDA
-		("cuda-device", boost::program_options::value(&CUDA::desiredDeviceID)->default_value(-2), "CUDA device number to be used for mesh refinement (-2 - CPU processing, -1 - best GPU, >=0 - device index)")
+		("cuda-device", boost::program_options::value(&CUDA::desiredDeviceID)->default_value(-1), "CUDA device number to be used for mesh refinement (-2 - CPU processing, -1 - best GPU, >=0 - device index)")
 		#endif
 		;
 


### PR DESCRIPTION
It is natural for those who build with `_USE_CUDA(OpenMVS_USE_CUDA=ON)` to want to use the GPU by default. However, only RefineMesh.cpp has a default setting value of CPU.

I traced the commit and found that this came from https://github.com/cdcseacave/openMVS/pull/719/commits/c6daaf78ef1bc7f4afd6b2b90bad652c69e8a914. 

I could not find any reason why this change was introduced, so if the CPU is to be used for accuracy or any other reason, please tell me and close this PR.


---

There are several files that includes the `cuda-device` option, but only RefineMesh.cpp has CPU as the default value.

```bash
develop:~/devel/openMVS❯ git log -n 1
commit c1b1cc99d87125e77cd7f0355417d9a5ccda056c (HEAD -> develop, upstream/develop, change_default_to_use_gpu_in_refine_mesh)
Author: 4CJ7T <108303308+4CJ7T@users.noreply.github.com>
Date:   Wed Sep 20 21:28:03 2023 -0700

    common: add Python utility for reading DMAP files (#1059)
```

```bash
develop:~/devel/openMVS❯ grep -rn cuda-device
./apps/RefineMesh/RefineMesh.cpp:102:		("cuda-device", boost::program_options::value(&CUDA::desiredDeviceID)->default_value(-2), "CUDA device number to be used for mesh refinement (-2 - CPU processing, -1 - best GPU, >=0 - device index)")
./apps/DensifyPointCloud/DensifyPointCloud.cpp:103:		("cuda-device", boost::program_options::value(&CUDA::desiredDeviceID)->default_value(-1), "CUDA device number to be used for depth-map estimation (-2 - CPU processing, -1 - best GPU, >=0 - device index)")
./apps/ReconstructMesh/ReconstructMesh.cpp:112:		("cuda-device", boost::program_options::value(&CUDA::desiredDeviceID)->default_value(-1), "CUDA device number to be used to reconstruct the mesh (-2 - CPU processing, -1 - best GPU, >=0 - device index)")
./apps/TextureMesh/TextureMesh.cpp:103:		("cuda-device", boost::program_options::value(&CUDA::desiredDeviceID)->default_value(-1), "CUDA device number to be used to texture the mesh (-2 - CPU processing, -1 - best GPU, >=0 - device index)")
develop:~/devel/openMVS❯
```
