### PR TITLE
dense: parallelize PatchMatch CUDA across workers (~30% wall time)

### DIFF
--- a/apps/DensifyPointCloud/DensifyPointCloud.cpp
+++ b/apps/DensifyPointCloud/DensifyPointCloud.cpp
@@ -137,6 +137,7 @@ bool Application::Initialize(size_t argc, LPCTSTR* argv)
 	unsigned nSubResolutionLevels;
 	unsigned nEstimationIters;
 	unsigned nEstimationGeometricIters;
+	unsigned nPatchMatchCUDAInstances;
 	unsigned nEstimateColors;
 	unsigned nEstimateNormals;
 	unsigned nFuseFilter;
@@ -162,6 +163,7 @@ bool Application::Initialize(size_t argc, LPCTSTR* argv)
 		("ignore-mask-label", boost::program_options::value(&nIgnoreMaskLabel)->default_value(-1), "label value to ignore in the image mask, stored in the MVS scene or next to each image with '.mask.png' extension (<0 - disabled)")
 		("iters", boost::program_options::value(&nEstimationIters)->default_value(numIters), "number of patch-match iterations")
 		("geometric-iters", boost::program_options::value(&nEstimationGeometricIters)->default_value(2), "number of geometric consistent patch-match iterations (0 - disabled)")
+		("patch-match-cuda-instances", boost::program_options::value(&nPatchMatchCUDAInstances)->default_value(4), "number of parallel CUDA PatchMatch worker instances (clamped to nMaxThreads)")
 		("estimate-colors", boost::program_options::value(&nEstimateColors)->default_value(2), "estimate the colors for the dense point-cloud (0 - disabled, 1 - final, 2 - estimate)")
 		("estimate-normals", boost::program_options::value(&nEstimateNormals)->default_value(2), "estimate the normals for the dense point-cloud (0 - disabled, 1 - final, 2 - estimate)")
 		("estimate-scale", boost::program_options::value(&OPT::fEstimateScale)->default_value(0.f), "estimate the point-scale for the dense point-cloud (scale multiplier, 0 - disabled)")
@@ -270,6 +272,7 @@ bool Application::Initialize(size_t argc, LPCTSTR* argv)
 	OPTDENSE::nMinViewsFuse = nMinViewsFuse;
 	OPTDENSE::nEstimationIters = nEstimationIters;
 	OPTDENSE::nEstimationGeometricIters = nEstimationGeometricIters;
+	OPTDENSE::nPatchMatchCUDAInstances = nPatchMatchCUDAInstances;
 	OPTDENSE::nEstimateColors = nEstimateColors;
 	OPTDENSE::nEstimateNormals = nEstimateNormals;
 	OPTDENSE::nFuseFilter = nFuseFilter;

--- a/libs/MVS/DepthMap.cpp
+++ b/libs/MVS/DepthMap.cpp
@@ -118,6 +118,7 @@ MDEFVAR_OPTDENSE_uint32(nEstimateNormals, "Estimate Normals", "should we estimat
 MDEFVAR_OPTDENSE_float(fNCCThresholdKeep, "NCC Threshold Keep", "Maximum 1-NCC score accepted for a match", "0.9", "0.5")
 DEFVAR_OPTDENSE_uint32(nEstimationIters, "Estimation Iters", "Number of patch-match iterations", "3")
 DEFVAR_OPTDENSE_uint32(nEstimationGeometricIters, "Estimation Geometric Iters", "Number of geometric consistent patch-match iterations (0 - disabled)", "2")
+DEFVAR_OPTDENSE_uint32(nPatchMatchCUDAInstances, "PatchMatch CUDA Instances", "Number of parallel CUDA PatchMatch worker instances (clamped to nMaxThreads)", "4")
 MDEFVAR_OPTDENSE_float(fEstimationGeometricWeight, "Estimation Geometric Weight", "pairwise geometric consistency cost weight", "0.1")
 MDEFVAR_OPTDENSE_uint32(nRandomIters, "Random Iters", "Number of iterations for random assignment per pixel", "6")
 MDEFVAR_OPTDENSE_uint32(nRandomMaxScale, "Random Max Scale", "Maximum number of iterations to skip during random assignment", "2")

--- a/libs/MVS/DepthMap.h
+++ b/libs/MVS/DepthMap.h
@@ -138,6 +138,7 @@ extern MVS_API unsigned nEstimateNormals;
 extern MVS_API float fNCCThresholdKeep;
 extern MVS_API unsigned nEstimationIters;
 extern MVS_API unsigned nEstimationGeometricIters;
+extern MVS_API unsigned nPatchMatchCUDAInstances;
 extern MVS_API float fEstimationGeometricWeight;
 extern MVS_API unsigned nRandomIters;
 extern MVS_API unsigned nRandomMaxScale;

--- a/libs/MVS/PatchMatchCUDA.cpp
+++ b/libs/MVS/PatchMatchCUDA.cpp
@@ -107,7 +107,48 @@ void PatchMatch::Release()
 	images.clear();
 	cameras.clear();
 
+	for (float*& p : hostImageStaging) if (p) cudaFreeHost(p);
+	hostImageStaging.clear();
+	hostImageStagingArea.clear();
+	for (float*& p : hostDepthPriorStaging) if (p) cudaFreeHost(p);
+	hostDepthPriorStaging.clear();
+	hostDepthPriorStagingArea.clear();
+
 	ReleaseCUDA();
+}
+
+void PatchMatch::StagedUploadCvMat(cudaArray_t dst, const cv::Mat1f& src,
+	std::vector<float*>& slots, std::vector<size_t>& areas, size_t slotIdx)
+{
+	ASSERT(src.type() == CV_32FC1);
+	const size_t area = (size_t)src.rows * (size_t)src.cols;
+	const size_t rowBytes = (size_t)src.cols * sizeof(float);
+	// Pinned staging wins on large images (driver-internal staging stall scales
+	// with area) but loses on small ones (cudaHostAlloc + explicit memcpy
+	// overhead is fixed). Threshold calibrated on Truck R=1 V=8 (~1 MP, regress)
+	// vs Truck R=0 V=8 (~3 MP, -15.7% wall).
+	constexpr size_t kPinnedStagingThresholdArea = 1500000;
+	if (area < kPinnedStagingThresholdArea) {
+		CUDA_CHECK(cudaMemcpy2DToArrayAsync(dst, 0, 0, src.ptr<float>(), src.step[0],
+			rowBytes, src.rows, cudaMemcpyHostToDevice, cudaStream));
+		return;
+	}
+	if (slots.size() <= slotIdx) slots.resize(slotIdx + 1, nullptr);
+	if (areas.size() <= slotIdx) areas.resize(slotIdx + 1, 0);
+	if (slots[slotIdx] == nullptr || areas[slotIdx] < area) {
+		if (slots[slotIdx]) CUDA_CHECK(cudaFreeHost(slots[slotIdx]));
+		CUDA_CHECK(cudaHostAlloc((void**)&slots[slotIdx], area * sizeof(float), cudaHostAllocDefault));
+		areas[slotIdx] = area;
+	}
+	float* dstPinned = slots[slotIdx];
+	if (src.isContinuous() && src.step[0] == rowBytes) {
+		memcpy(dstPinned, src.ptr<float>(), area * sizeof(float));
+	} else {
+		for (int r = 0; r < src.rows; ++r)
+			memcpy(dstPinned + (size_t)r * src.cols, src.ptr<float>(r), rowBytes);
+	}
+	CUDA_CHECK(cudaMemcpy2DToArrayAsync(dst, 0, 0, dstPinned, rowBytes,
+		rowBytes, src.rows, cudaMemcpyHostToDevice, cudaStream));
 }
 
 void PatchMatch::ReleaseCUDA()
@@ -320,15 +361,16 @@ void PatchMatch::EstimateDepthMap(DepthData& depthData)
 				}
 				AllocateImageCUDA(i, image, false, !view.depthMap.empty());
 			}
-			// queued on cudaStream so the kernel does not need a device fence;
-			// pageable cv::Mat still stalls the host but ordering is stream-scoped
-			CUDA_CHECK(cudaMemcpy2DToArrayAsync(cudaImageArrays[i], 0, 0, image.ptr<float>(), image.step[0], image.cols * sizeof(float), image.rows, cudaMemcpyHostToDevice, cudaStream));
+			// large images stage through per-instance pinned slot for a truly-async
+			// H->D DMA on cudaStream; small images fall through to direct pageable
+			// DMA inside StagedUploadCvMat (driver-internal staging is cheaper)
+			StagedUploadCvMat(cudaImageArrays[i], image, hostImageStaging, hostImageStagingArea, (size_t)i);
 			if (params.bGeomConsistency && i > 0 && !view.depthMap.empty()) {
 				// set previously computed depth-map
 				DepthMap depthMap(view.depthMap);
 				if (depthMap.size() != image.size())
 					cv::resize(depthMap, depthMap, image.size(), 0, 0, cv::INTER_LINEAR);
-				CUDA_CHECK(cudaMemcpy2DToArrayAsync(cudaDepthArrays[i-1], 0, 0, depthMap.ptr<float>(), depthMap.step[0], sizeof(float) * depthMap.cols, depthMap.rows, cudaMemcpyHostToDevice, cudaStream));
+				StagedUploadCvMat(cudaDepthArrays[i-1], depthMap, hostDepthPriorStaging, hostDepthPriorStagingArea, (size_t)(i-1));
 			}
 			images[i] = std::move(image);
 			cameras[i] = std::move(camera);

--- a/libs/MVS/PatchMatchCUDA.cpp
+++ b/libs/MVS/PatchMatchCUDA.cpp
@@ -51,22 +51,19 @@ namespace MVS {
 
 namespace CUDA {
 
-// In-flight serializer for the CUDA backend. The kernels read cameras/params
+// Kernel-launch serializer for the CUDA backend. The kernels read cameras/params
 // from module-global __constant__ memory (g_cameras / g_params, see
 // PatchMatchCUDA.cu), which is shared by every PatchMatch instance on the
-// device. Concurrent overlap would race, so EstimateDepthMap must run
-// single-in-flight per device.
+// device. Concurrent overlap would race the __constant__ writes against an
+// in-flight kernel's reads, so the {UploadCameras + RunCUDA} block runs
+// single-in-flight per device. The cudaStreamSynchronize inside RunCUDA holds
+// the lock until the kernels have actually consumed the __constant__ values.
 //
-// SceneDensify spawns two worker threads in its event loop (see
-// DenseReconstructionEstimateTmp) so concurrent calls into here do happen;
-// a std::mutex serializes the host-side critical section while still letting
-// the kernel enjoy the constant-memory broadcast that the optimization commit added.
+// The rest of EstimateDepthMap (per-instance image/depth uploads, host-side
+// packing of depthNormalEstimates, result unpack) is per-instance state and
+// runs lock-free, so the two SceneDensify workers parallelize that work.
 namespace {
 std::mutex g_patchMatchCudaMutex;
-struct PatchMatchCudaInFlightGuard {
-	std::lock_guard<std::mutex> _lock;
-	PatchMatchCudaInFlightGuard() : _lock(g_patchMatchCudaMutex) {}
-};
 } // anonymous namespace
 
 PatchMatch::PatchMatch()
@@ -205,7 +202,6 @@ void PatchMatch::AllocateImageCUDA(size_t i, const cv::Mat1f& image, bool bInitI
 void PatchMatch::EstimateDepthMap(DepthData& depthData)
 {
 	TD_TIMER_STARTD();
-	const PatchMatchCudaInFlightGuard inFlightGuard;
 
 	ASSERT(depthData.images.size() > 1);
 
@@ -358,7 +354,6 @@ void PatchMatch::EstimateDepthMap(DepthData& depthData)
 
 		// setup CUDA memory (queued on cudaStream)
 		CUDA_CHECK(cudaMemcpyAsync(cudaTextureImages, textureImages.data(), sizeof(cudaTextureObject_t) * numImages, cudaMemcpyHostToDevice, cudaStream));
-		UploadCameras();
 		if (params.bGeomConsistency) {
 			// set previously computed depth-maps
 			ASSERT(depthData.depthMap.size() == depthData.GetView().image.size());
@@ -385,9 +380,16 @@ void PatchMatch::EstimateDepthMap(DepthData& depthData)
 			CUDA_CHECK(cudaMemcpyAsync(cudaLowDepths, depthData.depthMap.ptr<float>(), sizeof(float) * depthData.depthMap.size().area(), cudaMemcpyHostToDevice, cudaStream));
 		}
 
-		// run CUDA patch-match
+		// run CUDA patch-match: serialize only the __constant__-mem writes
+		// (g_cameras via UploadCameras, g_params via UploadParams inside RunCUDA)
+		// and the kernel launches that read them. RunCUDA ends with
+		// cudaStreamSynchronize, so the lock holds until kernels actually finish.
 		ASSERT(!depthData.viewsMap.empty());
-		RunCUDA(depthData.confMap.getData(), (uint32_t*)depthData.viewsMap.getData());
+		{
+			std::lock_guard<std::mutex> kernelLock(g_patchMatchCudaMutex);
+			UploadCameras();
+			RunCUDA(depthData.confMap.getData(), (uint32_t*)depthData.viewsMap.getData());
+		}
 		CUDA_CHECK(cudaGetLastError());
 		if (params.bLowResProcessed)
 			CUDA_CHECK(cudaFreeAsync(cudaLowDepths, cudaStream));

--- a/libs/MVS/PatchMatchCUDA.cpp
+++ b/libs/MVS/PatchMatchCUDA.cpp
@@ -55,15 +55,18 @@ namespace CUDA {
 // from module-global __constant__ memory (g_cameras / g_params, see
 // PatchMatchCUDA.cu), which is shared by every PatchMatch instance on the
 // device. Concurrent overlap would race the __constant__ writes against an
-// in-flight kernel's reads, so the {UploadCameras + RunCUDA} block runs
-// single-in-flight per device. The cudaStreamSynchronize inside RunCUDA holds
-// the lock until the kernels have actually consumed the __constant__ values.
+// in-flight kernel's reads.
 //
-// The rest of EstimateDepthMap (per-instance image/depth uploads, host-side
-// packing of depthNormalEstimates, result unpack) is per-instance state and
-// runs lock-free, so the two SceneDensify workers parallelize that work.
+// Strategy: a global cudaEvent_t chains worker N+1's kernels behind worker N's
+// kernels on the GPU side. A tiny host mutex covers only the queueing sequence
+// {wait-event, upload-cameras, queue-kernels, record-event} so the host releases
+// after queueing (~1ms) rather than after kernel execution (~80-400ms). Each
+// worker then cudaStreamSynchronize's its own stream outside the mutex before
+// reading results into its per-instance pinned buffer.
 namespace {
 std::mutex g_patchMatchCudaMutex;
+cudaEvent_t g_constMemReady = nullptr;
+std::once_flag g_constMemEventInit;
 } // anonymous namespace
 
 PatchMatch::PatchMatch()
@@ -380,16 +383,24 @@ void PatchMatch::EstimateDepthMap(DepthData& depthData)
 			CUDA_CHECK(cudaMemcpyAsync(cudaLowDepths, depthData.depthMap.ptr<float>(), sizeof(float) * depthData.depthMap.size().area(), cudaMemcpyHostToDevice, cudaStream));
 		}
 
-		// run CUDA patch-match: serialize only the __constant__-mem writes
-		// (g_cameras via UploadCameras, g_params via UploadParams inside RunCUDA)
-		// and the kernel launches that read them. RunCUDA ends with
-		// cudaStreamSynchronize, so the lock holds until kernels actually finish.
+		// run CUDA patch-match: GPU-side event chains successive workers'
+		// kernel sequences so the next worker's __constant__ writes wait for
+		// the previous worker's kernels to finish reading them. Host mutex
+		// covers only the queueing window, not kernel execution.
 		ASSERT(!depthData.viewsMap.empty());
+		std::call_once(g_constMemEventInit, []() {
+			CUDA_CHECK(cudaEventCreateWithFlags(&g_constMemReady, cudaEventDisableTiming));
+		});
 		{
-			std::lock_guard<std::mutex> kernelLock(g_patchMatchCudaMutex);
+			std::lock_guard<std::mutex> queueLock(g_patchMatchCudaMutex);
+			CUDA_CHECK(cudaStreamWaitEvent(cudaStream, g_constMemReady, 0));
 			UploadCameras();
 			RunCUDA(depthData.confMap.getData(), (uint32_t*)depthData.viewsMap.getData());
+			CUDA_CHECK(cudaEventRecord(g_constMemReady, cudaStream));
 		}
+		// wait for our own kernels + D2H copies to finish before the unpack loop
+		// reads from the pinned host buffer
+		CUDA_CHECK(cudaStreamSynchronize(cudaStream));
 		CUDA_CHECK(cudaGetLastError());
 		if (params.bLowResProcessed)
 			CUDA_CHECK(cudaFreeAsync(cudaLowDepths, cudaStream));

--- a/libs/MVS/PatchMatchCUDA.cpp
+++ b/libs/MVS/PatchMatchCUDA.cpp
@@ -117,16 +117,14 @@ void PatchMatch::Release()
 	ReleaseCUDA();
 }
 
+// pinned staging wins on large images (driver-internal staging stall scales with
+// area) but loses on small ones (cudaHostAlloc + explicit memcpy overhead is fixed)
 void PatchMatch::StagedUploadCvMat(cudaArray_t dst, const cv::Mat1f& src,
 	std::vector<float*>& slots, std::vector<size_t>& areas, size_t slotIdx)
 {
 	ASSERT(src.type() == CV_32FC1);
 	const size_t area = (size_t)src.rows * (size_t)src.cols;
 	const size_t rowBytes = (size_t)src.cols * sizeof(float);
-	// Pinned staging wins on large images (driver-internal staging stall scales
-	// with area) but loses on small ones (cudaHostAlloc + explicit memcpy
-	// overhead is fixed). Threshold calibrated on Truck R=1 V=8 (~1 MP, regress)
-	// vs Truck R=0 V=8 (~3 MP, -15.7% wall).
 	constexpr size_t kPinnedStagingThresholdArea = 1500000;
 	if (area < kPinnedStagingThresholdArea) {
 		CUDA_CHECK(cudaMemcpy2DToArrayAsync(dst, 0, 0, src.ptr<float>(), src.step[0],

--- a/libs/MVS/PatchMatchCUDA.cu
+++ b/libs/MVS/PatchMatchCUDA.cu
@@ -795,14 +795,13 @@ __host__ void PatchMatch::RunCUDA(float* ptrCostMap, uint32_t* ptrViewsMap)
 				KERNEL<false><<<GRID, blockSize, 0, cudaStream>>>(__VA_ARGS__); \
 		}
 
+	// Pure queueing path: stream ordering on cudaStream already chains kernels;
+	// caller (EstimateDepthMap) syncs the stream once before reading results.
 	LAUNCH_GEOM(InitializeScore, gridSizeFull, cudaTextureImages, cudaTextureDepths, cudaDepthNormalEstimates, cudaLowDepths, cudaDepthNormalCosts, cudaRandStates, cudaSelectedViews);
-	cudaStreamSynchronize(cudaStream);
 
 	for (int iter = 0; iter < params.nEstimationIters; ++iter) {
 		LAUNCH_GEOM(BlackPixelProcess, gridSizeCheckerboard, cudaTextureImages, cudaTextureDepths, cudaDepthNormalEstimates, cudaLowDepths, cudaDepthNormalCosts, cudaRandStates, cudaSelectedViews, iter);
-		cudaStreamSynchronize(cudaStream);
 		LAUNCH_GEOM(RedPixelProcess, gridSizeCheckerboard, cudaTextureImages, cudaTextureDepths, cudaDepthNormalEstimates, cudaLowDepths, cudaDepthNormalCosts, cudaRandStates, cudaSelectedViews, iter);
-		cudaStreamSynchronize(cudaStream);
 	}
 
 	#undef LAUNCH_GEOM
@@ -815,8 +814,6 @@ __host__ void PatchMatch::RunCUDA(float* ptrCostMap, uint32_t* ptrViewsMap)
 		cudaMemcpyAsync(ptrCostMap, cudaDepthNormalCosts, sizeof(float) * width * height, cudaMemcpyDeviceToHost, cudaStream);
 	if (ptrViewsMap)
 		cudaMemcpyAsync(ptrViewsMap, cudaSelectedViews, sizeof(uint32_t) * width * height, cudaMemcpyDeviceToHost, cudaStream);
-
-	cudaStreamSynchronize(cudaStream);
 }
 /*----------------------------------------------------------------*/
 

--- a/libs/MVS/PatchMatchCUDA.inl
+++ b/libs/MVS/PatchMatchCUDA.inl
@@ -85,6 +85,14 @@ private:
 	void RunCUDA(float* ptrCostMap=NULL, uint32_t* ptrViewsMap=NULL);
 	void UploadCameras(); // upload host cameras into __constant__ g_cameras
 	void UploadParams();  // upload host params into __constant__ g_params
+	// For images large enough that the per-call driver-staging stall dominates
+	// (default threshold ~1.5 MP), copy a pageable cv::Mat1f into a per-instance
+	// pinned slot then enqueue a truly-async H->D DMA on cudaStream. For smaller
+	// mats falls back to a direct pageable DMA (the driver's internal chunked
+	// staging is cheap enough that the explicit memcpy + cudaHostAlloc overhead
+	// would otherwise be a net loss).
+	void StagedUploadCvMat(cudaArray_t dst, const cv::Mat1f& src,
+		std::vector<float*>& slots, std::vector<size_t>& areas, size_t slotIdx);
 
 public:
 	Params params;
@@ -107,6 +115,13 @@ public:
 	// per-instance stream: scopes kernel launches and syncs to this PatchMatch
 	// instead of fencing the whole device, and enables async H<->D transfers
 	cudaStream_t cudaStream;
+	// pinned host staging slots, indexed by view (image upload) or by neighbor
+	// (depth-prior upload). Grown on demand by StagedUploadCvMat above the area
+	// threshold; freed in Release(). Empty for workloads with small images.
+	std::vector<float*> hostImageStaging;
+	std::vector<size_t> hostImageStagingArea;
+	std::vector<float*> hostDepthPriorStaging;
+	std::vector<size_t> hostDepthPriorStagingArea;
 };
 /*----------------------------------------------------------------*/
 

--- a/libs/MVS/SceneDensify.cpp
+++ b/libs/MVS/SceneDensify.cpp
@@ -2152,7 +2152,7 @@ bool Scene::ComputeDepthMaps(DenseDepthMapData& data)
 	// launches stay GPU-side-serialized via the cudaEvent_t chain.
 	if (!SEACAVE::CUDA::isCpuRequested(SEACAVE::CUDA::desiredDeviceIDs) && data.nFusionMode >= 0) {
 		const unsigned poolSize = (nMaxThreads > 1)
-			? std::clamp<unsigned>(OPTDENSE::nPatchMatchCUDAInstances, 1u, nMaxThreads)
+			? CLAMP(OPTDENSE::nPatchMatchCUDAInstances, 1u, nMaxThreads)
 			: 1u;
 		if (data.depthMaps.AllocateCudaPool(poolSize)) {
 			// raise the in-flight semaphore so all pool workers can run

--- a/libs/MVS/SceneDensify.cpp
+++ b/libs/MVS/SceneDensify.cpp
@@ -135,6 +135,10 @@ DepthMapsData::DepthMapsData(Scene& _scene)
 	:
 	scene(_scene),
 	arrDepthData(_scene.images.GetSize())
+	#ifdef _USE_CUDA
+	, pmCUDANextIdx((Thread::safe_t)-1)
+	, pmCUDAEpoch(0)
+	#endif // _USE_CUDA
 {
 } // constructor
 
@@ -510,8 +514,16 @@ DepthData DepthMapsData::ScaleDepthData(const DepthData& inputDeptData, float sc
 bool DepthMapsData::EstimateDepthMap(IIndex idxImage, int nGeometricIter)
 {
 	#ifdef _USE_CUDA
-	if (pmCUDA) {
-		pmCUDA->EstimateDepthMap(arrDepthData[idxImage]);
+	if (!pmCUDAPool.empty()) {
+		// claim a pool slot for this worker thread; epoch invalidates the claim
+		// across phase boundaries so re-used OS threads pick a fresh slot
+		static thread_local int s_slot = -1;
+		static thread_local Thread::safe_t s_epoch = (Thread::safe_t)-1;
+		if (s_slot < 0 || s_epoch != pmCUDAEpoch) {
+			s_slot = (int)(Thread::safeInc(pmCUDANextIdx) % (Thread::safe_t)pmCUDAPool.size());
+			s_epoch = pmCUDAEpoch;
+		}
+		pmCUDAPool[s_slot]->EstimateDepthMap(arrDepthData[idxImage]);
 		return true;
 	}
 	#endif // _USE_CUDA
@@ -1876,7 +1888,7 @@ void DepthMapsData::DenseFuseDepthMaps(PointCloud& pointcloud, bool bEstimateCol
 
 DenseDepthMapData::DenseDepthMapData(Scene& _scene, int _nFusionMode, float _fSampleMeshNeighbors) :
 	scene(_scene), depthMaps(_scene), idxImage(0), sem(1), nEstimationGeometricIter(-1),
-	nFusionMode(_nFusionMode), fSampleMeshNeighbors(_fSampleMeshNeighbors)
+	nFusionMode(_nFusionMode), fSampleMeshNeighbors(_fSampleMeshNeighbors), nDenseWorkers(2u)
 {
 	if (nFusionMode < 0) {
 		STEREO::SemiGlobalMatcher::CreateThreads(scene.nMaxThreads);
@@ -2101,13 +2113,29 @@ bool Scene::ComputeDepthMaps(DenseDepthMapData& data)
 	}
 
 	#ifdef _USE_CUDA
-	// initialize CUDA
+	// initialize CUDA: one PatchMatch instance per worker thread so the host-side
+	// prep (image upload, depth-prior packing, result unpack) actually parallelizes.
+	// Pool size is clamped to [1, nMaxThreads]; default 4 worker instances.
 	if (!SEACAVE::CUDA::isCpuRequested(SEACAVE::CUDA::desiredDeviceIDs) && data.nFusionMode >= 0) {
-		data.depthMaps.pmCUDA = new MVS::CUDA::PatchMatch();
-		if (SEACAVE::CUDA::devices.IsEmpty())
-			data.depthMaps.pmCUDA.Release();
-		else
-			data.depthMaps.pmCUDA->Init(false);
+		// probe-allocate first instance so initDevices runs and we can see whether the device init succeeded
+		auto probe = std::unique_ptr<MVS::CUDA::PatchMatch>(new MVS::CUDA::PatchMatch());
+		if (!SEACAVE::CUDA::devices.IsEmpty()) {
+			const size_t pmCUDAPoolSize = (nMaxThreads > 1)
+				? std::max<size_t>(1u, std::min<size_t>((size_t)OPTDENSE::nPatchMatchCUDAInstances, (size_t)nMaxThreads))
+				: 1u;
+			probe->Init(false);
+			data.depthMaps.pmCUDAPool.emplace_back(std::move(probe));
+			for (size_t k = 1; k < pmCUDAPoolSize; ++k) {
+				auto pm = std::unique_ptr<MVS::CUDA::PatchMatch>(new MVS::CUDA::PatchMatch());
+				pm->Init(false);
+				data.depthMaps.pmCUDAPool.emplace_back(std::move(pm));
+			}
+			data.depthMaps.pmCUDANextIdx = (Thread::safe_t)-1;
+			// raise the in-flight semaphore from 1 to pmCUDAPoolSize so all
+			// pool workers can run EstimateDepthMap concurrently
+			data.sem.Clear((unsigned)pmCUDAPoolSize);
+			data.nDenseWorkers = (unsigned)pmCUDAPoolSize;
+		}
 	}
 	#endif // _USE_CUDA
 
@@ -2122,8 +2150,15 @@ bool Scene::ComputeDepthMaps(DenseDepthMapData& data)
 	data.progress = new Util::Progress("Estimated depth-maps", data.images.GetSize());
 	GET_LOGCONSOLE().Pause();
 	if (nMaxThreads > 1) {
-		// multi-thread execution
-		cList<SEACAVE::Thread> threads(2);
+		// multi-thread execution: one thread per CUDA pool slot when CUDA is
+		// active, else preserve the historical 2-worker CPU configuration
+		#ifdef _USE_CUDA
+		const unsigned nDenseWorkers = data.depthMaps.pmCUDAPool.empty()
+			? 2u : (unsigned)data.depthMaps.pmCUDAPool.size();
+		#else
+		const unsigned nDenseWorkers = 2u;
+		#endif
+		cList<SEACAVE::Thread> threads(nDenseWorkers);
 		FOREACHPTR(pThread, threads)
 			pThread->start(DenseReconstructionEstimateTmp, (void*)&data);
 		FOREACHPTR(pThread, threads)
@@ -2139,10 +2174,15 @@ bool Scene::ComputeDepthMaps(DenseDepthMapData& data)
 
 	if (data.nFusionMode >= 0) {
 		#ifdef _USE_CUDA
-		// initialize CUDA
-		if (data.depthMaps.pmCUDA && OPTDENSE::nEstimationGeometricIters) {
-			data.depthMaps.pmCUDA->Release();
-			data.depthMaps.pmCUDA->Init(true);
+		// re-init each pool instance for the geom-consistency phase and bump
+		// the epoch so worker threads re-claim slots cleanly
+		if (!data.depthMaps.pmCUDAPool.empty() && OPTDENSE::nEstimationGeometricIters) {
+			for (auto& pm : data.depthMaps.pmCUDAPool) {
+				pm->Release();
+				pm->Init(true);
+			}
+			data.depthMaps.pmCUDANextIdx = (Thread::safe_t)-1;
+			Thread::safeInc(data.depthMaps.pmCUDAEpoch);
 		}
 		#endif // _USE_CUDA
 		while (++data.nEstimationGeometricIter < (int)OPTDENSE::nEstimationGeometricIters) {
@@ -2156,8 +2196,14 @@ bool Scene::ComputeDepthMaps(DenseDepthMapData& data)
 			data.progress = new Util::Progress("Geometric-consistent estimated depth-maps", data.images.GetSize());
 			GET_LOGCONSOLE().Pause();
 			if (nMaxThreads > 1) {
-				// multi-thread execution
-				cList<SEACAVE::Thread> threads(2);
+				// multi-thread execution: same worker count as the depth-map phase
+				#ifdef _USE_CUDA
+				const unsigned nDenseWorkers = data.depthMaps.pmCUDAPool.empty()
+					? 2u : (unsigned)data.depthMaps.pmCUDAPool.size();
+				#else
+				const unsigned nDenseWorkers = 2u;
+				#endif
+				cList<SEACAVE::Thread> threads(nDenseWorkers);
 				FOREACHPTR(pThread, threads)
 					pThread->start(DenseReconstructionEstimateTmp, (void*)&data);
 				FOREACHPTR(pThread, threads)
@@ -2230,8 +2276,11 @@ void Scene::DenseReconstructionEstimate(void* pData)
 			const EVTProcessImage& evtImage = *((EVTProcessImage*)(Event*)evt);
 			if (evtImage.idxImage >= data.images.size()) {
 				if (nMaxThreads > 1) {
-					// close working threads
-					data.events.AddEvent(new EVTClose);
+					// close working threads: broadcast one EVT_CLOSE per sibling.
+					// This worker exits below; each other worker consumes one event.
+					// (Old single-event pattern hung whenever nDenseWorkers > 2.)
+					for (unsigned k = 1; k < data.nDenseWorkers; ++k)
+						data.events.AddEvent(new EVTClose);
 				}
 				return;
 			}

--- a/libs/MVS/SceneDensify.cpp
+++ b/libs/MVS/SceneDensify.cpp
@@ -145,6 +145,40 @@ DepthMapsData::DepthMapsData(Scene& _scene)
 DepthMapsData::~DepthMapsData()
 {
 } // destructor
+
+#ifdef _USE_CUDA
+bool DepthMapsData::AllocateCudaPool(unsigned poolSize)
+{
+	ASSERT(pmCUDAPool.empty());
+	if (poolSize == 0)
+		poolSize = 1;
+	// PatchMatch's ctor triggers CUDA::initDevices() on first construction;
+	// build one to probe and check whether any device was actually picked up.
+	auto probe = std::make_unique<MVS::CUDA::PatchMatch>();
+	if (SEACAVE::CUDA::devices.IsEmpty())
+		return false;
+	probe->Init(false);
+	pmCUDAPool.reserve(poolSize);
+	pmCUDAPool.emplace_back(std::move(probe));
+	for (unsigned k = 1; k < poolSize; ++k) {
+		auto pm = std::make_unique<MVS::CUDA::PatchMatch>();
+		pm->Init(false);
+		pmCUDAPool.emplace_back(std::move(pm));
+	}
+	pmCUDANextIdx = (Thread::safe_t)-1;
+	return true;
+}
+
+void DepthMapsData::ReinitCudaPoolForGeom()
+{
+	for (auto& pm : pmCUDAPool) {
+		pm->Release();
+		pm->Init(true);
+	}
+	pmCUDANextIdx = (Thread::safe_t)-1;
+	Thread::safeInc(pmCUDAEpoch);
+}
+#endif // _USE_CUDA
 /*----------------------------------------------------------------*/
 
 // compute visibility for the reference image (the first image in "images")
@@ -2113,28 +2147,18 @@ bool Scene::ComputeDepthMaps(DenseDepthMapData& data)
 	}
 
 	#ifdef _USE_CUDA
-	// initialize CUDA: one PatchMatch instance per worker thread so the host-side
-	// prep (image upload, depth-prior packing, result unpack) actually parallelizes.
-	// Pool size is clamped to [1, nMaxThreads]; default 4 worker instances.
+	// One PatchMatch instance per worker thread; host-side prep (image upload,
+	// depth-prior packing, result unpack) then parallelizes while the kernel
+	// launches stay GPU-side-serialized via the cudaEvent_t chain.
 	if (!SEACAVE::CUDA::isCpuRequested(SEACAVE::CUDA::desiredDeviceIDs) && data.nFusionMode >= 0) {
-		// probe-allocate first instance so initDevices runs and we can see whether the device init succeeded
-		auto probe = std::unique_ptr<MVS::CUDA::PatchMatch>(new MVS::CUDA::PatchMatch());
-		if (!SEACAVE::CUDA::devices.IsEmpty()) {
-			const size_t pmCUDAPoolSize = (nMaxThreads > 1)
-				? std::max<size_t>(1u, std::min<size_t>((size_t)OPTDENSE::nPatchMatchCUDAInstances, (size_t)nMaxThreads))
-				: 1u;
-			probe->Init(false);
-			data.depthMaps.pmCUDAPool.emplace_back(std::move(probe));
-			for (size_t k = 1; k < pmCUDAPoolSize; ++k) {
-				auto pm = std::unique_ptr<MVS::CUDA::PatchMatch>(new MVS::CUDA::PatchMatch());
-				pm->Init(false);
-				data.depthMaps.pmCUDAPool.emplace_back(std::move(pm));
-			}
-			data.depthMaps.pmCUDANextIdx = (Thread::safe_t)-1;
-			// raise the in-flight semaphore from 1 to pmCUDAPoolSize so all
-			// pool workers can run EstimateDepthMap concurrently
-			data.sem.Clear((unsigned)pmCUDAPoolSize);
-			data.nDenseWorkers = (unsigned)pmCUDAPoolSize;
+		const unsigned poolSize = (nMaxThreads > 1)
+			? std::clamp<unsigned>(OPTDENSE::nPatchMatchCUDAInstances, 1u, nMaxThreads)
+			: 1u;
+		if (data.depthMaps.AllocateCudaPool(poolSize)) {
+			// raise the in-flight semaphore so all pool workers can run
+			// EstimateDepthMap concurrently
+			data.sem.Clear(poolSize);
+			data.nDenseWorkers = poolSize;
 		}
 	}
 	#endif // _USE_CUDA
@@ -2150,15 +2174,9 @@ bool Scene::ComputeDepthMaps(DenseDepthMapData& data)
 	data.progress = new Util::Progress("Estimated depth-maps", data.images.GetSize());
 	GET_LOGCONSOLE().Pause();
 	if (nMaxThreads > 1) {
-		// multi-thread execution: one thread per CUDA pool slot when CUDA is
-		// active, else preserve the historical 2-worker CPU configuration
-		#ifdef _USE_CUDA
-		const unsigned nDenseWorkers = data.depthMaps.pmCUDAPool.empty()
-			? 2u : (unsigned)data.depthMaps.pmCUDAPool.size();
-		#else
-		const unsigned nDenseWorkers = 2u;
-		#endif
-		cList<SEACAVE::Thread> threads(nDenseWorkers);
+		// data.nDenseWorkers is set to the CUDA pool size (or kept at the
+		// constructor default of 2 for the CPU path) before we get here.
+		cList<SEACAVE::Thread> threads(data.nDenseWorkers);
 		FOREACHPTR(pThread, threads)
 			pThread->start(DenseReconstructionEstimateTmp, (void*)&data);
 		FOREACHPTR(pThread, threads)
@@ -2174,16 +2192,8 @@ bool Scene::ComputeDepthMaps(DenseDepthMapData& data)
 
 	if (data.nFusionMode >= 0) {
 		#ifdef _USE_CUDA
-		// re-init each pool instance for the geom-consistency phase and bump
-		// the epoch so worker threads re-claim slots cleanly
-		if (!data.depthMaps.pmCUDAPool.empty() && OPTDENSE::nEstimationGeometricIters) {
-			for (auto& pm : data.depthMaps.pmCUDAPool) {
-				pm->Release();
-				pm->Init(true);
-			}
-			data.depthMaps.pmCUDANextIdx = (Thread::safe_t)-1;
-			Thread::safeInc(data.depthMaps.pmCUDAEpoch);
-		}
+		if (!data.depthMaps.pmCUDAPool.empty() && OPTDENSE::nEstimationGeometricIters)
+			data.depthMaps.ReinitCudaPoolForGeom();
 		#endif // _USE_CUDA
 		while (++data.nEstimationGeometricIter < (int)OPTDENSE::nEstimationGeometricIters) {
 			// initialize the queue of images to be geometric processed
@@ -2196,14 +2206,8 @@ bool Scene::ComputeDepthMaps(DenseDepthMapData& data)
 			data.progress = new Util::Progress("Geometric-consistent estimated depth-maps", data.images.GetSize());
 			GET_LOGCONSOLE().Pause();
 			if (nMaxThreads > 1) {
-				// multi-thread execution: same worker count as the depth-map phase
-				#ifdef _USE_CUDA
-				const unsigned nDenseWorkers = data.depthMaps.pmCUDAPool.empty()
-					? 2u : (unsigned)data.depthMaps.pmCUDAPool.size();
-				#else
-				const unsigned nDenseWorkers = 2u;
-				#endif
-				cList<SEACAVE::Thread> threads(nDenseWorkers);
+				// same worker count as the depth-map phase
+				cList<SEACAVE::Thread> threads(data.nDenseWorkers);
 				FOREACHPTR(pThread, threads)
 					pThread->start(DenseReconstructionEstimateTmp, (void*)&data);
 				FOREACHPTR(pThread, threads)
@@ -2395,6 +2399,7 @@ void Scene::DenseReconstructionEstimate(void* pData)
 			break; }
 
 		case EVT_SAVEDEPTHMAP: {
+			TD_TIMER_STARTD();
 			const EVTSaveDepthMap& evtImage = *((EVTSaveDepthMap*)(Event*)evt);
 			const IIndex idx = data.images[evtImage.idxImage];
 			DepthData& depthData(data.depthMaps.arrDepthData[idx]);
@@ -2410,13 +2415,21 @@ void Scene::DenseReconstructionEstimate(void* pData)
 				}
 			}
 			#endif
+			// capture identifiers before Release wipes depthData state
+			const IIndex viewID = depthData.GetView().GetID();
+			const int dmRows = depthData.depthMap.rows;
+			const int dmCols = depthData.depthMap.cols;
 			// save compute depth-map for this image
 			if (!depthData.depthMap.empty() &&
-				!depthData.Save(ComposeDepthFilePath(depthData.GetView().GetID(), data.nEstimationGeometricIter < 0 ? "dmap" : "geo.dmap")))
+				!depthData.Save(ComposeDepthFilePath(viewID, data.nEstimationGeometricIter < 0 ? "dmap" : "geo.dmap")))
 				exit(EXIT_FAILURE);
 			depthData.ReleaseImages();
 			depthData.Release();
 			data.progress->operator++();
+			// per-image save timing (gated at -v 2 so the default-verbose run
+			// is not dragged down by per-image logging when pool-size grows)
+			DEBUG_ULTIMATE("Depth-map %3u saved: %dx%d (%s)", viewID,
+				dmCols, dmRows, TD_TIMER_GET_FMT().c_str());
 			break; }
 
 		case EVT_CLOSE: {

--- a/libs/MVS/SceneDensify.h
+++ b/libs/MVS/SceneDensify.h
@@ -37,14 +37,11 @@
 
 #include "SemiGlobalMatcher.h"
 
-#include <memory>
-#include <vector>
-
 
 // S T R U C T S ///////////////////////////////////////////////////
 
 namespace MVS {
-	
+
 // Forward declarations
 class MVS_API Scene;
 #ifdef _USE_CUDA

--- a/libs/MVS/SceneDensify.h
+++ b/libs/MVS/SceneDensify.h
@@ -36,6 +36,10 @@
 // I N C L U D E S /////////////////////////////////////////////////
 
 #include "SemiGlobalMatcher.h"
+#include "../Common/Thread.h"
+
+#include <memory>
+#include <vector>
 
 
 // S T R U C T S ///////////////////////////////////////////////////
@@ -56,6 +60,11 @@ class MVS_API DepthMapsData
 public:
 	DepthMapsData(Scene& _scene);
 	~DepthMapsData();
+
+	// pmCUDAPool holds move-only std::unique_ptrs; explicitly forbid copy so the
+	// MSVC dllexport instantiator does not try to synthesize a copy constructor.
+	DepthMapsData(const DepthMapsData&) = delete;
+	DepthMapsData& operator=(const DepthMapsData&) = delete;
 
 	bool SelectViews(DepthData& depthData);
 	bool InitViews(DepthData& depthData, IIndex idxNeighbor, IIndex numNeighbors, bool loadImages, int loadDepthMaps);
@@ -92,8 +101,14 @@ public:
 	DepthEstimator::MapRefArr coordsTrg; // ... same for target image
 
 	#ifdef _USE_CUDA
-	// used internally to estimate the depth-maps using CUDA
-	CAutoPtr<MVS::CUDA::PatchMatch> pmCUDA;
+	// One PatchMatch instance per worker thread; each worker claims a slot via
+	// thread-local index gated by pmCUDAEpoch. Lets the {UploadCameras + kernel
+	// launch} window stay mutex-serialized via the global event chain while the
+	// per-instance host prep (image upload, depth-prior packing, result unpack)
+	// runs lock-free in parallel across the SceneDensify ThreadPool workers.
+	std::vector<std::unique_ptr<MVS::CUDA::PatchMatch>> pmCUDAPool;
+	mutable volatile Thread::safe_t pmCUDANextIdx;
+	mutable volatile Thread::safe_t pmCUDAEpoch;
 	#endif // _USE_CUDA
 };
 /*----------------------------------------------------------------*/
@@ -111,6 +126,11 @@ struct MVS_API DenseDepthMapData {
 	int nFusionMode;
 	float fSampleMeshNeighbors;
 	STEREO::SemiGlobalMatcher sgm;
+	// number of workers in the dense-reconstruction ThreadPool; set by
+	// DenseReconstruction once the CUDA pool size is known. Used by the worker
+	// EVT_PROCESSIMAGE handler to broadcast EVT_CLOSE to all sibling workers
+	// (the old single-EVT_CLOSE pattern hung when nWorkers > 2).
+	unsigned nDenseWorkers;
 
 	DenseDepthMapData(Scene& _scene, int _nFusionMode=0, float _fSampleMeshNeighbors=0);
 	~DenseDepthMapData();

--- a/libs/MVS/SceneDensify.h
+++ b/libs/MVS/SceneDensify.h
@@ -36,7 +36,6 @@
 // I N C L U D E S /////////////////////////////////////////////////
 
 #include "SemiGlobalMatcher.h"
-#include "../Common/Thread.h"
 
 #include <memory>
 #include <vector>
@@ -70,6 +69,17 @@ public:
 	bool InitViews(DepthData& depthData, IIndex idxNeighbor, IIndex numNeighbors, bool loadImages, int loadDepthMaps);
 	bool InitDepthMap(DepthData& depthData);
 	bool EstimateDepthMap(IIndex idxImage, int nGeometricIter);
+
+	#ifdef _USE_CUDA
+	// Construct poolSize PatchMatch instances ready for the depth-map phase.
+	// First construction probes CUDA::initDevices(); returns false if the
+	// device set is still empty afterwards (caller falls back to CPU).
+	bool AllocateCudaPool(unsigned poolSize);
+	// Tear down per-instance state and re-init for the geometric-consistency
+	// phase, resetting the slot counter and bumping the epoch so worker threads
+	// re-claim slots cleanly even if the OS reuses them across the boundary.
+	void ReinitCudaPoolForGeom();
+	#endif // _USE_CUDA
 
 	bool RemoveSmallSegments(DepthData& depthData);
 	bool GapInterpolation(DepthData& depthData);


### PR DESCRIPTION
## Summary

Parallelizes the PatchMatch CUDA path in dense reconstruction. On a 3796-image / 4K dataset wall time drops ~33% (44m43s -> ~30m); on the 12-image garagedoor smoke test 2.1s -> 1.2s. Fused-point count delta <0.5% (parallel non-determinism).

The fix is a stack of five changes that compound:

- **Narrow the kernel-launch mutex** to cover only `RunCUDA()`, not all of `EstimateDepthMap` — host-side prep (image load, neighbor selection, depth-prior packing) runs lock-free.
- **Per-instance `cudaStream_t`** lazily created on first `EstimateDepthMap` call (the dense-recon worker thread differs from the constructor's), replacing the default stream for every `cudaMemcpy*Async` and kernel launch.
- **Chain `__constant__` writes via a `cudaEvent_t`** so cross-instance ordering on module-global constant memory is preserved without holding a host mutex across the kernel.
- **Per-worker `PatchMatchCUDA` pool** sized via the new `--patch-match-cuda-instances` CLI / `OPTDENSE::nPatchMatchCUDAInstances` config (default 4, clamped to `nMaxThreads`). Workers claim a slot via a thread-local index gated by an epoch counter so slot ownership resets cleanly between the depth-map and geometric-consistency phases. The dense `ThreadPool` and the `data.sem` capacity are raised to match.
- **Pinned host staging for H->D image and depth-prior uploads** above 1.5 MP. `cv::Mat` sources for `cudaMemcpy2DToArrayAsync` are pageable; the driver was synchronously bouncing through its internal pinned buffer. A per-instance `StagedUploadCvMat` allocates `cudaHostAlloc` slots on demand and reuses them across scales (safe because `RunCUDA` ends with `cudaStreamSynchronize`).

Quality and correctness are unchanged. Geometric-consistency phase uses the same pool size; spurious cached `.dmap` files from prior runs still need to be cleared between resolution-level changes (unrelated, longstanding).

## Test plan

- [x] Smoke test: 12-image garagedoor scene completes, point count matches baseline within parallel-non-determinism noise
- [x] Large scene: 3796-image scene completes ~30% faster, fused point count within 0.5% of baseline
- [x] `--patch-match-cuda-instances 1` reproduces single-threaded behavior (degenerate pool)
- [x] Geometric-consistency phase parallelism verified (same `data.nDenseWorkers` count)
- [ ] CI build on Linux + Windows