### PR TITLE
Python scripting: remove -o for TextureMesh #1101 

### DIFF
--- a/scripts/python/MvgMvsPipeline.py
+++ b/scripts/python/MvgMvsPipeline.py
@@ -270,7 +270,7 @@ class StepsStore:
              ["scene_dense.mvs", "-m", "scene_dense_mesh.ply", "-o", "scene_dense_mesh_refine.mvs", "--scales", "1", "--gradient-step", "25.05", "-w", "\"%mvs_dir%\""]],
             ["Texture the mesh",             # 20
              os.path.join(OPENMVS_BIN, "TextureMesh"),
-             ["scene_dense.mvs", "-m", "scene_dense_mesh_refine.ply", "-o", "scene_dense_mesh_refine_texture.mvs", "--decimate", "0.5", "-w", "\"%mvs_dir%\""]],
+             ["scene_dense.mvs", "-m", "scene_dense_mesh_refine.ply", "--decimate", "0.5", "-w", "\"%mvs_dir%\""]],
             ["Estimate disparity-maps",      # 21
              os.path.join(OPENMVS_BIN, "DensifyPointCloud"),
              ["scene.mvs", "--dense-config-file", "Densify.ini", "--fusion-mode", "-1", "-w", "\"%mvs_dir%\""]],


### PR DESCRIPTION
_Same as the previous PR but this time on the correct branch._

v2.3.0 changed the meaning of the -o parameter for TextureMesh and it now exports the mesh instead of the scene (so this no longer makes sense to do).