### PR TITLE
target_link_libraries is required to build executable in my case.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ if(OpenMVS_USE_CUDA)
 		endif()
 		if(NOT OpenMVS_MAX_CUDA_COMPATIBILITY)
 			if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-				SET(CMAKE_CUDA_ARCHITECTURES 75)
+				SET(CMAKE_CUDA_ARCHITECTURES 86)
 			endif()
 		else()
 			# Build for maximum compatibility

--- a/apps/DensifyPointCloud/CMakeLists.txt
+++ b/apps/DensifyPointCloud/CMakeLists.txt
@@ -7,6 +7,9 @@ FILE(GLOB LIBRARY_FILES_H "*.h" "*.inl")
 
 cxx_executable_with_flags(DensifyPointCloud "Apps" "${cxx_default}" "MVS;${OpenMVS_EXTRA_LIBS}" ${LIBRARY_FILES_C} ${LIBRARY_FILES_H})
 
+# Ensure libCommon, libIO, and other dependencies are linked using the plain signature
+target_link_libraries(DensifyPointCloud Common IO)  # Add tinyxml2 if required
+
 # Install
 INSTALL(TARGETS DensifyPointCloud
 	EXPORT OpenMVSTargets

--- a/apps/InterfaceCOLMAP/CMakeLists.txt
+++ b/apps/InterfaceCOLMAP/CMakeLists.txt
@@ -7,6 +7,9 @@ FILE(GLOB LIBRARY_FILES_H "*.h" "*.inl")
 
 cxx_executable_with_flags(InterfaceCOLMAP "Apps" "${cxx_default}" "MVS;${OpenMVS_EXTRA_LIBS}" ${LIBRARY_FILES_C} ${LIBRARY_FILES_H})
 
+# Ensure libCommon and libIO are linked
+target_link_libraries(InterfaceCOLMAP Common IO)
+
 # Install
 INSTALL(TARGETS InterfaceCOLMAP
 	EXPORT OpenMVSTargets

--- a/apps/InterfaceMVSNet/CMakeLists.txt
+++ b/apps/InterfaceMVSNet/CMakeLists.txt
@@ -7,6 +7,9 @@ FILE(GLOB LIBRARY_FILES_H "*.h" "*.inl")
 
 cxx_executable_with_flags(InterfaceMVSNet "Apps" "${cxx_default}" "MVS;${OpenMVS_EXTRA_LIBS}" ${LIBRARY_FILES_C} ${LIBRARY_FILES_H})
 
+# Ensure libCommon, libIO, and other dependencies are linked using the plain signature
+target_link_libraries(InterfaceMVSNet Common IO)  # Add tinyxml2 if required
+
 # Install
 INSTALL(TARGETS InterfaceMVSNet
 	EXPORT OpenMVSTargets

--- a/apps/InterfaceMetashape/CMakeLists.txt
+++ b/apps/InterfaceMetashape/CMakeLists.txt
@@ -7,6 +7,9 @@ FILE(GLOB LIBRARY_FILES_H "*.h" "*.inl")
 
 cxx_executable_with_flags(InterfaceMetashape "Apps" "${cxx_default}" "MVS;${OpenMVS_EXTRA_LIBS}" ${LIBRARY_FILES_C} ${LIBRARY_FILES_H})
 
+# Ensure libCommon, libIO, and tinyxml2 are linked using the plain signature
+target_link_libraries(InterfaceMetashape Common IO tinyxml2)
+
 # Install
 INSTALL(TARGETS InterfaceMetashape
 	EXPORT OpenMVSTargets

--- a/apps/InterfacePolycam/CMakeLists.txt
+++ b/apps/InterfacePolycam/CMakeLists.txt
@@ -7,6 +7,9 @@ FILE(GLOB LIBRARY_FILES_H "*.h" "*.inl")
 
 cxx_executable_with_flags(InterfacePolycam "Apps" "${cxx_default}" "MVS;${OpenMVS_EXTRA_LIBS}" ${LIBRARY_FILES_C} ${LIBRARY_FILES_H})
 
+# Ensure libCommon, libIO, and other dependencies are linked using the plain signature
+target_link_libraries(InterfacePolycam Common IO)  # Add tinyxml2 if required
+
 # Install
 INSTALL(TARGETS InterfacePolycam
 	EXPORT OpenMVSTargets

--- a/apps/ReconstructMesh/CMakeLists.txt
+++ b/apps/ReconstructMesh/CMakeLists.txt
@@ -7,6 +7,9 @@ FILE(GLOB LIBRARY_FILES_H "*.h" "*.inl")
 
 cxx_executable_with_flags(ReconstructMesh "Apps" "${cxx_default}" "MVS;${OpenMVS_EXTRA_LIBS}" ${LIBRARY_FILES_C} ${LIBRARY_FILES_H})
 
+# Ensure libCommon, libIO, and other dependencies are linked using the plain signature
+target_link_libraries(ReconstructMesh Common IO)  # Add tinyxml2 if required
+
 # Install
 INSTALL(TARGETS ReconstructMesh
 	EXPORT OpenMVSTargets

--- a/apps/RefineMesh/CMakeLists.txt
+++ b/apps/RefineMesh/CMakeLists.txt
@@ -7,6 +7,9 @@ FILE(GLOB LIBRARY_FILES_H "*.h" "*.inl")
 
 cxx_executable_with_flags(RefineMesh "Apps" "${cxx_default}" "MVS;${OpenMVS_EXTRA_LIBS}" ${LIBRARY_FILES_C} ${LIBRARY_FILES_H})
 
+# Ensure libCommon, libIO, and other dependencies are linked using the plain signature
+target_link_libraries(RefineMesh Common IO)  # Add tinyxml2 if required
+
 # Install
 INSTALL(TARGETS RefineMesh
 	EXPORT OpenMVSTargets

--- a/apps/Tests/CMakeLists.txt
+++ b/apps/Tests/CMakeLists.txt
@@ -9,6 +9,9 @@ ADD_DEFINITIONS(-D_DATA_PATH="${CMAKE_CURRENT_SOURCE_DIR}/data/")
 
 cxx_executable_with_flags(Tests "Apps" "${cxx_default}" "MVS;${OpenMVS_EXTRA_LIBS}" ${LIBRARY_FILES_C} ${LIBRARY_FILES_H})
 
+# Ensure libCommon, libIO, and other dependencies are linked using the plain signature
+target_link_libraries(Tests Common IO)  # Add tinyxml2 if required
+
 # Install
 INSTALL(TARGETS Tests
 	EXPORT OpenMVSTargets

--- a/apps/TextureMesh/CMakeLists.txt
+++ b/apps/TextureMesh/CMakeLists.txt
@@ -7,6 +7,9 @@ FILE(GLOB LIBRARY_FILES_H "*.h" "*.inl")
 
 cxx_executable_with_flags(TextureMesh "Apps" "${cxx_default}" "MVS;${OpenMVS_EXTRA_LIBS}" ${LIBRARY_FILES_C} ${LIBRARY_FILES_H})
 
+# Ensure libCommon, libIO, and other dependencies are linked using the plain signature
+target_link_libraries(TextureMesh Common IO)  # Add tinyxml2 if required
+
 # Install
 INSTALL(TARGETS TextureMesh
 	EXPORT OpenMVSTargets

--- a/apps/TransformScene/CMakeLists.txt
+++ b/apps/TransformScene/CMakeLists.txt
@@ -7,6 +7,9 @@ FILE(GLOB LIBRARY_FILES_H "*.h" "*.inl")
 
 cxx_executable_with_flags(TransformScene "Apps" "${cxx_default}" "MVS;${OpenMVS_EXTRA_LIBS}" ${LIBRARY_FILES_C} ${LIBRARY_FILES_H})
 
+# Ensure libCommon, libIO, and other dependencies are linked using the plain signature
+target_link_libraries(TransformScene Common IO)  # Add tinyxml2 if required
+
 # Install
 INSTALL(TARGETS TransformScene
 	EXPORT OpenMVSTargets

--- a/apps/Viewer/CMakeLists.txt
+++ b/apps/Viewer/CMakeLists.txt
@@ -36,6 +36,9 @@ FILE(GLOB LIBRARY_FILES_H "*.h" "*.inl")
 
 cxx_executable_with_flags(${VIEWER_NAME} "Apps" "${cxx_default}" "MVS;${OPENGL_LIBRARIES};${GLEW_LIBRARY};${GLFW_STATIC_LIBRARIES};GLEW::GLEW;${glfw3_LIBRARY};${GLFW3_LIBRARY};glfw;${OpenMVS_EXTRA_LIBS}" ${LIBRARY_FILES_C} ${LIBRARY_FILES_H})
 
+# Ensure libCommon, libIO, and tinyxml2 are linked using the plain signature
+target_link_libraries(${VIEWER_NAME} Common IO tinyxml2)
+
 # Manually set Common.h as the precompiled header
 IF(CMAKE_VERSION VERSION_GREATER_EQUAL 3.16.0)
 	TARGET_PRECOMPILE_HEADERS(${VIEWER_NAME} PRIVATE "Common.h")


### PR DESCRIPTION

For instance:

`target_link_libraries(${VIEWER_NAME} Common IO tinyxml2)`