### PR TITLE
TextureMesh: export vertex-colored PLY meshes

### DIFF
--- a/apps/TextureMesh/TextureMesh.cpp
+++ b/apps/TextureMesh/TextureMesh.cpp
@@ -69,6 +69,7 @@ int nProcessPriority;
 unsigned nMaxThreads;
 int nMaxTextureSize;
 bool bExportTextureLossless;
+bool bVertexColors;
 String strExportType;
 String strConfigFileName;
 boost::program_options::variables_map vm;
@@ -133,6 +134,7 @@ bool Application::Initialize(size_t argc, LPCTSTR* argv)
 		("ignore-mask-label", boost::program_options::value(&OPT::nIgnoreMaskLabel)->default_value(-1), "label value to ignore in the image mask, stored in the MVS scene or next to each image with '.mask.png' extension (-1 - auto estimate mask for lens distortion, -2 - disabled)")
 		("max-texture-size", boost::program_options::value(&OPT::nMaxTextureSize)->default_value(8192), "maximum texture size, split it in multiple textures of this size if needed (0 - unbounded)")
 		("export-texture-lossless", boost::program_options::value(&OPT::bExportTextureLossless)->default_value(true), "save the texture as PNG (lossless) or JPG (smaller, lossy) when exporting to PLY")
+		("vertex-colors", boost::program_options::value(&OPT::bVertexColors)->default_value(false), "export a PLY mesh with per-vertex colors sampled from the selected source images instead of generating texture atlases")
 		;
 
 	// hidden options, allowed both on command line and
@@ -204,6 +206,8 @@ bool Application::Initialize(size_t argc, LPCTSTR* argv)
 		OPT::strMeshFileName = Util::getFileFullName(OPT::strInputFileName) + _T(".ply");
 	if (OPT::strOutputFileName.empty())
 		OPT::strOutputFileName = Util::getFileFullName(OPT::strInputFileName) + _T("_texture.mvs");
+	if (OPT::bVertexColors)
+		OPT::strExportType = _T(".ply");
 
 	MVS::Initialize(APPNAME, OPT::nMaxThreads, OPT::nProcessPriority);
 	return true;
@@ -299,6 +303,15 @@ int main(int argc, LPCTSTR* argv)
 	IIndexArr views;
 	if (!OPT::strViewsFileName.empty())
 		views = ParseViewsFile(MAKE_PATH_SAFE(OPT::strViewsFileName), scene);
+
+	if (OPT::bVertexColors) {
+		TD_TIMER_START();
+		if (!scene.ExportMeshVertexColors(baseFileName+OPT::strExportType, OPT::nResolutionLevel, OPT::nMinResolution, OPT::minCommonCameras,
+										  OPT::fOutlierThreshold, OPT::fRatioDataSmoothness, Pixel8U(OPT::nColEmpty), OPT::nIgnoreMaskLabel, views))
+			return EXIT_FAILURE;
+		VERBOSE("Mesh vertex coloring completed: %u vertices, %u faces (%s)", scene.mesh.vertices.GetSize(), scene.mesh.faces.GetSize(), TD_TIMER_GET_FMT().c_str());
+		return EXIT_SUCCESS;
+	}
 
 	// compute mesh texture
 	TD_TIMER_START();

--- a/libs/MVS/Scene.h
+++ b/libs/MVS/Scene.h
@@ -163,6 +163,9 @@ public:
 	bool TextureMesh(unsigned nResolutionLevel, unsigned nMinResolution, unsigned minCommonCameras=0, float fOutlierThreshold=0.f, float fRatioDataSmoothness=0.3f,
 		bool bGlobalSeamLeveling=true, bool bLocalSeamLeveling=true, unsigned nTextureSizeMultiple=0, Pixel8U colEmpty=Pixel8U(255,127,39),
 		float fSharpnessWeight=0.5f, int ignoreMaskLabel=-1, int maxTextureSize=0, const IIndexArr& views=IIndexArr());
+	bool ExportMeshVertexColors(const String& fileName, unsigned nResolutionLevel, unsigned nMinResolution, unsigned minCommonCameras=0,
+		float fOutlierThreshold=0.f, float fRatioDataSmoothness=0.3f, Pixel8U colEmpty=Pixel8U(255,127,39),
+		int ignoreMaskLabel=-1, const IIndexArr& views=IIndexArr());
 
 	// Reconstruction quality assessment
 	struct Score {

--- a/libs/MVS/SceneTexture.cpp
+++ b/libs/MVS/SceneTexture.cpp
@@ -2458,8 +2458,12 @@ static bool SaveVertexColoredMeshPLY(const Mesh& mesh, const MeshTexture::Colors
 	FOREACH(i, mesh.vertices) {
 		const Mesh::Vertex& vertex = mesh.vertices[i];
 		const float coords[3] = { (float)vertex.x, (float)vertex.y, (float)vertex.z };
-		const MeshTexture::Color& color = colors[i];
-		const uint8_t rgb[3] = { ColorToU8(color.x), ColorToU8(color.y), ColorToU8(color.z) };
+		const Pixel8U color(Pixel8U::Pnt(
+			ColorToU8(colors[i].x),
+			ColorToU8(colors[i].y),
+			ColorToU8(colors[i].z)
+		));
+		const uint8_t rgb[3] = { color.r, color.g, color.b };
 		stream.write((const char*)coords, sizeof(coords));
 		stream.write((const char*)rgb, sizeof(rgb));
 	}

--- a/libs/MVS/SceneTexture.cpp
+++ b/libs/MVS/SceneTexture.cpp
@@ -32,6 +32,7 @@
 #include "Common.h"
 #include "Scene.h"
 #include "AtlasPacker.h"
+#include <fstream>
 // connected components
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/connected_components.hpp>
@@ -2425,6 +2426,112 @@ bool Scene::TextureMesh(unsigned nResolutionLevel, unsigned nMinResolution, unsi
 
 	return true;
 } // TextureMesh
+
+static inline uint8_t ColorToU8(float value)
+{
+	return (uint8_t)CLAMP(ROUND2INT(value), 0, 255);
+}
+
+static bool SaveVertexColoredMeshPLY(const Mesh& mesh, const MeshTexture::Colors& colors, const String& fileName)
+{
+	ASSERT(!fileName.empty());
+	ASSERT(colors.size() == mesh.vertices.size());
+	Util::ensureFolder(fileName);
+
+	std::ofstream stream(fileName, std::ios::binary);
+	if (!stream)
+		return false;
+
+	stream << "ply\n";
+	stream << "format binary_little_endian 1.0\n";
+	stream << "element vertex " << mesh.vertices.size() << "\n";
+	stream << "property float x\n";
+	stream << "property float y\n";
+	stream << "property float z\n";
+	stream << "property uchar red\n";
+	stream << "property uchar green\n";
+	stream << "property uchar blue\n";
+	stream << "element face " << mesh.faces.size() << "\n";
+	stream << "property list uchar uint vertex_indices\n";
+	stream << "end_header\n";
+
+	FOREACH(i, mesh.vertices) {
+		const Mesh::Vertex& vertex = mesh.vertices[i];
+		const float coords[3] = { (float)vertex.x, (float)vertex.y, (float)vertex.z };
+		const MeshTexture::Color& color = colors[i];
+		const uint8_t rgb[3] = { ColorToU8(color.x), ColorToU8(color.y), ColorToU8(color.z) };
+		stream.write((const char*)coords, sizeof(coords));
+		stream.write((const char*)rgb, sizeof(rgb));
+	}
+	const uint8_t numVertices(3);
+	FOREACHPTR(pFace, mesh.faces) {
+		const uint32_t indices[3] = { (uint32_t)(*pFace)[0], (uint32_t)(*pFace)[1], (uint32_t)(*pFace)[2] };
+		stream.write((const char*)&numVertices, sizeof(numVertices));
+		stream.write((const char*)indices, sizeof(indices));
+	}
+	return stream.good();
+}
+
+bool Scene::ExportMeshVertexColors(const String& fileName, unsigned nResolutionLevel, unsigned nMinResolution, unsigned minCommonCameras,
+	float fOutlierThreshold, float fRatioDataSmoothness, Pixel8U colEmpty, int nIgnoreMaskLabel, const IIndexArr& views)
+{
+	if (mesh.IsEmpty())
+		return false;
+
+	MeshTexture texture(*this, nResolutionLevel, nMinResolution);
+	TD_TIMER_STARTD();
+	if (!texture.FaceViewSelection(minCommonCameras, fOutlierThreshold, fRatioDataSmoothness, nIgnoreMaskLabel, views))
+		return false;
+	DEBUG_EXTRA("Assigning the best view to each face completed: %u faces, %u patches (%s)", mesh.faces.size(), texture.texturePatches.size(), TD_TIMER_GET_FMT().c_str());
+
+	MeshTexture::Colors vertexColors(mesh.vertices.size());
+	vertexColors.Memset(0);
+	FloatArr vertexWeights(mesh.vertices.size());
+	vertexWeights.Memset(0);
+	const MeshTexture::Color emptyColor(colEmpty);
+	const unsigned numPatches(texture.texturePatches.size() > 0 ? texture.texturePatches.size()-1 : 0);
+	for (unsigned idxPatch=0; idxPatch<numPatches; ++idxPatch) {
+		const MeshTexture::TexturePatch& texturePatch = texture.texturePatches[idxPatch];
+		if (texturePatch.label == NO_ID)
+			continue;
+		Image& imageData = images[texturePatch.label];
+		if (imageData.image.empty()) {
+			unsigned level(nResolutionLevel);
+			const unsigned imageSize(imageData.RecomputeMaxResolution(level, nMinResolution));
+			if (!imageData.ReloadImage(imageSize))
+				continue;
+			imageData.UpdateCamera(platforms);
+		}
+		for (const FIndex idxFace: texturePatch.faces) {
+			const Face& face = mesh.faces[idxFace];
+			const float weight(MAXF((float)mesh.ComputeArea(idxFace), 1e-6f));
+			for (int v=0; v<3; ++v) {
+				const VIndex idxVertex(face[v]);
+				const auto [pt, depth] = imageData.camera.ProjectPointP(mesh.vertices[idxVertex]);
+				if (depth <= 0 || !imageData.image.isInside(pt))
+					continue;
+				vertexColors[idxVertex] += MeshTexture::Color(imageData.image.sampleSafe(pt)) * weight;
+				vertexWeights[idxVertex] += weight;
+			}
+		}
+	}
+
+	FOREACH(i, vertexColors) {
+		if (vertexWeights[i] > 0)
+			vertexColors[i] *= INVERT(vertexWeights[i]);
+		else
+			vertexColors[i] = emptyColor;
+	}
+
+	{
+	TD_TIMER_STARTD();
+	if (!SaveVertexColoredMeshPLY(mesh, vertexColors, fileName))
+		return false;
+	DEBUG_EXTRA("Vertex-colored mesh '%s' saved: %u vertices, %u faces (%s)",
+		Util::getFileNameExt(fileName).c_str(), mesh.vertices.size(), mesh.faces.size(), TD_TIMER_GET_FMT().c_str());
+	}
+	return true;
+} // ExportMeshVertexColors
 /*----------------------------------------------------------------*/
 
 #pragma pop_macro("VERBOSE")


### PR DESCRIPTION
This adds a `TextureMesh --vertex-colors` mode for exporting a PLY mesh with per-vertex RGB colors.

This is related to the older vertex-coloring proposal in #424, but takes a smaller export-only approach:

 - does not add persistent vertex colors to `Mesh`
 - does not change `Mesh::SavePLY`
 - does not generate a texture atlas
 - samples source image colors directly at mesh vertices after face best-view assignment
 - averages multiple contributing face/view samples per vertex, weighted by face area, instead of letting the last sampled face overwrite the vertex color

The tradeoff is that this does not currently use seam leveling/exposure correction from the full texture-atlas pipeline. The intended use is a lightweight colored PLY export when a full texture atlas is unnecessary or too expensive.

The PLY writer outputs standard `red`, `green`, `blue` uchar vertex properties in RGB order.