### PR TITLE
Don't use combination of /arch:AVX /arch:SSE2 /arch:SSE

### DIFF
--- a/build/Utils.cmake
+++ b/build/Utils.cmake
@@ -635,17 +635,13 @@ macro(optimize_default_compiler_settings)
 		set(BUILD_EXTRA_FLAGS_RELEASE "${BUILD_EXTRA_FLAGS_RELEASE} /Zi")
 	  endif()
 
-	  if(NOT MSVC64)
-		# 64-bit MSVC compiler uses SSE/SSE2 by default
-		if(ENABLE_SSE2)
-		  set(BUILD_EXTRA_FLAGS "${BUILD_EXTRA_FLAGS} /arch:SSE2")
-		elseif(ENABLE_SSE)
-		  set(BUILD_EXTRA_FLAGS "${BUILD_EXTRA_FLAGS} /arch:SSE")
-		endif()
-	  endif()
-
+	  # 64-bit MSVC compiler uses SSE/SSE2 by default
 	  if(ENABLE_AVX)
 		set(BUILD_EXTRA_FLAGS "${BUILD_EXTRA_FLAGS} /arch:AVX")
+	  elseif(ENABLE_SSE2 AND NOT MSVC64)
+		set(BUILD_EXTRA_FLAGS "${BUILD_EXTRA_FLAGS} /arch:SSE2")
+	  elseif(ENABLE_SSE AND NOT MSVC64)
+		set(BUILD_EXTRA_FLAGS "${BUILD_EXTRA_FLAGS} /arch:SSE")
 	  endif()
 
 	  if(ENABLE_SSE OR ENABLE_SSE2 OR ENABLE_SSE3 OR ENABLE_SSE4_1)

--- a/build/Utils.cmake
+++ b/build/Utils.cmake
@@ -642,7 +642,6 @@ macro(optimize_default_compiler_settings)
 		elseif(ENABLE_SSE)
 		  set(BUILD_EXTRA_FLAGS "${BUILD_EXTRA_FLAGS} /arch:SSE")
 		endif()
-		endif()
 	  endif()
 
 	  if(ENABLE_AVX)

--- a/build/Utils.cmake
+++ b/build/Utils.cmake
@@ -637,11 +637,11 @@ macro(optimize_default_compiler_settings)
 
 	  if(NOT MSVC64)
 		# 64-bit MSVC compiler uses SSE/SSE2 by default
-		if(ENABLE_SSE)
-		  set(BUILD_EXTRA_FLAGS "${BUILD_EXTRA_FLAGS} /arch:SSE")
-		endif()
 		if(ENABLE_SSE2)
 		  set(BUILD_EXTRA_FLAGS "${BUILD_EXTRA_FLAGS} /arch:SSE2")
+		elseif(ENABLE_SSE)
+		  set(BUILD_EXTRA_FLAGS "${BUILD_EXTRA_FLAGS} /arch:SSE")
+		endif()
 		endif()
 	  endif()
 


### PR DESCRIPTION
Avoid MSVC x86 compiler warning:
~~~
cl : Command line warning D9025 : overriding '/arch:SSE' with '/arch:SSE2'
~~~

(Both ENABLE_SSE and ENABLE_SSE2 are enabled by default for x86.)
