### PR TITLE
texture: add multi texture support

### DIFF
--- a/apps/TextureMesh/TextureMesh.cpp
+++ b/apps/TextureMesh/TextureMesh.cpp
@@ -68,6 +68,7 @@ unsigned nOrthoMapResolution;
 unsigned nArchiveType;
 int nProcessPriority;
 unsigned nMaxThreads;
+int nMaxTextureSize;
 String strExportType;
 String strConfigFileName;
 boost::program_options::variables_map vm;
@@ -125,6 +126,7 @@ bool Initialize(size_t argc, LPCTSTR* argv)
 		("sharpness-weight", boost::program_options::value(&OPT::fSharpnessWeight)->default_value(0.5f), "amount of sharpness to be applied on the texture (0 - disabled)")
 		("orthographic-image-resolution", boost::program_options::value(&OPT::nOrthoMapResolution)->default_value(0), "orthographic image resolution to be generated from the textured mesh - the mesh is expected to be already geo-referenced or at least properly oriented (0 - disabled)")
 		("ignore-mask-label", boost::program_options::value(&OPT::nIgnoreMaskLabel)->default_value(-1), "label value to ignore in the image mask, stored in the MVS scene or next to each image with '.mask.png' extension (-1 - auto estimate mask for lens distortion, -2 - disabled)")
+		("max-texture-size", boost::program_options::value(&OPT::nMaxTextureSize)->default_value(8192), "maximum texture size, split it in multiple textures of this size if needed (0 - unbounded)")
 		;
 
 	// hidden options, allowed both on command line and
@@ -286,7 +288,7 @@ int main(int argc, LPCTSTR* argv)
 		return EXIT_FAILURE;
 	}
 	const String baseFileName(MAKE_PATH_SAFE(Util::getFileFullName(OPT::strOutputFileName)));
-	if (OPT::nOrthoMapResolution && !scene.mesh.textureDiffuse.empty()) {
+	if (OPT::nOrthoMapResolution && !scene.mesh.HasTexture()) {
 		// the input mesh is already textured and an orthographic projection was requested
 		goto ProjectOrtho;
 	}
@@ -311,7 +313,7 @@ int main(int argc, LPCTSTR* argv)
 	TD_TIMER_START();
 	if (!scene.TextureMesh(OPT::nResolutionLevel, OPT::nMinResolution, OPT::minCommonCameras, OPT::fOutlierThreshold, OPT::fRatioDataSmoothness,
 						   OPT::bGlobalSeamLeveling, OPT::bLocalSeamLeveling, OPT::nTextureSizeMultiple, OPT::nRectPackingHeuristic, Pixel8U(OPT::nColEmpty),
-						   OPT::fSharpnessWeight, OPT::nIgnoreMaskLabel, views))
+						   OPT::fSharpnessWeight, OPT::nIgnoreMaskLabel, OPT::nMaxTextureSize, views))
 		return EXIT_FAILURE;
 	VERBOSE("Mesh texturing completed: %u vertices, %u faces (%s)", scene.mesh.vertices.GetSize(), scene.mesh.faces.GetSize(), TD_TIMER_GET_FMT().c_str());
 

--- a/apps/Viewer/Scene.cpp
+++ b/apps/Viewer/Scene.cpp
@@ -125,8 +125,7 @@ SEACAVE::Thread Scene::thread;
 Scene::Scene(ARCHIVE_TYPE _nArchiveType)
 	:
 	nArchiveType(_nArchiveType),
-	listPointCloud(0),
-	listMesh(0)
+	listPointCloud(0)
 {
 }
 Scene::~Scene()
@@ -171,9 +170,10 @@ void Scene::ReleasePointCloud()
 }
 void Scene::ReleaseMesh()
 {
-	if (listMesh) {
-		glDeleteLists(listMesh, 1);
-		listMesh = 0;
+	if (!listMeshes.empty()) {
+		for (GLuint listMesh: listMeshes)
+			glDeleteLists(listMesh, 1);
+		listMeshes.Release();
 	}
 }
 
@@ -294,26 +294,21 @@ bool Scene::Open(LPCTSTR fileName, LPCTSTR geometryFileName)
 
 	// init and load texture
 	if (scene.mesh.HasTexture()) {
-		Image8U3 atlas;
-		const cv::Size size = scene.mesh.texturesDiffuse.front().size();
-		atlas.create(size.height, size.width * scene.mesh.texturesDiffuse.size());
 		FOREACH(i, scene.mesh.texturesDiffuse) {
-			Image8U3& texture = scene.mesh.texturesDiffuse[i];
-			const cv::Size size = texture.size();
-			texture.copyTo(atlas(cv::Rect(i * size.width, 0, size.width, size.height)));
+			Image& image = textures.emplace_back();
+			ASSERT(image.idx == NO_ID);
+			#if 0
+			Image8U3& textureDiffuse = scene.mesh.texturesDiffuse[i];
+			cv::flip(textureDiffuse, textureDiffuse, 0);
+			image.SetImage(textureDiffuse);
+			textureDiffuse.release();
+			#else // preserve texture, used only to be able to export the mesh
+			Image8U3 textureDiffuse;
+			cv::flip(scene.mesh.texturesDiffuse[i], textureDiffuse, 0);
+			image.SetImage(textureDiffuse);
+			#endif
+			image.GenerateMipmap();
 		}
-		Image& image = textures.AddEmpty();
-		ASSERT(image.idx == NO_ID);
-		#if 0
-		cv::flip(scene.mesh.textureDiffuse, scene.mesh.textureDiffuse, 0);
-		image.SetImage(scene.mesh.textureDiffuse);
-		scene.mesh.textureDiffuse.release();
-		#else // preserve texture, used only to be able to export the mesh
-		Image8U3 textureDiffuse;
-		cv::flip(atlas, textureDiffuse, 0);
-		image.SetImage(textureDiffuse);
-		#endif
-		image.GenerateMipmap();
 	}
 
 	// init display lists
@@ -431,15 +426,15 @@ void Scene::CompilePointCloud()
 	glNewList(listPointCloud, GL_COMPILE);
 	ASSERT((window.sparseType&(Window::SPR_POINTS|Window::SPR_LINES)) != 0);
 	// compile point-cloud
-	if (!scene.pointcloud.IsEmpty() && (window.sparseType&Window::SPR_POINTS) != 0) {
+	if ((window.sparseType&Window::SPR_POINTS) != 0) {
 		ASSERT_ARE_SAME_TYPE(float, MVS::PointCloud::Point::Type);
 		glBegin(GL_POINTS);
 		glColor3f(1.f,1.f,1.f);
 		FOREACH(i, scene.pointcloud.points) {
-			if (!scene.pointcloud.pointViews.IsEmpty() &&
+			if (!scene.pointcloud.pointViews.empty() &&
 				scene.pointcloud.pointViews[i].size() < window.minViews)
 				continue;
-			if (!scene.pointcloud.colors.IsEmpty()) {
+			if (!scene.pointcloud.colors.empty()) {
 				const MVS::PointCloud::Color& c = scene.pointcloud.colors[i];
 				glColor3ub(c.r,c.g,c.b);
 			}
@@ -460,39 +455,37 @@ void Scene::CompileMesh()
 		scene.mesh.ComputeNormalFaces();
 	// translate, normalize and flip Y axis of the texture coordinates
 	MVS::Mesh::TexCoordArr normFaceTexcoords;
-	if (scene.mesh.HasTexture()) {
+	if (scene.mesh.HasTexture() && window.bRenderTexture)
 		scene.mesh.FaceTexcoordsNormalize(normFaceTexcoords, true);
-		FOREACH(i, normFaceTexcoords) {
-			const MVS::Mesh::TexIndex texIdx(scene.mesh.GetFaceTexxtureIndex(i/3));
-			normFaceTexcoords[i] = MVS::Mesh::TexCoord(
-				(normFaceTexcoords[i].x + texIdx) / (float)scene.mesh.texturesDiffuse.size(),
-				normFaceTexcoords[i].y
-			);
-		}
-	}
-	listMesh = glGenLists(1);
-	glNewList(listMesh, GL_COMPILE);
-	// compile mesh
-	ASSERT_ARE_SAME_TYPE(float, MVS::Mesh::Vertex::Type);
-	ASSERT_ARE_SAME_TYPE(float, MVS::Mesh::Normal::Type);
-	ASSERT_ARE_SAME_TYPE(float, MVS::Mesh::TexCoord::Type);
-	glColor3f(1.f, 1.f, 1.f);
-	glBegin(GL_TRIANGLES);
-	FOREACH(i, scene.mesh.faces) {
-		const MVS::Mesh::Face& face = scene.mesh.faces[i];
-		const MVS::Mesh::Normal& n = scene.mesh.faceNormals[i];
-		glNormal3fv(n.ptr());
-		for (int j = 0; j < 3; ++j) {
-			if (!normFaceTexcoords.empty() && window.bRenderTexture) {
-				const MVS::Mesh::TexCoord& t = normFaceTexcoords[i * 3 + j];
-				glTexCoord2fv(t.ptr());
+	MVS::Mesh::TexIndex texIdx(0);
+	do {
+		GLuint& listMesh = listMeshes.emplace_back(glGenLists(1));
+		listMesh = glGenLists(1);
+		glNewList(listMesh, GL_COMPILE);
+		// compile mesh
+		ASSERT_ARE_SAME_TYPE(float, MVS::Mesh::Vertex::Type);
+		ASSERT_ARE_SAME_TYPE(float, MVS::Mesh::Normal::Type);
+		ASSERT_ARE_SAME_TYPE(float, MVS::Mesh::TexCoord::Type);
+		glColor3f(1.f, 1.f, 1.f);
+		glBegin(GL_TRIANGLES);
+		FOREACH(idxFace, scene.mesh.faces) {
+			if (!scene.mesh.faceTexindices.empty() && scene.mesh.faceTexindices[idxFace] != texIdx)
+				continue;
+			const MVS::Mesh::Face& face = scene.mesh.faces[idxFace];
+			const MVS::Mesh::Normal& n = scene.mesh.faceNormals[idxFace];
+			glNormal3fv(n.ptr());
+			for (int j = 0; j < 3; ++j) {
+				if (!normFaceTexcoords.empty()) {
+					const MVS::Mesh::TexCoord& t = normFaceTexcoords[idxFace*3 + j];
+					glTexCoord2fv(t.ptr());
+				}
+				const MVS::Mesh::Vertex& p = scene.mesh.vertices[face[j]];
+				glVertex3fv(p.ptr());
 			}
-			const MVS::Mesh::Vertex& p = scene.mesh.vertices[face[j]];
-			glVertex3fv(p.ptr());
 		}
-	}
-	glEnd();
-	glEndList();
+		glEnd();
+		glEndList();
+	} while (++texIdx < scene.mesh.texturesDiffuse.size());
 }
 
 void Scene::CompileBounds()
@@ -529,17 +522,20 @@ void Scene::Draw()
 		glCallList(listPointCloud);
 	}
 	// render mesh
-	if (listMesh) {
+	if (!listMeshes.empty()) {
 		glEnable(GL_DEPTH_TEST);
 		glEnable(GL_CULL_FACE);
 		if (!scene.mesh.faceTexcoords.empty() && window.bRenderTexture) {
 			glEnable(GL_TEXTURE_2D);
-			textures.back().Bind();
-			glCallList(listMesh);
+			FOREACH(i, listMeshes) {
+				textures[i].Bind();
+				glCallList(listMeshes[i]);
+			}
 			glDisable(GL_TEXTURE_2D);
 		} else {
 			glEnable(GL_LIGHTING);
-			glCallList(listMesh);
+			for (GLuint listMesh: listMeshes)
+				glCallList(listMesh);
 			glDisable(GL_LIGHTING);
 		}
 	}

--- a/apps/Viewer/Scene.h
+++ b/apps/Viewer/Scene.h
@@ -68,7 +68,7 @@ public:
 	Point3fArr obbPoints;
 
 	GLuint listPointCloud;
-	GLuint listMesh;
+	CLISTDEF0IDX(GLuint,MVS::Mesh::TexIndex) listMeshes;
 
 	// multi-threading
 	static SEACAVE::EventQueue events; // internal events queue (processed by the working threads)

--- a/libs/Common/Types.inl
+++ b/libs/Common/Types.inl
@@ -2617,9 +2617,11 @@ void TImage<TYPE>::RasterizeTriangleBary(const TPoint2<T>& v1, const TPoint2<T>&
 	ImageRef boxMinI(FLOOR2INT(boxMin));
 	ImageRef boxMaxI(CEIL2INT(boxMax));
 	Base::clip(boxMinI, boxMaxI, size);
-	// parse all pixels inside the bounding-box
+	// ignore back oriented triangles (negative area)
 	const T area(EdgeFunction(v1, v2, v3));
-	ASSERTM(area < 0, "UV triangle of negative area");
+	if (area <= 0)
+		return;
+	// parse all pixels inside the bounding-box
 	const T invArea(T(1) / area);
 	for (int y = boxMinI.y; y <= boxMaxI.y; ++y) {
 		for (int x = boxMinI.x; x <= boxMaxI.x; ++x) {

--- a/libs/MVS/Mesh.cpp
+++ b/libs/MVS/Mesh.cpp
@@ -1435,7 +1435,7 @@ void Mesh::FaceTexcoordsNormalize(TexCoordArr& newFaceTexcoords, bool flipY) con
 	if (flipY) {
 		FOREACH(i, faceTexcoords) {
 			const TexCoord& texcoord = faceTexcoords[i];
-			const TexCoord& invNorm = invNorms[GetFaceTexxtureIndex(i/3)];
+			const TexCoord& invNorm = invNorms[GetFaceTextureIndex(i/3)];
 			newFaceTexcoords[i] = TexCoord(
 				(texcoord.x+halfPixel.x)*invNorm.x,
 				1.f-(texcoord.y+halfPixel.y)*invNorm.y
@@ -1443,7 +1443,7 @@ void Mesh::FaceTexcoordsNormalize(TexCoordArr& newFaceTexcoords, bool flipY) con
 		}
 	} else {
 		FOREACH(i, faceTexcoords) {
-			const TexCoord& invNorm = invNorms[GetFaceTexxtureIndex(i/3)];
+			const TexCoord& invNorm = invNorms[GetFaceTextureIndex(i/3)];
 			newFaceTexcoords[i] = (faceTexcoords[i]+halfPixel)*invNorm;
 		}
 	}
@@ -1462,7 +1462,7 @@ void Mesh::FaceTexcoordsUnnormalize(TexCoordArr& newFaceTexcoords, bool flipY) c
 	if (flipY) {
 		FOREACH(i, faceTexcoords) {
 			const TexCoord& texcoord = faceTexcoords[i];
-			const TexCoord& scale = scales[GetFaceTexxtureIndex(i/3)];
+			const TexCoord& scale = scales[GetFaceTextureIndex(i/3)];
 			newFaceTexcoords[i] = TexCoord(
 				texcoord.x*scale.x-halfPixel.x,
 				(1.f-texcoord.y)*scale.y-halfPixel.y
@@ -1470,7 +1470,7 @@ void Mesh::FaceTexcoordsUnnormalize(TexCoordArr& newFaceTexcoords, bool flipY) c
 		}
 	} else {
 		FOREACH(i, faceTexcoords) {
-			const TexCoord& scale = scales[GetFaceTexxtureIndex(i/3)];
+			const TexCoord& scale = scales[GetFaceTextureIndex(i/3)];
 			newFaceTexcoords[i] = faceTexcoords[i]*scale - halfPixel;
 		}
 	}

--- a/libs/MVS/Mesh.h
+++ b/libs/MVS/Mesh.h
@@ -131,7 +131,7 @@ public:
 
 	NormalArr faceNormals; // for each face, the normal to it (optional)
 	FaceFacesArr faceFaces; // for each face, the list of adjacent faces, NO_ID for border edges (optional)
-	TexCoordArr faceTexcoords; // for each face, the texture-coordinates corresponding to its vertices, 3x num faces (optional)
+	TexCoordArr faceTexcoords; // for each face, the texture-coordinates corresponding to its vertices, 3x num faces OR for each vertex (optional)
 	TexIndexArr faceTexindices; // for each face, the corresponding index of the texture (optional)
 
 	Image8U3Arr texturesDiffuse; // textures containing the diffuse color (optional)
@@ -154,7 +154,8 @@ public:
 	void Join(const Mesh&);
 	bool IsEmpty() const { return vertices.empty(); }
 	bool IsWatertight();
-	bool HasTexture() const { ASSERT(faces.size()*3 == faceTexcoords.size()); return !faceTexcoords.empty() && !texturesDiffuse.empty(); }
+	bool HasTexture() const { ASSERT(faces.size()*3 == faceTexcoords.size() || vertices.size() == faceTexcoords.size()); return !faceTexcoords.empty() && !texturesDiffuse.empty(); }
+	bool HasTextureCoordinatesPerVertex() const { return !faceTexcoords.empty() && vertices.size() == faceTexcoords.size(); }
 
 	Box GetAABB() const;
 	Box GetAABB(const Box& bound) const;

--- a/libs/MVS/Mesh.h
+++ b/libs/MVS/Mesh.h
@@ -193,7 +193,7 @@ public:
 	std::vector<Mesh> SplitMeshPerTextureBlob() const;
 	void ConvertTexturePerVertex(Mesh&) const;
 
-	TexIndex GetFaceTexxtureIndex(FIndex idxF) const { return faceTexindices.empty() ? 0 : faceTexindices[idxF]; }
+	TexIndex GetFaceTextureIndex(FIndex idxF) const { return faceTexindices.empty() ? 0 : faceTexindices[idxF]; }
 	void FaceTexcoordsNormalize(TexCoordArr& newFaceTexcoords, bool flipY=true) const;
 	void FaceTexcoordsUnnormalize(TexCoordArr& newFaceTexcoords, bool flipY=true) const;
 

--- a/libs/MVS/Mesh.h
+++ b/libs/MVS/Mesh.h
@@ -71,8 +71,9 @@ public:
 	typedef TPoint2<Type> TexCoord;
 	typedef SEACAVE::cList<TexCoord,const TexCoord&,0,8192,FIndex> TexCoordArr;
 
-	typedef uint8_t TexChunk;
-	typedef SEACAVE::cList<TexChunk,const TexChunk&,0,8192,FIndex> TexChunkArr;
+	typedef uint8_t TexIndex;
+	typedef SEACAVE::cList<TexIndex,const TexIndex&,0,8192,FIndex> TexIndexArr;
+	typedef SEACAVE::cList<Image8U3,const Image8U3&,2,4,TexIndex> Image8U3Arr;
 
 	typedef TPoint3<FIndex> FaceFaces;
 	typedef SEACAVE::cList<FaceFaces,const FaceFaces&,0,8192,FIndex> FaceFacesArr;
@@ -130,9 +131,10 @@ public:
 
 	NormalArr faceNormals; // for each face, the normal to it (optional)
 	FaceFacesArr faceFaces; // for each face, the list of adjacent faces, NO_ID for border edges (optional)
-	TexCoordArr faceTexcoords; // for each face, the texture-coordinates corresponding to the contained vertices (optional)
+	TexCoordArr faceTexcoords; // for each face, the texture-coordinates corresponding to its vertices, 3x num faces (optional)
+	TexIndexArr faceTexindices; // for each face, the corresponding index of the texture (optional)
 
-	Image8U3 textureDiffuse; // texture containing the diffuse color (optional)
+	Image8U3Arr texturesDiffuse; // textures containing the diffuse color (optional)
 
 	#ifdef _USE_CUDA
 	static CUDA::KernelRT kernelComputeFaceNormal;
@@ -150,9 +152,9 @@ public:
 	void EmptyExtra();
 	void Swap(Mesh&);
 	void Join(const Mesh&);
-	inline bool IsEmpty() const { return vertices.empty(); }
+	bool IsEmpty() const { return vertices.empty(); }
 	bool IsWatertight();
-	inline bool HasTexture() const { ASSERT(faceTexcoords.empty() == textureDiffuse.empty()); return !faceTexcoords.empty(); }
+	bool HasTexture() const { ASSERT(faces.size()*3 == faceTexcoords.size()); return !faceTexcoords.empty() && !texturesDiffuse.empty(); }
 
 	Box GetAABB() const;
 	Box GetAABB(const Box& bound) const;
@@ -187,8 +189,10 @@ public:
 	void RemoveFaces(FaceIdxArr& facesRemove, bool bUpdateLists=false);
 	void RemoveVertices(VertexIdxArr& vertexRemove, bool bUpdateLists=false);
 	VIndex RemoveUnreferencedVertices(bool bUpdateLists=false);
+	std::vector<Mesh> SplitMeshPerTextureBlob() const;
 	void ConvertTexturePerVertex(Mesh&) const;
 
+	TexIndex GetFaceTexxtureIndex(FIndex idxF) const { return faceTexindices.empty() ? 0 : faceTexindices[idxF]; }
 	void FaceTexcoordsNormalize(TexCoordArr& newFaceTexcoords, bool flipY=true) const;
 	void FaceTexcoordsUnnormalize(TexCoordArr& newFaceTexcoords, bool flipY=true) const;
 
@@ -264,7 +268,8 @@ protected:
 		ar & vertexBoundary;
 		ar & faceNormals;
 		ar & faceTexcoords;
-		ar & textureDiffuse;
+		ar & faceTexindices;
+		ar & texturesDiffuse;
 	}
 	#endif
 };

--- a/libs/MVS/RectsBinPack.cpp
+++ b/libs/MVS/RectsBinPack.cpp
@@ -88,12 +88,10 @@ MaxRectsBinPack::Rect MaxRectsBinPack::Insert(int width, int height, FreeRectCho
 	return newNode;
 }
 
-bool MaxRectsBinPack::Insert(RectArr& rects, FreeRectChoiceHeuristic method)
+MaxRectsBinPack::RectWIdxArr MaxRectsBinPack::Insert(RectWIdxArr& unplacedRects, FreeRectChoiceHeuristic method)
 {
-	cList<IDX, IDX, 0> indices(rects.GetSize());
-	std::iota(indices.Begin(), indices.End(), 0);
-	RectArr newRects(rects.GetSize());
-	while (!rects.IsEmpty()) {
+	RectWIdxArr placedRects;
+	while (!unplacedRects.IsEmpty()) {
 		int bestScore1 = std::numeric_limits<int>::max();
 		int bestScore2 = std::numeric_limits<int>::max();
 		IDX bestRectIndex = NO_IDX;
@@ -108,9 +106,9 @@ bool MaxRectsBinPack::Insert(RectArr& rects, FreeRectChoiceHeuristic method)
 			IDX privBestRectIndex = NO_IDX;
 			Rect privBestNode;
 			#pragma omp for nowait
-			for (int_t i=0; i<(int_t)rects.GetSize(); ++i) {
+			for (int_t i=0; i<(int_t)unplacedRects.GetSize(); ++i) {
 				int score1, score2;
-				Rect newNode(ScoreRect(rects[i].width, rects[i].height, method, score1, score2));
+				Rect newNode(ScoreRect(unplacedRects[i].rect.width, unplacedRects[i].rect.height, method, score1, score2));
 				if (score1 < privBestScore1 || (score1 == privBestScore1 && score2 < privBestScore2)) {
 					privBestScore1 = score1;
 					privBestScore2 = score2;
@@ -141,24 +139,18 @@ bool MaxRectsBinPack::Insert(RectArr& rects, FreeRectChoiceHeuristic method)
 		}
 		#endif
 
-		// if no place found...
+		// if no place found, return the placed rectangles list
 		if (bestRectIndex == NO_IDX) {
-			// restore the original rectangles
-			FOREACH(j, rects)
-				newRects[indices[j]] = rects[j];
-			rects.Swap(newRects);
-			return false;
+			break;
 		}
 
 		// store rectangle
 		PlaceRect(bestNode);
 
-		newRects[indices[bestRectIndex]] = bestNode;
-		rects.RemoveAt(bestRectIndex);
-		indices.RemoveAt(bestRectIndex);
+		placedRects.Insert(RectWIdx{bestNode, unplacedRects[bestRectIndex].patchIdx});
+		unplacedRects.RemoveAt(bestRectIndex);
 	}
-	rects.Swap(newRects);
-	return true;
+	return placedRects;
 }
 
 void MaxRectsBinPack::PlaceRect(const Rect &node)
@@ -524,6 +516,13 @@ int MaxRectsBinPack::ComputeTextureSize(const RectArr& rects, int mult)
 	// ... as power of two
 	return POWI(2, CEIL2INT<unsigned>(LOGN((float)sizeTex) / LOGN(2.f)));
 }
+
+int MaxRectsBinPack::ComputeTextureSize(const RectWIdxArr& rectsWIdx, int mult) {
+	RectArr rects(rectsWIdx.GetSize());
+	FOREACH(i, rectsWIdx)
+		rects[i] = rectsWIdx[i].rect;
+	return ComputeTextureSize(rects, mult);
+}
 /*----------------------------------------------------------------*/
 
 
@@ -563,7 +562,7 @@ void GuillotineBinPack::Init(int width, int height)
 	freeRectangles.push_back(n);
 }
 
-bool GuillotineBinPack::Insert(RectArr& rects, bool merge,
+GuillotineBinPack::RectWIdxArr GuillotineBinPack::Insert(RectWIdxArr& unplacedRects, bool merge,
 							   FreeRectChoiceHeuristic rectChoice, GuillotineSplitHeuristic splitMethod)
 {
 	// Remember variables about the best packing choice we have made so far during the iteration process.
@@ -571,19 +570,18 @@ bool GuillotineBinPack::Insert(RectArr& rects, bool merge,
 	size_t bestRect = 0;
 	bool bestFlipped = false;
 
-	// Pack rectangles one at a time until we have cleared the rects array of all rectangles.
-	// rects will get destroyed in the process.
-	cList<IDX, IDX, 0> indices(rects.GetSize());
-	std::iota(indices.Begin(), indices.End(), 0);
-	RectArr newRects(rects.GetSize());
-	while (!rects.IsEmpty()) {
+	// Pack rectangles one at a time until we have cleared the rects array of all rectangles or there is no space.
+	// unplacedRects will get destroyed in the process.
+	RectWIdxArr placedRects;
+	while (!unplacedRects.IsEmpty()) {
 		// Stores the penalty score of the best rectangle placement - bigger=worse, smaller=better.
 		int bestScore = std::numeric_limits<int>::max();
 
 		for (size_t i = 0; i < freeRectangles.size(); ++i) {
-			for (size_t j = 0; j < rects.GetSize(); ++j) {
+			for (size_t j = 0; j < unplacedRects.GetSize(); ++j) {
+				Rect currentRect = unplacedRects[j].rect;
 				// If this rectangle is a perfect match, we pick it instantly.
-				if (rects[j].width == freeRectangles[i].width && rects[j].height == freeRectangles[i].height) {
+				if (currentRect.width == freeRectangles[i].width && currentRect.height == freeRectangles[i].height) {
 					bestFreeRect = i;
 					bestRect = j;
 					bestFlipped = false;
@@ -592,7 +590,7 @@ bool GuillotineBinPack::Insert(RectArr& rects, bool merge,
 					break;
 				}
 				// If flipping this rectangle is a perfect match, pick that then.
-				else if (rects[j].height == freeRectangles[i].width && rects[j].width == freeRectangles[i].height) {
+				else if (currentRect.height == freeRectangles[i].width && currentRect.width == freeRectangles[i].height) {
 					bestFreeRect = i;
 					bestRect = j;
 					bestFlipped = true;
@@ -601,8 +599,8 @@ bool GuillotineBinPack::Insert(RectArr& rects, bool merge,
 					break;
 				}
 				// Try if we can fit the rectangle upright.
-				else if (rects[j].width <= freeRectangles[i].width && rects[j].height <= freeRectangles[i].height) {
-					int score = ScoreByHeuristic(rects[j].width, rects[j].height, freeRectangles[i], rectChoice);
+				else if (currentRect.width <= freeRectangles[i].width && currentRect.height <= freeRectangles[i].height) {
+					int score = ScoreByHeuristic(currentRect.width, currentRect.height, freeRectangles[i], rectChoice);
 					if (score < bestScore) {
 						bestFreeRect = i;
 						bestRect = j;
@@ -611,8 +609,8 @@ bool GuillotineBinPack::Insert(RectArr& rects, bool merge,
 					}
 				}
 				// If not, then perhaps flipping sideways will make it fit?
-				else if (rects[j].height <= freeRectangles[i].width && rects[j].width <= freeRectangles[i].height) {
-					int score = ScoreByHeuristic(rects[j].height, rects[j].width, freeRectangles[i], rectChoice);
+				else if (currentRect.height <= freeRectangles[i].width && currentRect.width <= freeRectangles[i].height) {
+					int score = ScoreByHeuristic(currentRect.height, currentRect.width, freeRectangles[i], rectChoice);
 					if (score < bestScore) {
 						bestFreeRect = i;
 						bestRect = j;
@@ -625,19 +623,15 @@ bool GuillotineBinPack::Insert(RectArr& rects, bool merge,
 
 		// If we didn't manage to find any rectangle to pack, abort.
 		if (bestScore == std::numeric_limits<int>::max()) {
-			// restore the original rectangles
-			FOREACH(j, rects)
-				newRects[indices[j]] = rects[j];
-			rects.Swap(newRects);
-			return false;
+			break;
 		}
 
 		// Otherwise, we're good to go and do the actual packing.
 		Rect newNode;
 		newNode.x = freeRectangles[bestFreeRect].x;
 		newNode.y = freeRectangles[bestFreeRect].y;
-		newNode.width = rects[bestRect].width;
-		newNode.height = rects[bestRect].height;
+		newNode.width = unplacedRects[bestRect].rect.width;
+		newNode.height = unplacedRects[bestRect].rect.height;
 
 		if (bestFlipped)
 			std::swap(newNode.width, newNode.height);
@@ -647,9 +641,8 @@ bool GuillotineBinPack::Insert(RectArr& rects, bool merge,
 		freeRectangles.erase(freeRectangles.begin() + bestFreeRect);
 
 		// Remove the rectangle we just packed from the input list.
-		newRects[indices[bestRect]] = newNode;
-		rects.RemoveAt(bestRect);
-		indices.RemoveAt(bestRect);
+		placedRects.Insert(MaxRectsBinPack::RectWIdx{newNode, unplacedRects[bestRect].patchIdx});
+		unplacedRects.RemoveAt(bestRect);
 
 		// Perform a Rectangle Merge step if desired.
 		if (merge)
@@ -661,7 +654,7 @@ bool GuillotineBinPack::Insert(RectArr& rects, bool merge,
 		// Check that we're really producing correct packings here.
 		ASSERT(disjointRects.Add(newNode) == true);
 	}
-	return true;
+	return placedRects;
 }
 
 GuillotineBinPack::Rect GuillotineBinPack::Insert(int width, int height, bool merge, FreeRectChoiceHeuristic rectChoice, GuillotineSplitHeuristic splitMethod)
@@ -984,12 +977,10 @@ void SkylineBinPack::Init(int width, int height, bool useWasteMap_)
 	}
 }
 
-bool SkylineBinPack::Insert(RectArr& rects, LevelChoiceHeuristic method)
+SkylineBinPack::RectWIdxArr SkylineBinPack::Insert(RectWIdxArr& unplacedRects, LevelChoiceHeuristic method)
 {
-	cList<IDX, IDX, 0> indices(rects.GetSize());
-	std::iota(indices.Begin(), indices.End(), 0);
-	RectArr newRects(rects.GetSize());
-	while (!rects.IsEmpty()) {
+	RectWIdxArr placedRects;
+	while (!unplacedRects.IsEmpty()) {
 		int bestScore1 = std::numeric_limits<int>::max();
 		int bestScore2 = std::numeric_limits<int>::max();
 		int bestSkylineIndex = -1;
@@ -1005,9 +996,9 @@ bool SkylineBinPack::Insert(RectArr& rects, LevelChoiceHeuristic method)
 			IDX privBestRectIndex = NO_IDX;
 			Rect privBestNode;
 			#pragma omp for nowait
-			for (int_t i=0; i<(int_t)rects.GetSize(); ++i) {
+			for (int_t i=0; i<(int_t)unplacedRects.GetSize(); ++i) {
 				int score1, score2, index;
-				Rect newNode(ScoreRect(rects[i].width, rects[i].height, method, score1, score2, index));
+				Rect newNode(ScoreRect(unplacedRects[i].rect.width, unplacedRects[i].rect.height, method, score1, score2, index));
 				if (score1 < privBestScore1 || (score1 == privBestScore1 && score2 < privBestScore2)) {
 					privBestScore1 = score1;
 					privBestScore2 = score2;
@@ -1028,9 +1019,9 @@ bool SkylineBinPack::Insert(RectArr& rects, LevelChoiceHeuristic method)
 			}
 		}
 		#else
-		FOREACH(i, rects) {
+		FOREACH(i, unplacedRects) {
 			int score1, score2, index;
-			Rect newNode(ScoreRect(rects[i].width, rects[i].height, method, score1, score2, index));
+			Rect newNode(ScoreRect(unplacedRects[i].rect.width, unplacedRects[i].rect.height, method, score1, score2, index));
 			if (score1 < bestScore1 || (score1 == bestScore1 && score2 < bestScore2)) {
 				bestNode = newNode;
 				bestScore1 = score1;
@@ -1041,13 +1032,9 @@ bool SkylineBinPack::Insert(RectArr& rects, LevelChoiceHeuristic method)
 		}
 		#endif
 
-		// if no place found...
+		// if no place found, give up
 		if (bestRectIndex == NO_IDX) {
-			// restore the original rectangles
-			FOREACH(j, rects)
-				newRects[indices[j]] = rects[j];
-			rects.Swap(newRects);
-			return false;
+			break;
 		}
 
 		// Perform the actual packing.
@@ -1056,14 +1043,12 @@ bool SkylineBinPack::Insert(RectArr& rects, LevelChoiceHeuristic method)
 		disjointRects.Add(bestNode);
 		#endif
 		AddSkylineLevel(bestSkylineIndex, bestNode);
-		usedSurfaceArea += rects[bestRectIndex].area();
+		usedSurfaceArea += unplacedRects[bestRectIndex].rect.area();
 
-		newRects[indices[bestRectIndex]] = bestNode;
-		rects.RemoveAt(bestRectIndex);
-		indices.RemoveAt(bestRectIndex);
+		placedRects.Insert(MaxRectsBinPack::RectWIdx{bestNode, unplacedRects[bestRectIndex].patchIdx});
+		unplacedRects.RemoveAt(bestRectIndex);
 	}
-	rects.Swap(newRects);
-	return true;
+	return placedRects;
 }
 
 SkylineBinPack::Rect SkylineBinPack::Insert(int width, int height, LevelChoiceHeuristic method)

--- a/libs/MVS/RectsBinPack.h
+++ b/libs/MVS/RectsBinPack.h
@@ -57,8 +57,17 @@ namespace MVS {
 class MaxRectsBinPack
 {
 public:
+	// A simple rectangle
 	typedef cv::Rect Rect;
+	// A rectangle that stores an index of origin
+	typedef struct {
+	    Rect rect;
+	    uint32_t patchIdx;
+	} RectWIdx;
+	/// A list of rectangles
 	typedef CLISTDEF0(Rect) RectArr;
+	/// A list of rectangles along their original indices
+	typedef CLISTDEF0(RectWIdx) RectWIdxArr;
 
 	/// Instantiates a bin of size (0,0). Call Init to create a new bin.
 	MaxRectsBinPack();
@@ -84,7 +93,7 @@ public:
 	/// @param rects [IN/OUT] The list of rectangles to insert; the rectangles will be modified with the new coordinates in the process.
 	/// @param method The rectangle placement rule to use when packing.
 	/// returns true if all rectangles were inserted
-	bool Insert(RectArr& rects, FreeRectChoiceHeuristic method=RectBestShortSideFit);
+	RectWIdxArr Insert(RectWIdxArr& rects, FreeRectChoiceHeuristic method=RectBestShortSideFit);
 
 	/// Inserts a single rectangle into the bin, possibly rotated.
 	Rect Insert(int width, int height, FreeRectChoiceHeuristic method=RectBestShortSideFit);
@@ -94,6 +103,7 @@ public:
 
 	/// Computes an approximate texture atlas size.
 	static int ComputeTextureSize(const RectArr& rects, int mult=0);
+	static int ComputeTextureSize(const RectWIdxArr& rects, int mult=0);
 
 	/// Returns true if a is contained/on the border in b.
 	static inline bool IsContainedIn(const Rect& a, const Rect& b) {
@@ -190,8 +200,12 @@ public:
 class GuillotineBinPack
 {
 public:
+	// A simple rectangle
 	typedef cv::Rect Rect;
+	/// A list of rectangles
 	typedef CLISTDEF0(Rect) RectArr;
+	/// A list of rectangles along their original indices
+	typedef CLISTDEF0(MaxRectsBinPack::RectWIdx) RectWIdxArr;
 
 	/// The initial bin size will be (0,0). Call Init to set the bin size.
 	GuillotineBinPack();
@@ -243,7 +257,7 @@ public:
 	/// @param merge If true, performs Rectangle Merge operations during the packing process.
 	/// @param rectChoice The free rectangle choice heuristic rule to use.
 	/// @param splitMethod The free rectangle split heuristic rule to use.
-	bool Insert(RectArr& rects, bool merge,
+	RectWIdxArr Insert(RectWIdxArr& rects, bool merge,
 				FreeRectChoiceHeuristic rectChoice, GuillotineSplitHeuristic splitMethod);
 
 	/// Computes the ratio of used/total surface area. 0.00 means no space is yet used, 1.00 means the whole bin is used.
@@ -311,8 +325,12 @@ protected:
 class SkylineBinPack
 {
 public:
+	// A simple rectangle
 	typedef cv::Rect Rect;
+	/// A list of rectangles
 	typedef CLISTDEF0(Rect) RectArr;
+	/// A list of rectangles along their original indices
+	typedef CLISTDEF0(MaxRectsBinPack::RectWIdx) RectWIdxArr;
 
 	/// Instantiates a bin of size (0,0). Call Init to create a new bin.
 	SkylineBinPack();
@@ -335,7 +353,7 @@ public:
 	/// Inserts the given list of rectangles in an offline/batch mode, possibly rotated.
 	/// @param rects [in/out] The list of rectangles to insert. This vector will be update in the process.
 	/// @param method The rectangle placement rule to use when packing.
-	bool Insert(RectArr& rects, LevelChoiceHeuristic method);
+	RectWIdxArr Insert(RectWIdxArr& rects, LevelChoiceHeuristic method);
 
 	/// Inserts a single rectangle into the bin, possibly rotated.
 	Rect Insert(int width, int height, LevelChoiceHeuristic method);

--- a/libs/MVS/Scene.h
+++ b/libs/MVS/Scene.h
@@ -152,7 +152,7 @@ public:
 	// Mesh texturing
 	bool TextureMesh(unsigned nResolutionLevel, unsigned nMinResolution, unsigned minCommonCameras=0, float fOutlierThreshold=0.f, float fRatioDataSmoothness=0.3f,
 		bool bGlobalSeamLeveling=true, bool bLocalSeamLeveling=true, unsigned nTextureSizeMultiple=0, unsigned nRectPackingHeuristic=3, Pixel8U colEmpty=Pixel8U(255,127,39),
-		float fSharpnessWeight=0.5f, int ignoreMaskLabel = -1, const IIndexArr& views=IIndexArr());
+		float fSharpnessWeight=0.5f, int ignoreMaskLabel=-1, int maxTextureSize=0, const IIndexArr& views=IIndexArr());
 
 	#ifdef _USE_BOOST
 	// implement BOOST serialization

--- a/libs/MVS/SceneTexture.cpp
+++ b/libs/MVS/SceneTexture.cpp
@@ -133,6 +133,7 @@ typedef Mesh::VIndex VIndex;
 typedef Mesh::Face Face;
 typedef Mesh::FIndex FIndex;
 typedef Mesh::TexCoord TexCoord;
+typedef Mesh::TexIndex TexIndex;
 
 typedef int MatIdx;
 typedef Eigen::Triplet<float,MatIdx> MatEntry;
@@ -340,7 +341,7 @@ public:
 	void CreateSeamVertices();
 	void GlobalSeamLeveling();
 	void LocalSeamLeveling();
-	void GenerateTexture(bool bGlobalSeamLeveling, bool bLocalSeamLeveling, unsigned nTextureSizeMultiple, unsigned nRectPackingHeuristic, Pixel8U colEmpty, float fSharpnessWeight);
+	void GenerateTexture(bool bGlobalSeamLeveling, bool bLocalSeamLeveling, unsigned nTextureSizeMultiple, unsigned nRectPackingHeuristic, Pixel8U colEmpty, float fSharpnessWeight, int maxTextureSize);
 
 	template <typename PIXEL>
 	static inline PIXEL RGB2YCBCR(const PIXEL& v) {
@@ -387,7 +388,8 @@ public:
 	BoolArr& vertexBoundary; // for each vertex, stores if it is at the boundary or not
 	Mesh::FaceFacesArr& faceFaces; // for each face, the list of adjacent faces, NO_ID for border edges (optional)
 	Mesh::TexCoordArr& faceTexcoords; // for each face, the texture-coordinates of the vertices
-	Image8U3& textureDiffuse; // texture containing the diffuse color
+	Mesh::TexIndexArr& faceTexindices; // for each face, the texture-coordinates of the vertices
+	Mesh::Image8U3Arr& texturesDiffuse; // texture containing the diffuse color
 
 	// constant the entire time
 	Mesh::VertexArr& vertices;
@@ -436,7 +438,8 @@ MeshTexture::MeshTexture(Scene& _scene, unsigned _nResolutionLevel, unsigned _nM
 	vertexBoundary(_scene.mesh.vertexBoundary),
 	faceFaces(_scene.mesh.faceFaces),
 	faceTexcoords(_scene.mesh.faceTexcoords),
-	textureDiffuse(_scene.mesh.textureDiffuse),
+	faceTexindices(_scene.mesh.faceTexindices),
+	texturesDiffuse(_scene.mesh.texturesDiffuse),
 	vertices(_scene.mesh.vertices),
 	faces(_scene.mesh.faces),
 	images(_scene.images),
@@ -2109,11 +2112,12 @@ void MeshTexture::LocalSeamLeveling()
 	}
 }
 
-void MeshTexture::GenerateTexture(bool bGlobalSeamLeveling, bool bLocalSeamLeveling, unsigned nTextureSizeMultiple, unsigned nRectPackingHeuristic, Pixel8U colEmpty, float fSharpnessWeight)
+void MeshTexture::GenerateTexture(bool bGlobalSeamLeveling, bool bLocalSeamLeveling, unsigned nTextureSizeMultiple, unsigned nRectPackingHeuristic, Pixel8U colEmpty, float fSharpnessWeight, int maxTextureSize)
 {
 	// project patches in the corresponding view and compute texture-coordinates and bounding-box
 	const int border(2);
 	faceTexcoords.resize(faces.size()*3);
+	faceTexindices.resize(faces.size());
 	#ifdef TEXOPT_USE_OPENMP
 	const unsigned numPatches(texturePatches.size()-1);
 	#pragma omp parallel for schedule(dynamic)
@@ -2210,84 +2214,115 @@ void MeshTexture::GenerateTexture(bool bGlobalSeamLeveling, bool bLocalSeamLevel
 	// create texture
 	{
 		// arrange texture patches to fit the smallest possible texture image
-		RectsBinPack::RectArr rects(texturePatches.GetSize());
-		FOREACH(i, texturePatches)
-			rects[i] = texturePatches[i].rect;
-		int textureSize(RectsBinPack::ComputeTextureSize(rects, nTextureSizeMultiple));
-		// increase texture size till all patches fit
-		while (true) {
-			TD_TIMER_STARTD();
-			bool bPacked(false);
+		RectsBinPack::RectWIdxArr unplacedRects(texturePatches.size());
+		FOREACH(i, texturePatches) {
+			if (maxTextureSize > 0 && (texturePatches[i].rect.width > maxTextureSize || texturePatches[i].rect.height > maxTextureSize)) {
+			    DEBUG("error: a patch of size %u x %u does not fit the texture", texturePatches[i].rect.width, texturePatches[i].rect.height);
+			    ABORT("the maximum texture size chosen cannot fit a patch");
+			}
+			unplacedRects[i] = {texturePatches[i].rect, i};
+		}
+
+		// pack patches: one pack per texture file
+		std::vector<RectsBinPack::RectWIdxArr> placedRects; {
+			// increase texture size till all patches fit
 			const unsigned typeRectsBinPack(nRectPackingHeuristic/100);
 			const unsigned typeSplit((nRectPackingHeuristic-typeRectsBinPack*100)/10);
 			const unsigned typeHeuristic(nRectPackingHeuristic%10);
-			switch (typeRectsBinPack) {
-			case 0: {
-				MaxRectsBinPack pack(textureSize, textureSize);
-				bPacked = pack.Insert(rects, (MaxRectsBinPack::FreeRectChoiceHeuristic)typeHeuristic);
-				break; }
-			case 1: {
-				SkylineBinPack pack(textureSize, textureSize, typeSplit!=0);
-				bPacked = pack.Insert(rects, (SkylineBinPack::LevelChoiceHeuristic)typeHeuristic);
-				break; }
-			case 2: {
-				GuillotineBinPack pack(textureSize, textureSize);
-				bPacked = pack.Insert(rects, false, (GuillotineBinPack::FreeRectChoiceHeuristic)typeHeuristic, (GuillotineBinPack::GuillotineSplitHeuristic)typeSplit);
-				break; }
-			default:
-				ABORT("error: unknown RectsBinPack type");
+			int textureSize = 0;
+			while (!unplacedRects.empty()) {
+				TD_TIMER_STARTD();
+				if (textureSize == 0) {
+					textureSize = RectsBinPack::ComputeTextureSize(unplacedRects, nTextureSizeMultiple);
+					if (maxTextureSize > 0 && textureSize > maxTextureSize)
+						textureSize = maxTextureSize;
+				}
+
+				RectsBinPack::RectWIdxArr newPlacedRects;
+				switch (typeRectsBinPack) {
+				case 0: {
+					MaxRectsBinPack pack(textureSize, textureSize);
+					newPlacedRects = pack.Insert(unplacedRects, (MaxRectsBinPack::FreeRectChoiceHeuristic)typeHeuristic);
+					break; }
+				case 1: {
+					SkylineBinPack pack(textureSize, textureSize, typeSplit!=0);
+					newPlacedRects = pack.Insert(unplacedRects, (SkylineBinPack::LevelChoiceHeuristic)typeHeuristic);
+					break; }
+				case 2: {
+					GuillotineBinPack pack(textureSize, textureSize);
+					newPlacedRects = pack.Insert(unplacedRects, false, (GuillotineBinPack::FreeRectChoiceHeuristic)typeHeuristic, (GuillotineBinPack::GuillotineSplitHeuristic)typeSplit);
+					break; }
+				default:
+					ABORT("error: unknown RectsBinPack type");
+				}
+				DEBUG_ULTIMATE("\tpacking texture completed: %u initial patches, %u placed patches, %u texture-size, %u textures (%s)", texturePatches.size(), newPlacedRects.GetSize(), textureSize, placedRects.size(), TD_TIMER_GET_FMT().c_str());
+
+				if (textureSize == maxTextureSize || unplacedRects.empty()) {
+					// create texture image
+					placedRects.emplace_back(std::move(newPlacedRects));
+					texturesDiffuse.emplace_back(textureSize, textureSize).setTo(cv::Scalar(colEmpty.b, colEmpty.g, colEmpty.r));
+					textureSize = 0;
+				} else {
+					// try again with a bigger texture
+					textureSize *= 2;
+					if (maxTextureSize > 0)
+						textureSize = std::max(textureSize, maxTextureSize);
+					unplacedRects.JoinRemove(newPlacedRects);
+				}
 			}
-			DEBUG_ULTIMATE("\tpacking texture completed: %u patches, %u texture-size (%s)", rects.size(), textureSize, TD_TIMER_GET_FMT().c_str());
-			if (bPacked)
-				break;
-			textureSize *= 2;
 		}
 
-		// create texture image
-		textureDiffuse.create(textureSize, textureSize);
-		textureDiffuse.setTo(cv::Scalar(colEmpty.b, colEmpty.g, colEmpty.r));
 		#ifdef TEXOPT_USE_OPENMP
 		#pragma omp parallel for schedule(dynamic)
-		for (int_t i=0; i<(int_t)texturePatches.size(); ++i) {
-			const uint32_t idxPatch((uint32_t)i);
+		for (int_t i=0; i<(int_t)placedRects.size(); ++i) {
+			for (int_t j=0; j<(int_t)placedRects[i].size(); ++j) {
+				const uint32_t idxTexture((uint32_t)i);
+				const uint32_t idxPlacedPatch((uint32_t)j);
 		#else
-		FOREACH(idxPatch, texturePatches) {
+		FOREACH(idxTexture, placedRects) {
+			FOREACH(idxPlacedPatch, placedRects[idxTexture]) {
 		#endif
-			const TexturePatch& texturePatch = texturePatches[idxPatch];
-			const RectsBinPack::Rect& rect = rects[idxPatch];
-			// copy patch image
-			ASSERT((rect.width == texturePatch.rect.width && rect.height == texturePatch.rect.height) ||
-				   (rect.height == texturePatch.rect.width && rect.width == texturePatch.rect.height));
-			int x(0), y(1);
-			if (texturePatch.label != NO_ID) {
-				const Image& imageData = images[texturePatch.label];
-				cv::Mat patch(imageData.image(texturePatch.rect));
-				if (rect.width != texturePatch.rect.width) {
-					// flip patch and texture-coordinates
-					patch = patch.t();
-					x = 1; y = 0;
+				const TexturePatch& texturePatch = texturePatches[placedRects[idxTexture][idxPlacedPatch].patchIdx];
+				RectsBinPack::Rect rect = placedRects[idxTexture][idxPlacedPatch].rect;
+				// copy patch image
+				ASSERT((rect.width == texturePatch.rect.width && rect.height == texturePatch.rect.height) ||
+					(rect.height == texturePatch.rect.width && rect.width == texturePatch.rect.height));
+				int x(0), y(1);
+				if (texturePatch.label != NO_ID) {
+					const Image& imageData = images[texturePatch.label];
+					cv::Mat patch(imageData.image(texturePatch.rect));
+					if (rect.width != texturePatch.rect.width) {
+						// flip patch and texture-coordinates
+						patch = patch.t();
+						x = 1; y = 0;
+					}
+					patch.copyTo(texturesDiffuse[idxTexture](rect));
 				}
-				patch.copyTo(textureDiffuse(rect));
-			}
-			// compute final texture coordinates
-			const TexCoord offset(rect.tl());
-			for (const FIndex idxFace: texturePatch.faces) {
-				TexCoord* texcoords = faceTexcoords.data()+idxFace*3;
-				for (int v=0; v<3; ++v) {
-					TexCoord& texcoord = texcoords[v];
-					texcoord = TexCoord(
-						texcoord[x]+offset.x,
-						texcoord[y]+offset.y
-					);
+				// compute final texture coordinates
+				const TexCoord offset(rect.tl());
+				for (const FIndex idxFace: texturePatch.faces) {
+					TexCoord* texcoords = faceTexcoords.data()+idxFace*3;
+					faceTexindices[idxFace] = idxTexture;
+					for (int v=0; v<3; ++v) {
+						TexCoord& texcoord = texcoords[v];
+						texcoord = TexCoord(
+							texcoord[x]+offset.x,
+							texcoord[y]+offset.y
+						);
+					}
 				}
 			}
 		}
+		if (texturesDiffuse.size() == 1)
+			faceTexindices.Release();
 		// apply some sharpening
 		if (fSharpnessWeight > 0) {
 			constexpr double sigma = 1.5;
-			Image8U3 blurryTextureDiffuse;
-			cv::GaussianBlur(textureDiffuse, blurryTextureDiffuse, cv::Size(), sigma);
-			cv::addWeighted(textureDiffuse, 1+fSharpnessWeight, blurryTextureDiffuse, -fSharpnessWeight, 0, textureDiffuse);
+			for (auto &textureDiffuse: texturesDiffuse) {
+			    Image8U3 blurryTextureDiffuse;
+			    cv::GaussianBlur(textureDiffuse, blurryTextureDiffuse, cv::Size(), sigma);
+			    cv::addWeighted(textureDiffuse, 1+fSharpnessWeight, blurryTextureDiffuse, -fSharpnessWeight, 0, textureDiffuse);
+			}
 		}
 	}
 }
@@ -2298,7 +2333,7 @@ void MeshTexture::GenerateTexture(bool bGlobalSeamLeveling, bool bLocalSeamLevel
 //  - nIgnoreMaskLabel: label value to ignore in the image mask, stored in the MVS scene or next to each image with '.mask.png' extension (-1 - auto estimate mask for lens distortion, -2 - disabled)
 bool Scene::TextureMesh(unsigned nResolutionLevel, unsigned nMinResolution, unsigned minCommonCameras, float fOutlierThreshold, float fRatioDataSmoothness,
 	bool bGlobalSeamLeveling, bool bLocalSeamLeveling, unsigned nTextureSizeMultiple, unsigned nRectPackingHeuristic, Pixel8U colEmpty, float fSharpnessWeight,
-	int nIgnoreMaskLabel, const IIndexArr& views)
+	int nIgnoreMaskLabel, int maxTextureSize, const IIndexArr& views)
 {
 	MeshTexture texture(*this, nResolutionLevel, nMinResolution);
 
@@ -2313,8 +2348,8 @@ bool Scene::TextureMesh(unsigned nResolutionLevel, unsigned nMinResolution, unsi
 	// generate the texture image and atlas
 	{
 		TD_TIMER_STARTD();
-		texture.GenerateTexture(bGlobalSeamLeveling, bLocalSeamLeveling, nTextureSizeMultiple, nRectPackingHeuristic, colEmpty, fSharpnessWeight);
-		DEBUG_EXTRA("Generating texture atlas and image completed: %u patches, %u image size (%s)", texture.texturePatches.GetSize(), mesh.textureDiffuse.width(), TD_TIMER_GET_FMT().c_str());
+		texture.GenerateTexture(bGlobalSeamLeveling, bLocalSeamLeveling, nTextureSizeMultiple, nRectPackingHeuristic, colEmpty, fSharpnessWeight, maxTextureSize);
+		DEBUG_EXTRA("Generating texture atlas and image completed: %u patches, %u image size, %u textures (%s)", texture.texturePatches.GetSize(), mesh.texturesDiffuse[0].width(), mesh.texturesDiffuse.size(), TD_TIMER_GET_FMT().c_str());
 	}
 
 	return true;

--- a/libs/MVS/SceneTexture.cpp
+++ b/libs/MVS/SceneTexture.cpp
@@ -559,7 +559,7 @@ bool MeshTexture::ListCameraFaces(FaceDataViewArr& facesDatas, float fOutlierThr
 			#endif
 		}
 		rasterer.Clear();
-		for (auto idxFace : cameraFaces) {
+		for (FIndex idxFace : cameraFaces) {
 			rasterer.validFace = true;
 			const Face& facet = faces[idxFace];
 			rasterer.idxFace = idxFace;
@@ -2224,7 +2224,7 @@ void MeshTexture::GenerateTexture(bool bGlobalSeamLeveling, bool bLocalSeamLevel
 		}
 
 		// pack patches: one pack per texture file
-		std::vector<RectsBinPack::RectWIdxArr> placedRects; {
+		CLISTDEF2IDX(RectsBinPack::RectWIdxArr, TexIndex) placedRects; {
 			// increase texture size till all patches fit
 			const unsigned typeRectsBinPack(nRectPackingHeuristic/100);
 			const unsigned typeSplit((nRectPackingHeuristic-typeRectsBinPack*100)/10);
@@ -2275,15 +2275,15 @@ void MeshTexture::GenerateTexture(bool bGlobalSeamLeveling, bool bLocalSeamLevel
 		#ifdef TEXOPT_USE_OPENMP
 		#pragma omp parallel for schedule(dynamic)
 		for (int_t i=0; i<(int_t)placedRects.size(); ++i) {
-			for (int_t j=0; j<(int_t)placedRects[i].size(); ++j) {
-				const uint32_t idxTexture((uint32_t)i);
+			for (int_t j=0; j<(int_t)placedRects[(TexIndex)i].size(); ++j) {
+				const TexIndex idxTexture((TexIndex)i);
 				const uint32_t idxPlacedPatch((uint32_t)j);
 		#else
 		FOREACH(idxTexture, placedRects) {
 			FOREACH(idxPlacedPatch, placedRects[idxTexture]) {
 		#endif
 				const TexturePatch& texturePatch = texturePatches[placedRects[idxTexture][idxPlacedPatch].patchIdx];
-				RectsBinPack::Rect rect = placedRects[idxTexture][idxPlacedPatch].rect;
+				const RectsBinPack::Rect& rect = placedRects[idxTexture][idxPlacedPatch].rect;
 				// copy patch image
 				ASSERT((rect.width == texturePatch.rect.width && rect.height == texturePatch.rect.height) ||
 					(rect.height == texturePatch.rect.width && rect.width == texturePatch.rect.height));


### PR DESCRIPTION
Rebase to develop and finetuned implementation from PR #1037

This PR adds an argument `--max-texture-size` to the `TextureMesh` app to allow limiting the maximum texture size.

### Method description

The general idea is that the `Insert` method of the packers (`MaxRectsBinPack`, `GuillotineBinPack` and `SkylinePack`), instead of simply failing if it cannot pack, now packs as much as possible. The input list of patches is modified in-place, the successfully placed patches being removed, and the method returns a list of successfully placed patches. In the calling code of texture generation, some logic has been added supports growing the texture and retrying packing if possible (for the cases where the max texture size is too big, or is default), or to start a new texture. The UV coordinates are computed as if the texture files are joined horizontally, and this type of I/O has been added to the PLY reader/writer to demonstrate the functionality.

A known limitation is that the maximum texture size cannot be smaller than the largest patch - for this, a patch splitting logic needs to be added.

A few minor changes have been brought to the code:

- the introduction of a data structure that allows storing a patch alongside its original patch id. This eliminates the need of storing explicitly the ids in a separate list.
- a bit of a naming convention, using `unplacedPatches` and `placedPatches` to differentiate between the patches that are to be placed and those which already have been placed.

## Testing

The testing was done on the Sceaux Castle dataset.

The default behavior is unchanged, generating a texture file of 4096x4096:

 ![textured_mesh0](https://github.com/cdcseacave/openMVS/assets/2312684/0ea3d114-35e0-43fb-972e-68d76dd02ee3)

If the texture is limited to 3000px, we obtain a texture which is of size 3000x6000, which is then split by the I/O into two textures of 3000x3000:

<img src=https://github.com/cdcseacave/openMVS/assets/2312684/4d9293a9-812a-44f2-89c7-ae432c2aad22 width=80% height=80%>


<img src=https://github.com/cdcseacave/openMVS/assets/2312684/469244a0-bed1-4e63-a214-d1e821d3566c width=40% height=40%> |  <img src=https://github.com/cdcseacave/openMVS/assets/2312684/f94e3a99-5f86-4586-b009-6969f3573bfd width=40% height=40%>

Similarly, if the texture is limited at 2200px, we obtain a texture of size 2200x6600, which is then split by the I/O into three textures of 2200x2200:

<img src=https://github.com/cdcseacave/openMVS/assets/2312684/e024cebd-9e5d-4dcd-937f-32bc78de27e0 width=80% height=80%>

<img src=https://github.com/cdcseacave/openMVS/assets/2312684/0911d78d-55b7-4cf0-9bd4-2559a745139c width=20% height=20%> | <img src=https://github.com/cdcseacave/openMVS/assets/2312684/04fba1a3-2f9b-4137-a1dd-9399159d7264 width=20% height=20%> | <img src=https://github.com/cdcseacave/openMVS/assets/2312684/9557e01c-c635-4f51-a8b8-5c5edd576175 width=20% height=20%>

Attempting a maximum texture size smaller than 2200 produces the following message:

```
14:52:58 [App     ] A patch of size 2169 x 117 does not fit the texture
14:52:58 [App     ] error: "the maximum texture size chosen cannot fit a patch"
```

Information regarding the way the textures should be loaded is stored in the header of the `ply` file, which for the last example looks like:

```
format binary_little_endian 1.0
comment TextureFile textured_mesh0.png
comment TextureFile textured_mesh1.png
comment TextureFile textured_mesh2.png
element vertex 486120
```

For completeness, these are the textures produced with skyline packing (`--patch-packing-heuristic 100`) at a maximum texture size of 2200:

<img src=https://github.com/cdcseacave/openMVS/assets/2312684/a60d5164-0b40-453e-a214-d93144abbd78 width=80% height=80%>
<img src=https://github.com/cdcseacave/openMVS/assets/2312684/5876b888-eb9f-42ae-9e1d-127a0684e5c8 width=20% height=20%> | <img src=https://github.com/cdcseacave/openMVS/assets/2312684/ddbcef4a-af22-469f-b59c-5698f5bfcb3c width=20% height=20%> | <img src=https://github.com/cdcseacave/openMVS/assets/2312684/a101bce0-ec07-4291-af81-075e760a07de width=20% height=20%> | <img src=https://github.com/cdcseacave/openMVS/assets/2312684/1b4a3094-10aa-41e0-ab95-d1e5e790150d width=20% height=20%>

and guillotine packing (`--patch-packing-heuristic 300`) at a maximum texture size of 2200:

<img src=https://github.com/cdcseacave/openMVS/assets/2312684/254d612e-80da-428e-b6c4-4a601228dadb width=80% height=80%>

<img src=https://github.com/cdcseacave/openMVS/assets/2312684/bdf64fd3-0ef8-4996-b0a5-dde42dac051c width=20% height=20%> | <img src=https://github.com/cdcseacave/openMVS/assets/2312684/2771883f-7312-4c53-9363-ebd1f2779472 width=20% height=20%> | <img src=https://github.com/cdcseacave/openMVS/assets/2312684/09d33c14-0f22-4a42-b82d-74ca659c7a0f width=20% height=20%>

Just to clarify, in all the examples above what is shown is first the entire texture image, as is represented in memory with the mesh and the UV coordinates, and below is the image split into the multiple texture maps of maximum size, as is exported on disk. 

The produced texture has been inspected visually to not change the appearance of the textured mesh, confirming that the UV coordinates are computed correctly.