### PR TITLE
Fix x86 MSVC compilation

### DIFF
--- a/apps/InterfaceMetashape/InterfaceMetashape.cpp
+++ b/apps/InterfaceMetashape/InterfaceMetashape.cpp
@@ -625,7 +625,7 @@ bool ParseSceneXML(Scene& scene, PlatformDistCoeffs& pltDistCoeffs, size_t& nCam
 		}
 		const size_t nLen(pStream->getSize());
 		String str; str.resize(nLen);
-		pStream->read(&str[0], nLen);
+		pStream->read(str.data(), nLen);
 		doc.Parse(str.c_str(), nLen);
 	}
 	if (doc.ErrorID() != tinyxml2::XML_SUCCESS) {


### PR DESCRIPTION
Upstreamed from vcpkg port. Fixes
~~~
FAILED: [code=2] apps/InterfaceMetashape/CMakeFiles/InterfaceMetashape.dir/InterfaceMetashape.cpp.obj 
C:\PROGRA~1\MICROS~1\2022\ENTERP~1\VC\Tools\MSVC\1444~1.352\bin\Hostx64\x86\cl.exe   /TP  -ID:\installed\x86-windows\include -ID:\installed\x86-windows\include\eigen3 -ID:\installed\x86-windows\include\opencv4 -ID:\b\openmvs\src\v2.3.0-1d44f1f1db.clean -ID:\b\openmvs\x86-windows-rel /nologo /DWIN32 /D_WINDOWS /utf-8 /GR /EHsc /MP   /D _CRT_SECURE_NO_DEPRECATE /D _CRT_NONSTDC_NO_DEPRECATE /D _SCL_SECURE_NO_WARNINGS /Gy /bigobj /arch:SSE2 /Oi /fp:fast /Zm170 /Zc:__cplusplus  /wd4231 /wd4251 /wd4308 /wd4396 /wd4503 /wd4661 /wd4996 /MD /O2 /Oi /Gy /DNDEBUG /Z7   /GL -std:c++17 -MD  /nologo /DWIN32 /D_WINDOWS /utf-8 /GR /EHsc /MP   /D _CRT_SECURE_NO_DEPRECATE /D _CRT_NONSTDC_NO_DEPRECATE /D _SCL_SECURE_NO_WARNINGS /Gy /bigobj /arch:SSE2 /Oi /fp:fast /Zm170 /Zc:__cplusplus  /wd4231 /wd4251 /wd4308 /wd4396 /wd4503 /wd4661 /wd4996 -DWIN32 -D_WIN32 -EHsc -D_HAS_EXCEPTIONS=1 /showIncludes /Foapps\InterfaceMetashape\CMakeFiles\InterfaceMetashape.dir\InterfaceMetashape.cpp.obj /Fdapps\InterfaceMetashape\CMakeFiles\InterfaceMetashape.dir\ /FS -c D:\b\openmvs\src\v2.3.0-1d44f1f1db.clean\apps\InterfaceMetashape\InterfaceMetashape.cpp
D:\b\openmvs\src\v2.3.0-1d44f1f1db.clean\apps\InterfaceMetashape\InterfaceMetashape.cpp(628): error C2666: 'std::basic_string<char,std::char_traits<char>,std::allocator<char>>::operator []': overloaded functions have similar conversions
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\xstring(2275): note: could be 'const char &std::basic_string<char,std::char_traits<char>,std::allocator<char>>::operator [](const unsigned int) noexcept const'
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\xstring(2267): note: or       'char &std::basic_string<char,std::char_traits<char>,std::allocator<char>>::operator [](const unsigned int) noexcept'
D:\b\openmvs\src\v2.3.0-1d44f1f1db.clean\apps\InterfaceMetashape\InterfaceMetashape.cpp(628): note: or       'built-in C++ operator[](LPCTSTR, int)'
D:\b\openmvs\src\v2.3.0-1d44f1f1db.clean\apps\InterfaceMetashape\InterfaceMetashape.cpp(628): note: while trying to match the argument list '(SEACAVE::String, int)'
~~~