### PR TITLE
Add CUDA SM 8.7 (Jetson Orin) and SM 12.0 (Blackwell) GPU support

### DIFF
--- a/libs/Common/UtilCUDA.cpp
+++ b/libs/Common/UtilCUDA.cpp
@@ -52,8 +52,10 @@ int _convertSMVer2Cores(int major, int minor)
 		{0x75, 64 }, // Turing Generation (SM 7.5) TU1xx class
 		{0x80, 64 }, // Ampere Generation (SM 8.0) GA100 class
 		{0x86, 128}, // Ampere Generation (SM 8.6) GA102-GA107 class
-		{0x89, 128}, // Ada Generation (SM 8.9) AD106 class
+		{0x87, 128}, // Ampere Generation (SM 8.7) Jetson Orin
+		{0x89, 128}, // Ada Generation (SM 8.9) AD102-AD107 class
 		{0x90, 128}, // Hopper Generation (SM 9.0) GH100 class
+		{0xC0, 128}, // Blackwell Generation (SM 12.0) GB202-GB207 class
 		{-1, -1}
 	};
 


### PR DESCRIPTION
Fixes #1248

## Summary
Adds missing SM architecture mappings to `nGpuArchCoresPerSM` for newer NVIDIA GPUs:

- **SM 8.7**: Ampere Generation (Jetson Orin) - 128 cores/SM
- **SM 12.0**: Blackwell Generation (RTX 5090, GB202-GB207 class) - 128 cores/SM

## Problem
When using OpenMVS with an RTX 5090 (Blackwell architecture), the application shows:
```
MapSMtoCores for SM 12.0 is undefined; default to use 64 cores/SM
```

The RTX 5090 has 128 CUDA cores per SM, but without the mapping it defaults to 64, which may affect GPU utilization and scheduling decisions.

## Testing
Tested on RTX 5090 (SM 12.0) - processing completes successfully with correct core count detection.

## Changes
- Added `{0x87, 128}` for Jetson Orin (SM 8.7)
- Added `{0xC0, 128}` for Blackwell (SM 12.0)
- Minor comment fix: AD106 → AD102-AD107 for Ada generation