### PR TITLE
Fix idxImages initialization

### DIFF
--- a/libs/MVS/Scene.cpp
+++ b/libs/MVS/Scene.cpp
@@ -1809,7 +1809,8 @@ bool Scene::ExportChunks(const ImagesChunkArr& chunks, const String& path, ARCHI
 {
 	FOREACH(chunkID, chunks) {
 		const ImagesChunk& chunk = chunks[chunkID];
-		IIndexArr idxImages(chunk.images.begin(), chunk.images.end(), true);
+		IIndexArr idxImages((uint32_t)chunk.images.size());
+		std::iota(idxImages.begin(), idxImages.end(), 0u);
 		Scene subset = SubScene(idxImages);
 		// set scene ROI
 		subset.obb.Set(OBB3f::MATRIX::Identity(), chunk.aabb.ptMin, chunk.aabb.ptMax);


### PR DESCRIPTION
Hi :wave:

I think there's a problem initializing `idxImages` in the exportChunks function. Currently the resulting `IIndexArr` will be initialized to 2*chunk.images.size() size, causing a buffer overflow in SubScene(). 

There might be a better way to fix this, but this fixes the crash and runs the split functionality as expected. 

It's kind of strange because the IIndexArr constructor looks correct on the surface, but:

```c
bool Scene::ExportChunks(const ImagesChunkArr& chunks, const String& path, ARCHIVE_TYPE type) const
{
	FOREACH(chunkID, chunks) {
		const ImagesChunk& chunk = chunks[chunkID];
		std::cerr << "SIZE: " << chunk.images.size() << std::endl;
		IIndexArr idxImages(chunk.images.begin(), chunk.images.end(), true);
		std::cerr << "IDX SIZE: " << idxImages.size() << std::endl;
		exit(1);
```

```
SIZE: 66
IDX SIZE: 132
```

```
g++ --version
g++ (Ubuntu 9.4.0-1ubuntu1~20.04.2) 9.4.0
```