### PR TITLE
texture: honor ignore-mask-label instead of uninitialized OPTDENSE global

### DIFF
--- a/libs/MVS/SceneTexture.cpp
+++ b/libs/MVS/SceneTexture.cpp
@@ -552,7 +552,10 @@ bool MeshTexture::ListCameraFaces(FaceDataViewArr& facesDatas, float fOutlierThr
 		if (nIgnoreMaskLabel >= 0) {
 			// import mask
 			BitMatrix bmask;
-			DepthEstimator::ImportIgnoreMask(imageData, fullSize, (uint8_t)OPTDENSE::nIgnoreMaskLabel, bmask, &rasterer.mask);
+			// use the label passed by the caller: the OPTDENSE config is not
+			// initialized in the TextureMesh app, so its global would be 0 here,
+			// inverting the mask (only label-marked pixels would remain valid)
+			DepthEstimator::ImportIgnoreMask(imageData, fullSize, (uint8_t)nIgnoreMaskLabel, bmask, &rasterer.mask);
 		} else if (nIgnoreMaskLabel == -1) {
 			// creating mask to discard invalid regions created during image radial undistortion
 			rasterer.mask = DetectInvalidImageRegions(imageData.image);


### PR DESCRIPTION
## Problem

`TextureMesh --ignore-mask-label N` (N >= 0) produces an **inverted** result: the atlas is textured exclusively from the regions the mask asked to ignore, and every unmasked region is discarded.

## Root cause

`MeshTexture::ListCameraFaces` gates the mask import on its `nIgnoreMaskLabel` parameter (the CLI value), but then passes `OPTDENSE::nIgnoreMaskLabel` to `DepthEstimator::ImportIgnoreMask`:

```cpp
if (nIgnoreMaskLabel >= 0) {
    BitMatrix bmask;
    DepthEstimator::ImportIgnoreMask(imageData, fullSize, (uint8_t)OPTDENSE::nIgnoreMaskLabel, bmask, &rasterer.mask);
}
```

The TextureMesh app never initializes the OPTDENSE config, so the global is zero-initialized. `ImportIgnoreMask` then computes the validity mask as `(mask != 0)`: background pixels (0) are invalidated, and only pixels carrying the ignore label survive — an exact inversion of the intended behavior. DensifyPointCloud is unaffected because its app writes the OPTDENSE config before use.

## Repro

Per-image `.mask.png` files (person = 255, background = 0) on a 360-view indoor capture, `--ignore-mask-label 255`: the produced 4096 atlas contained **only the masked-out person**. With this one-argument fix, the same scene textures correctly with the person fully excluded (verified on macOS arm64, develop @ 69b25a3, OpenCV 4.14).

## Fix

Pass the function's own `nIgnoreMaskLabel` parameter through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)