### PR TITLE
Add a remove unseen faces option to TextureMesh app.

### DIFF
--- a/apps/TextureMesh/TextureMesh.cpp
+++ b/apps/TextureMesh/TextureMesh.cpp
@@ -62,6 +62,7 @@ bool bLocalSeamLeveling;
 unsigned nTextureSizeMultiple;
 unsigned nRectPackingHeuristic;
 uint32_t nColEmpty;
+bool bRemoveUnseenFaces;
 float fSharpnessWeight;
 int nIgnoreMaskLabel;
 unsigned nOrthoMapResolution;
@@ -132,6 +133,7 @@ bool Application::Initialize(size_t argc, LPCTSTR* argv)
 		("texture-size-multiple", boost::program_options::value(&OPT::nTextureSizeMultiple)->default_value(0), "texture size should be a multiple of this value (0 - power of two)")
 		("patch-packing-heuristic", boost::program_options::value(&OPT::nRectPackingHeuristic)->default_value(3), "specify the heuristic used when deciding where to place a new patch (0 - best fit, 3 - good speed, 100 - best speed)")
 		("empty-color", boost::program_options::value(&OPT::nColEmpty)->default_value(0x00FF7F27), "color used for faces not covered by any image")
+		("remove-unseen-faces", boost::program_options::value(&OPT::bRemoveUnseenFaces)->default_value(false), "remove faces which are not seen by any image")
 		("sharpness-weight", boost::program_options::value(&OPT::fSharpnessWeight)->default_value(0.5f), "amount of sharpness to be applied on the texture (0 - disabled)")
 		("orthographic-image-resolution", boost::program_options::value(&OPT::nOrthoMapResolution)->default_value(0), "orthographic image resolution to be generated from the textured mesh - the mesh is expected to be already geo-referenced or at least properly oriented (0 - disabled)")
 		("ignore-mask-label", boost::program_options::value(&OPT::nIgnoreMaskLabel)->default_value(-1), "label value to ignore in the image mask, stored in the MVS scene or next to each image with '.mask.png' extension (-1 - auto estimate mask for lens distortion, -2 - disabled)")
@@ -308,7 +310,7 @@ int main(int argc, LPCTSTR* argv)
 	TD_TIMER_START();
 	if (!scene.TextureMesh(OPT::nResolutionLevel, OPT::nMinResolution, OPT::minCommonCameras, OPT::fOutlierThreshold, OPT::fRatioDataSmoothness,
 						   OPT::bGlobalSeamLeveling, OPT::bLocalSeamLeveling, OPT::nTextureSizeMultiple, OPT::nRectPackingHeuristic, Pixel8U(OPT::nColEmpty),
-						   OPT::fSharpnessWeight, OPT::nIgnoreMaskLabel, OPT::nMaxTextureSize, views))
+						   OPT::fSharpnessWeight, OPT::nIgnoreMaskLabel, OPT::nMaxTextureSize, OPT::bRemoveUnseenFaces, views))
 		return EXIT_FAILURE;
 	VERBOSE("Mesh texturing completed: %u vertices, %u faces (%s)", scene.mesh.vertices.GetSize(), scene.mesh.faces.GetSize(), TD_TIMER_GET_FMT().c_str());
 

--- a/libs/MVS/Mesh.cpp
+++ b/libs/MVS/Mesh.cpp
@@ -3565,6 +3565,8 @@ void Mesh::RemoveFaces(FaceIdxArr& facesRemove, bool bUpdateLists)
 			faces.RemoveAt(idxF);
 			if (!faceTexcoords.empty())
 				faceTexcoords.RemoveAt(idxF * 3, 3);
+			if (!faceTexindices.empty())
+				faceTexindices.RemoveAt(idxF);
 			idxLast = idxF;
 		}
 	} else {
@@ -3599,6 +3601,8 @@ void Mesh::RemoveFaces(FaceIdxArr& facesRemove, bool bUpdateLists)
 			faces.RemoveAt(idxF);
 			if (!faceTexcoords.empty())
 				faceTexcoords.RemoveAt(idxF * 3, 3);
+			if (!faceTexindices.empty())
+				faceTexindices.RemoveAt(idxF);
 			idxLast = idxF;
 		}
 	}

--- a/libs/MVS/Scene.h
+++ b/libs/MVS/Scene.h
@@ -153,7 +153,7 @@ public:
 	// Mesh texturing
 	bool TextureMesh(unsigned nResolutionLevel, unsigned nMinResolution, unsigned minCommonCameras=0, float fOutlierThreshold=0.f, float fRatioDataSmoothness=0.3f,
 		bool bGlobalSeamLeveling=true, bool bLocalSeamLeveling=true, unsigned nTextureSizeMultiple=0, unsigned nRectPackingHeuristic=3, Pixel8U colEmpty=Pixel8U(255,127,39),
-		float fSharpnessWeight=0.5f, int ignoreMaskLabel=-1, int maxTextureSize=0, const IIndexArr& views=IIndexArr());
+		float fSharpnessWeight=0.5f, int ignoreMaskLabel=-1, int maxTextureSize=0, bool bRemoveUnseenFaces=false, const IIndexArr& views=IIndexArr());
 
 	#ifdef _USE_BOOST
 	// implement BOOST serialization

--- a/libs/MVS/SceneTexture.cpp
+++ b/libs/MVS/SceneTexture.cpp
@@ -2269,8 +2269,6 @@ void MeshTexture::GenerateTexture(bool bGlobalSeamLeveling, bool bLocalSeamLevel
 			}
 		}
 
-		Mesh::FaceIdxArr facesToRemove;
-
 		#ifdef TEXOPT_USE_OPENMP
 		#pragma omp parallel for schedule(dynamic)
 		for (int_t i=0; i<(int_t)placedRects.size(); ++i) {
@@ -2296,15 +2294,6 @@ void MeshTexture::GenerateTexture(bool bGlobalSeamLeveling, bool bLocalSeamLevel
 						x = 1; y = 0;
 					}
 					patch.copyTo(texturesDiffuse[idxTexture](rect));
-				}
-				else if (bRemoveUnseenFaces)
-				{
-					auto it = texturePatch.faces.begin();
-					while (it != texturePatch.faces.end())
-					{
-						facesToRemove.push_back(*it);
-						++it;
-					}
 				}
 				// compute final texture coordinates
 				const TexCoord offset(rect.tl());
@@ -2333,9 +2322,10 @@ void MeshTexture::GenerateTexture(bool bGlobalSeamLeveling, bool bLocalSeamLevel
 			}
 		}
 
-		if (bRemoveUnseenFaces)
-		{
-			scene.mesh.RemoveFaces(facesToRemove);
+		// Remove unseen faces
+		if (bRemoveUnseenFaces) {
+			scene.mesh.RemoveFaces(texturePatches.back().faces, true);
+			scene.mesh.RemoveUnreferencedVertices(true);
 		}
 	}
 }


### PR DESCRIPTION
If enabled, faces which are not seen by any image are removed from the mesh.