### PR TITLE
Dense: Fix out of memory edge case due to footprint explosion

### DIFF
--- a/libs/MVS/Scene.cpp
+++ b/libs/MVS/Scene.cpp
@@ -1293,7 +1293,7 @@ bool Scene::SelectNeighborViews(uint32_t ID, IndexArr& points, unsigned nMinView
 		const PointCloud::Point& point = pointcloud.points[idx];
 		const Depth depth((float)imageData.camera.PointDepth(point));
 		ASSERT(depth > 0);
-		if (depth <= 0)
+		if (depth <= 0.01)
 			continue;
 		// store this point
 		if (views.size() >= nMinPointViews)
@@ -1312,7 +1312,7 @@ bool Scene::SelectNeighborViews(uint32_t ID, IndexArr& points, unsigned nMinView
 			const Image& imageData2 = images[view];
 			const Depth depth2((float)imageData2.camera.PointDepth(point));
 			ASSERT(depth2 > 0);
-			if (depth2 <= 0)
+			if (depth2 <= 0.01)
 				continue;
 			const Point3f V2(imageData2.camera.C - Cast<REAL>(point));
 			const float fAngle(ACOS(ComputeAngle(V1.ptr(), V2.ptr())));


### PR DESCRIPTION
Hey :wave:

I've tracked down a recurring (but infrequent) issue that would cause OpenMVS to attempt to resize a depthmap to a very large size and causing: 

```
Estimated depth-maps 134 (87.58%, 3m14s, ETA 27s)...terminate called after throwing an instance of 'cv::Exception'
what():  OpenCV(4.12.0) /code/SuperBuild/src/opencv/modules/core/src/alloc.cpp:73: error: (-4:Insufficient memory) Failed to allocate 68896563262380 bytes in function 'OutOfMemoryError'
```

This seems to happen when noise from an input sparse point cloud places a point really, really close to a view. When that happens, the `footprint1` can end up being (`focal / very very small depth value`) --> `very large number`. In turn, this causes `fScaleRatio` to be set to a very large number, which pushes the `avgScale` value, and thus `neighbor.scale` to be a very large number. 

This causes the call to:

```
if (DepthData::ViewData::ScaleImage(viewTrg.image, viewTrg.image, viewTrg.scale)) // <-- viewTrg.scale could be really large
```

In `InitViews` to crash the program.

One possible solution here is to bump the depth checks from 0 to a reasonable epsilon (I've picked 0.01, because the dataset where I reproduced this had a depth value of 0.000001), or another one could be to track a median scale rather than average (which would filter out noisy scale values). 