### PR TITLE
dense: fix new confidence values computation in FilterDepthMap

### DIFF
--- a/libs/MVS/SceneDensify.cpp
+++ b/libs/MVS/SceneDensify.cpp
@@ -1198,7 +1198,7 @@ bool DepthMapsData::FilterDepthMap(DepthData& depthDataRef, const IIndexArr& idx
 				if (nPosViews >= nMinViewsAdjust && posConf > negConf && ISINSIDE(avgDepth/=posConf, depthDataRef.dMin, depthDataRef.dMax)) {
 					// consider this pixel an inlier
 					newDepthMap(xRef) = avgDepth;
-					newConfMap(xRef) = posConf - negConf;
+					newConfMap(xRef) = (posConf - negConf)/(nPosViews + nNegViews + 1);
 				} else {
 					// consider this pixel an outlier
 					DiscardDepth:


### PR DESCRIPTION
As reported  in [#1055](https://github.com/cdcseacave/openMVS/issues/1055), the confidence values after executing the FilterDepthMap function were not in the expected range of [0,1]. The changes presented here address that issue by ensuring the confidence values fall within the expected range.