### PR TITLE
OBJ: Remove incorrect transparency on material

### DIFF
--- a/libs/IO/OBJ.cpp
+++ b/libs/IO/OBJ.cpp
@@ -66,7 +66,6 @@ bool ObjModel::MaterialLib::Save(const String& prefix, bool texLossless) const
 			<< "Ka 1.000000 1.000000 1.000000" << "\n"
 			<< "Kd " << mat.Kd.r << " " << mat.Kd.g << " " << mat.Kd.b << "\n"
 			<< "Ks 0.000000 0.000000 0.000000" << "\n"
-			<< "Tr 1.000000" << "\n"
 			<< "illum 1" << "\n"
 			<< "Ns 1.000000" << "\n";
 		// save material maps


### PR DESCRIPTION
The OBJ MTL writer defaults to writing a fully _transparent_ material rather than an opaque one:
```
newmtl material_00
Ka 1.000000 1.000000 1.000000
Kd 1 1 1
Ks 0.000000 0.000000 0.000000
Tr 1.000000  # <- wrong
illum 1
Ns 1.000000
map_Kd
```
The spec default when Tr is not specified is `0.`, so this PR just removes this declaration entirely.

I ran into this with a downstream post-processor converting OBJs to GLBs and the post-processor made the materials transparent.