### PR TITLE
feat: Implement A|B compare view with swipe and split modes

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -33,6 +33,7 @@ jobs:
     name: Build on ${{ matrix.os }}
     if: github.event_name != 'schedule'
     runs-on: ${{ matrix.os }}
+    timeout-minutes: ${{ matrix.timeout-minutes }}
     # packages:write is needed to push vcpkg binary cache to GitHub Packages NuGet
     # feed (see VCPKG_BINARY_SOURCES configuration). contents:read is the default.
     permissions:
@@ -47,16 +48,19 @@ jobs:
             build-type: Release
             cmake-extra-args: -A x64
             artifact-name: OpenMVS_Windows_Release_x64
+            timeout-minutes: 480
           - os: ubuntu-latest
             triplet: x64-linux-release
             build-type: Release
             cmake-extra-args: -G Ninja
             artifact-name: OpenMVS_Ubuntu_Release_x64
+            timeout-minutes: 360
           - os: macos-latest
             triplet: arm64-osx
             build-type: Release
             cmake-extra-args: -G Ninja
             artifact-name: OpenMVS_macOS_Release_arm64
+            timeout-minutes: 360
     env:
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}
       BUILD_CONFIG: ${{ matrix.build-type }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -33,7 +33,6 @@ jobs:
     name: Build on ${{ matrix.os }}
     if: github.event_name != 'schedule'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: ${{ matrix.timeout-minutes }}
     # packages:write is needed to push vcpkg binary cache to GitHub Packages NuGet
     # feed (see VCPKG_BINARY_SOURCES configuration). contents:read is the default.
     permissions:
@@ -46,21 +45,18 @@ jobs:
           - os: windows-latest
             triplet: x64-windows-release
             build-type: Release
-            cmake-extra-args: -A x64
+            cmake-extra-args: -A x64 -DOpenMVS_MSVC_FAST_RELEASE=ON
             artifact-name: OpenMVS_Windows_Release_x64
-            timeout-minutes: 480
           - os: ubuntu-latest
             triplet: x64-linux-release
             build-type: Release
             cmake-extra-args: -G Ninja
             artifact-name: OpenMVS_Ubuntu_Release_x64
-            timeout-minutes: 360
           - os: macos-latest
             triplet: arm64-osx
             build-type: Release
             cmake-extra-args: -G Ninja
             artifact-name: OpenMVS_macOS_Release_arm64
-            timeout-minutes: 360
     env:
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}
       BUILD_CONFIG: ${{ matrix.build-type }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,8 +76,10 @@ VERBOSE("Info: %s", str);   // General logging
 ```
 
 ### Error Handling
-- `ASSERT(condition)` for debug checks
-- Return false/NULL for failures
+- Use `ASSERT(condition)` for impossible or disallowed internal states. Do not add a runtime guard that lets execution continue with an invalid state.
+- If an assertion can be reached, fix the caller or state transition that violated the invariant; do not hide the defect with a fallback.
+- Use runtime validation and return false/NULL only for expected, recoverable failures such as invalid external input or unavailable resources.
+- `ASSERT` also communicates its invariant to MSVC Code Analysis; do not add separate analyzer assumptions at call sites.
 
 ### Common Typedefs
 ```cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ OPTION(OpenMVS_MAX_CUDA_COMPATIBILITY "Build for maximum CUDA device compatibili
 OPTION(OpenMVS_ENABLE_IPO "Whether to enable interprocedural optimization" ON)
 OPTION(OpenMVS_ENABLE_TESTS "Enable test code" ON)
 OPTION(OpenMVS_HEADLESS_DEBUG "Print asserts to stderr and continue; do not redirect cout/cerr or pop modal dialogs (for CI / non-interactive debug runs)" OFF)
+OPTION(OpenMVS_MSVC_FAST_RELEASE "Compile MVS Camera.cpp and Scene.cpp without optimization in MSVC Release builds" OFF)
 
 # Disable CUDA on MacOS
 IF(APPLE)

--- a/apps/Viewer/AGENTS.md
+++ b/apps/Viewer/AGENTS.md
@@ -8,8 +8,11 @@ Interactive 3D visualization and workflow execution tool for OpenMVS scenes. Liv
 
 ```
 Scene (top-level container)
-├── MVS::Scene          — core photogrammetry data
-├── ImageArr            — valid scene photographs
+├── LayerArr            — independently visible scene/geometry layers
+│   └── Layer
+│       ├── MVS::Scene  — core photogrammetry data
+│       ├── ImageArr    — valid photographs for this layer
+│       └── appearance, bounds, working folder, dirty/uncertainty state
 ├── Window              — GLFW window + event loop
 │   ├── Camera          — view/projection matrices, perspective/orthographic
 │   ├── Renderer        — OpenGL rendering, GPU buffers, shaders, picker FBO
@@ -48,13 +51,14 @@ main() [Viewer.cpp]
 Use `Window::RequestRedraw()` to post a GLFW event that wakes the wait-for-events loop.
 
 ### Background Worker
-`Scene::thread` processes `Scene::events` queue for async workflow execution. Workflow results are finalized on the main thread via `CheckWorkflowCompletion()` → `FinalizeWorkflow()`.
+`Scene::thread` processes `Scene::events` for async workflow and image-load execution. Workflows are tied to a stable layer ID; results are finalized on the main thread via `CheckWorkflowCompletion()` → `FinalizeWorkflow()`. Layer-container mutation is disabled while background work holds layer/image references.
 
 ## Rendering Pipeline
 
 ### Data Upload (CPU → GPU)
-- `UploadPointCloud(MVS::PointCloud, normalLength)` — points + optional normals
-- `UploadMesh(MVS::Mesh)` — vertices, faces, normals, texcoords, sub-mesh partitioning
+- `UploadLayers(Scene, Window)` — refresh all visible layer geometry
+- `UploadPointClouds(Scene, normalLength)` — aggregate visible points + optional normals
+- `UploadMeshes(Scene)` — aggregate visible meshes, normals, texcoords, and texture partitions
 - `UploadCameras(Window)` — camera frustum line geometry
 - `UploadUncertaintyEllipsoids(Window)` — per-camera pose-uncertainty solid shaded ellipsoids
 - `UploadSelection(Window)` — highlighted primitive geometry
@@ -84,12 +88,13 @@ layer flags (`c`, `b`, ...) therefore apply to the capture.
 ### Pose-Uncertainty Ellipsoids
 `Scene::LoadPoseUncertainty(csv)` (triggered by `--pose-quality-file`) parses a CreateStructure
 pose-quality report, matches rows to scene images by ID (`scene.images[image.idx].ID` — preserved
-from the SFM scene by ExportMVS), and fills `Scene::cameraUncertainty` (per VIEWER-image index).
+from the SFM scene by ExportMVS), and fills the active `Layer::cameraUncertainty` array (per
+VIEWER-image index). Visible layers with reports are rendered together.
 `UploadUncertaintyEllipsoids` eigen-decomposes each 3x3 position covariance into an oriented
 solid (triangulated UV-sphere) ellipsoid at the camera center, scaled by
 `cameraUncertaintyAutoScale * Window::uncertaintyEllipsoidScale` (scene auto-fit base times the user
 slider) and colored via the jet colormap normalized to the 95th-percentile sigma
-(`cameraUncertaintyNorm`). It is drawn by `ellipsoidShader` (lit head-light shading + per-vertex color)
+(`Layer::cameraUncertaintyNorm`). It is drawn by `ellipsoidShader` (lit head-light shading + per-vertex color)
 as a translucent surface — blended, depth-tested but not depth-writing, so the camera frustum at the
 center stays visible. `LoadPoseUncertainty` AUTO-SETS `cameraUncertaintyAutoScale` — kept SEPARATE from
 the user-facing `Window::uncertaintyEllipsoidScale` (which multiplies it, defaulting to x1) so the
@@ -110,7 +115,20 @@ magnification slider in Render Settings; per-axis sigmas shown for the selected 
 Off-screen FBO with `R32UI` color texture + depth renderbuffer. `PickPrimitiveAt(screenPos, radius)` renders primitive IDs, reads back to identify clicked point/triangle/camera. Returns index + triangle corner points + is-point flag.
 
 ### Sub-Mesh Management
-Meshes are partitioned by texture into sub-meshes via `mapFaceSubsetIndices`/`mapSubsetFaceIndices`/`meshFaceCounts`. Each sub-mesh can be independently toggled visible (`Window::meshSubMeshVisible`).
+Visible meshes are packed into shared GPU buffers. `meshFaceCounts` stores cumulative sub-mesh face offsets, `meshTextureIndices` selects each sub-mesh's texture (or `NO_ID`), and layer-local/global face maps preserve picking and selection after texture-based face reordering. Each sub-mesh can be independently toggled via `Window::meshSubMeshVisible`.
+
+### Compare View (A|B)
+`Window::compareMode` renders side-A layers left and side-B layers right of a vertical divider in one of two modes:
+
+- **Swipe** (`COMPARE_SWIPE`): both passes share the full-window projection and differ only by the scissor rectangle and the renderer layer pass filter (`Renderer::SetLayerPassFilter`), so aligned scenes line up pixel-exact across the draggable divider (`Window::compareSplitPos`).
+- **Split** (`COMPARE_SPLIT`): two equal side-by-side viewports (`Window::GetCompareViewport`), each pass rendered with its own half-window projection (`Renderer::UpdateViewProjection` re-primes the view-projection UBO per pass), so each scene appears centered in its own full frustum.
+
+Camera synchronization (`Window::compareSyncCameras`, default on) renders both sides from the same `Camera` object, so the views cannot drift apart. Unchecking it copies the current view into a second camera (`Window::cameraB`, driven by a second `ArcballControls`) and routes mouse input to the camera of the viewport under the cursor — the side is latched at button-press (`compareDragSide`) so a drag crossing the divider never switches cameras mid-gesture, and cursor positions are normalized into the side's viewport NDC. The main `camera` always renders the ACTIVE layer's side (poses are swapped when the active layer changes sides, see `Window::UpdateCompareState`), which keeps every active-layer interaction (selection, bbox edit, camera view mode, overlays) on the main camera and thus correct by construction; `Window::GetSize()` reports the framebuffer size independently of the (possibly half-window) camera viewport size.
+
+Per-layer GPU buffer sub-ranges (points, normals, camera EBO point/line blocks, ellipsoid slots, per-sub-mesh layer IDs) make the filtered passes cheap draw-call subsets, with no re-upload when sides change. Active-layer extras (selection, bounds, bbox gizmos, image overlay) draw only in the pass showing the active layer; `PickPrimitiveAt` restricts the pick pass to the layers displayed under the cursor and rasterizes it with that side's camera and viewport. Side assignment lives in `Layer::compareRight` (Layers panel A/B buttons; enabling compare defaults the active layer to A, the rest to B; switching between swipe and split keeps the assignment).
+
+### Layer Alignment
+`Scene::AlignLayersToActive()` moves every other layer onto the active layer with a similarity transform (`SimilarityTransform` + `DecomposeSimilarityTransform` from libs/Math, applied via `MVS::Scene::Transform`) estimated from camera centers matched by photo file name, falling back to the preserved SFM image ID. Requires ≥3 shared cameras per layer; aligned layers are marked dirty and all render data is re-uploaded while the current viewpoint is kept.
 
 ## Shader System
 
@@ -152,20 +170,20 @@ Three selection shapes: BOX (rectangular), LASSO (free-form polygon), CIRCLE. Th
 
 ## Selection & Picking
 
-**Single-click picking**: Renderer FBO renders primitive IDs → readback identifies SEL_POINT, SEL_TRIANGLE, or SEL_CAMERA.
+**Single-click picking**: Renderer FBO renders primitive IDs → readback identifies the owning layer and local point/face index; camera cone picking also scans visible layers. Selecting geometry in another layer activates that layer.
 
-**Multi-select**: SelectionController classifies visible point cloud points and mesh triangles against 2D selection region. Results stored in `Window::selectionIdx`.
+**Multi-select**: SelectionController classifies the active visible layer's point cloud points and mesh triangles against the 2D selection region. Results are stored as active-layer-local indices in `Window::selectionIdx`.
 
 **Actions on selection**: `Scene::RemoveSelectedGeometry()` deletes selected points/triangles. `Scene::SetROIFromSelection()` sets region-of-interest from selection. `Scene::CropToPoints()` extracts sub-scene from selected points.
 
-**Index mapping**: `Scene::ImageIdxMVS2Viewer()` converts between MVS image indices and Viewer-local image array indices (which skip invalid images).
+**Index mapping**: `Scene::ImageIdxMVS2Viewer()` converts between active-layer MVS image indices and Viewer-local image indices (which skip invalid images).
 
 ## UI System
 
 ImGui with docking support, GLFW/OpenGL3 backends, persistent `.ini` settings.
 
 ### Panels
-- Scene info, camera controls, selection controls, render settings
+- Layers (visibility/solo/active, compare off/swipe/split with A|B sides and camera sync, align-to-active), scene info, camera controls, selection controls, render settings
 - Console overlay (log output), performance overlay (frame stats)
 - Viewport overlay, selection overlay
 
@@ -191,13 +209,14 @@ Async MVS pipeline stages executable from the Viewer UI:
 | TextureMesh | `TextureMeshWorkflowOptions` | `resolutionLevel`, `ratioDataSmoothness`, `globalSeamLeveling`, `maxTextureSize` |
 
 ### State Machine
-`WorkflowState`: IDLE → RUNNING → COMPLETED / FAILED. Tracked via atomics (`workflowState`, `currentWorkflowType`, `geometryModified`). `workflowHistory` records duration and success for stats display. Protected by `workflowMutex`.
+`WorkflowState`: IDLE → RUNNING → COMPLETED / FAILED. Tracked via atomics (`workflowState`, `currentWorkflowType`, `geometryModified`). Each worker event owns an immutable copy of its options. Batch execution queues workflow types and starts the next stage from main-thread finalization, so stages run sequentially against the same active layer. `workflowHistory` records duration and success for stats display. Protected by `workflowMutex`.
 
 ## I/O Interface
 
 ### Command-Line Options
 ```
 -i, --input-file      MVS project file (positional)
+-l, --layer-file      Additional scene/geometry layer (repeatable)
 -g, --geometry-file   Mesh/point-cloud to override existing geometry
     --pose-quality-file  Pose-quality CSV (CreateStructure --export-pose-quality) shown as
                          per-camera uncertainty ellipsoids
@@ -211,9 +230,9 @@ Async MVS pipeline stages executable from the Viewer UI:
 ```
 
 ### Runtime I/O
-- **Drag-and-drop**: Files dropped on window trigger `Scene::Open()`
-- **Save**: `Scene::Save()` writes `.mvs` project
-- **Export**: `Scene::Export()` writes `.ply` or `.obj`
+- **Drag-and-drop**: Files dropped on the window are added as layers
+- **Save**: `Scene::Save()` writes the active layer as a self-contained `.mvs` project
+- **Export**: export the active layer or merge all visible layer geometry
 - **Screenshot**: `Window::RequestScreenshot(path, includeUI)` captures framebuffer
 
 ### Track-Based Neighbors
@@ -234,6 +253,8 @@ Async MVS pipeline stages executable from the Viewer UI:
 - **OpenGL error checking**: Wrap all GL calls with `GL_CHECK()` macro from `OpenGLDebug.h`. Use `GL_DEBUG_SCOPE(name)` for RAII scoped checks.
 - **Eigen over OpenCV for transforms**: View/projection matrices and camera transforms use `Eigen::Matrix4d`, `Eigen::Vector3d` throughout the Viewer (unlike MVS core which mixes both).
 - **Render-on-change**: Default mode only redraws when input occurs. Any code that modifies visual state must call `Window::RequestRedraw()`.
-- **Image index duality**: MVS::Scene image indices include invalid entries; Viewer `images` array only has valid ones. Always use `Scene::ImageIdxMVS2Viewer()` when crossing the boundary.
+- **Layer identity**: Async jobs and renderer mappings use stable `Layer::id` values, never vector addresses or indices that can change after removal.
+- **Working folders**: Activate a layer's own `workingFolder` before loading, saving, or running a workflow; restore/activate the current layer after temporary operations.
+- **Image index duality**: `MVS::Scene::images` includes invalid entries; each layer's Viewer `images` array only has valid ones. Always use `Scene::ImageIdxMVS2Viewer()` for the active layer when crossing the boundary.
 - **GPU buffer ownership**: `Renderer` owns all VAO/VBO/EBO/UBO/FBO resources. Upload methods are the only path from CPU data to GPU.
 - **Control mode exclusivity**: Only one control system (arcball/first-person/selection) is active at a time. Switch via `Window::SetControlMode()`.

--- a/apps/Viewer/Camera.h
+++ b/apps/Viewer/Camera.h
@@ -100,6 +100,15 @@ public:
 	void SetSceneDistance(float distance) { sceneDistance = distance; }
 	void SetTarget(const Point3f& newTarget);
 	void SetLookAt(const Eigen::Vector3d& eye, const Eigen::Vector3d& target, const Eigen::Vector3d& up);
+	// Copy the view pose (not the viewport size) from another camera; used by the
+	// compare view to hand the current view over between the side cameras
+	void CopyViewFrom(const Camera& other) {
+		position = other.position;
+		target = other.target;
+		up = other.up;
+		fov = other.fov;
+		orthographic = other.orthographic;
+	}
 
 	// Ray casting
 	Ray3d GetPickingRay(const Eigen::Vector2d& screenPos) const;

--- a/apps/Viewer/Image.cpp
+++ b/apps/Viewer/Image.cpp
@@ -84,6 +84,11 @@ void Image::ReleaseImage()
 		delete p;
 	}
 }
+void Image::CancelImageLoading()
+{
+	if (IsImageLoading())
+		Thread::safeExchange(pImage.ptr, (int_t)IMG_NULL);
+}
 
 void Image::SetImageLoading()
 {
@@ -94,10 +99,6 @@ void Image::AssignImage(cv::InputArray img)
 {
 	ASSERT(IsImageLoading());
 	ImagePtrInt pImg(new cv::Mat(img.getMat()));
-	if (pImg.pImage->cols%4 != 0) {
-		// make sure the width is multiple of 4 (seems to be an OpenGL limitation)
-		cv::resize(*pImg.pImage, *pImg.pImage, cv::Size((pImg.pImage->cols/4)*4, pImg.pImage->rows), 0, 0, cv::INTER_AREA);
-	}
 	Thread::safeExchange(pImage.ptr, pImg.ptr);
 }
 bool Image::TransferImage()

--- a/apps/Viewer/Image.h
+++ b/apps/Viewer/Image.h
@@ -78,6 +78,7 @@ public:
 
 	void Release();
 	void ReleaseImage();
+	void CancelImageLoading();
 	inline bool IsImageEmpty() const { return pImage.ptr == IMG_NULL; }
 	inline bool IsImageLoading() const { return pImage.ptr == IMG_LOADING; }
 	inline bool IsImageValid() const { return pImage.ptr >= IMG_VALID; }

--- a/apps/Viewer/Renderer.cpp
+++ b/apps/Viewer/Renderer.cpp
@@ -1909,8 +1909,8 @@ void Renderer::RenderCoordinateAxes(const Camera& camera) {
 	const int margin = 10;	// Margin from screen edges
 
 	GL_CHECK(glViewport(
-		oldViewport[2] - axesSize - margin,  // x: right side minus size and margin
-		margin,							     // y: bottom with margin
+		oldViewport[0] + oldViewport[2] - axesSize - margin, // x: viewport right minus size and margin
+		oldViewport[1] + margin,							  // y: viewport bottom with margin
 		axesSize,							 // width
 		axesSize							 // height
 	));

--- a/apps/Viewer/Renderer.cpp
+++ b/apps/Viewer/Renderer.cpp
@@ -36,6 +36,18 @@
 
 using namespace VIEWER;
 
+static std::array<Point3f, 4> ComputeCameraFrustumCorners(const MVS::Image& imageData, float depth);
+static uint32_t CreateCameraFrustumGeometry(
+	const MVS::Image& imageData,
+	float depth,
+	bool showLookAt,
+	const Pixel32F& centerColor,
+	const Pixel32F& frustumColor,
+	std::vector<float>& vertices,
+	std::vector<float>& colors,
+	std::vector<uint32_t>& indices,
+	size_t baseIndex);
+
 Renderer::Renderer()
 	: pointCount(0)
 	, pointNormalCount(0)
@@ -44,6 +56,7 @@ Renderer::Renderer()
 	, ellipsoidIndexCount(0)
 	, imageOverlayIndexCount(0)
 	, selectionPrimitiveCount(0)
+	, neighborSelectionPrimitiveCount(0)
 	, selectionOverlayVertexCount(0)
 	, boundsPrimitiveCount(0)
 	, pickFBO(0)
@@ -109,13 +122,23 @@ void Renderer::Reset() {
 	ellipsoidIndexCount = 0;
 	imageOverlayIndexCount = 0;
 	selectionPrimitiveCount = 0;
+	neighborSelectionPrimitiveCount = 0;
 	boundsPrimitiveCount = 0;
 
 	// Clear mesh-related data
-	mapFaceSubsetIndices.clear();
-	mapSubsetFaceIndices.clear();
+	pointLayerRanges.clear();
 	meshFaceCounts.clear();
 	meshTextures.clear();
+	meshTextureIndices.clear();
+	meshSubMeshLayerIDs.clear();
+	meshLayerFaceMaps.clear();
+	faceRefs.clear();
+	globalFaceSubMeshIndices.clear();
+	cameraLayerRanges.clear();
+	ellipsoidCenters.clear();
+	ellipsoidLayerIDs.clear();
+	ellipsoidDrawOrder.clear();
+	layerPassFilter.clear();
 
 	// Clear scene-dependent geometry buffers by allocating empty data
 	ReleasePickerBuffers();
@@ -153,6 +176,312 @@ void Renderer::Reset() {
 
 	if (boundsVBO)
 		boundsVBO->AllocateBuffer(0);
+}
+
+const Renderer::LayerIndexRange* Renderer::FindPointLayerRange(uint32_t layerID) const
+{
+	for (const LayerIndexRange& range : pointLayerRanges)
+		if (range.layerID == layerID)
+			return &range;
+	return nullptr;
+}
+
+const Renderer::CameraLayerRange* Renderer::FindCameraLayerRange(uint32_t layerID) const
+{
+	for (const CameraLayerRange& range : cameraLayerRanges)
+		if (range.layerID == layerID)
+			return &range;
+	return nullptr;
+}
+
+const Renderer::LayerFaceMap* Renderer::FindMeshLayerMap(uint32_t layerID) const
+{
+	for (const LayerFaceMap& map : meshLayerFaceMaps)
+		if (map.layerID == layerID)
+			return &map;
+	return nullptr;
+}
+
+bool Renderer::MapGlobalPoint(size_t globalIndex, uint32_t& layerID, uint32_t& localIndex) const
+{
+	for (const LayerIndexRange& range : pointLayerRanges) {
+		if (globalIndex < range.offset || globalIndex >= range.offset + range.count)
+			continue;
+		layerID = range.layerID;
+		localIndex = static_cast<uint32_t>(globalIndex - range.offset);
+		return true;
+	}
+	return false;
+}
+
+bool Renderer::MapGlobalFace(size_t globalIndex, uint32_t& layerID, uint32_t& localIndex) const
+{
+	if (globalIndex >= faceRefs.size())
+		return false;
+	layerID = faceRefs[globalIndex].layerID;
+	localIndex = faceRefs[globalIndex].localIndex;
+	return layerID != NO_ID && localIndex != NO_ID;
+}
+
+bool Renderer::MapLocalFace(uint32_t layerID, uint32_t localIndex, uint32_t& globalIndex) const
+{
+	const LayerFaceMap* faceMap = FindMeshLayerMap(layerID);
+	if (faceMap == nullptr || localIndex >= faceMap->localToGlobalFace.size())
+		return false;
+	globalIndex = faceMap->localToGlobalFace[localIndex];
+	return globalIndex != NO_ID;
+}
+
+void Renderer::UploadLayers(const Scene& sceneController, const Window& window)
+{
+	UploadPointClouds(sceneController, window.pointNormalLength);
+	UploadMeshes(sceneController);
+	UploadCameras(window);
+}
+
+void Renderer::UploadPointClouds(const Scene& sceneController, float normalLength)
+{
+	pointCount = 0;
+	pointNormalCount = 0;
+	pointLayerRanges.clear();
+
+	// Aggregate visible point clouds.
+	for (const Scene::Layer& layer : sceneController.GetLayers()) {
+		if (!layer.visible || layer.scene.pointcloud.IsEmpty())
+			continue;
+		const MVS::PointCloud& pointcloud = layer.scene.pointcloud;
+		LayerIndexRange range;
+		range.layerID = layer.id;
+		range.offset = pointCount;
+		range.count = pointcloud.points.size();
+		if (pointcloud.normals.size() == pointcloud.points.size()) {
+			range.normalOffset = pointNormalCount;
+			range.normalCount = pointcloud.normals.size() * 2;
+		}
+		pointLayerRanges.push_back(range);
+		pointCount += range.count;
+		pointNormalCount += range.normalCount;
+	}
+	if (pointCount) {
+		pointCloudVBO->AllocateBuffer(pointCount * 3 * sizeof(float));
+		pointCloudColorVBO->AllocateBuffer(pointCount * 3 * sizeof(float));
+		if (pointNormalCount)
+			pointCloudNormalsVBO->AllocateBuffer(pointNormalCount * 3 * sizeof(float));
+		size_t pointOffset = 0;
+		size_t normalOffset = 0;
+		for (const Scene::Layer& layer : sceneController.GetLayers()) {
+			if (!layer.visible || layer.scene.pointcloud.IsEmpty())
+				continue;
+			const MVS::PointCloud& pointcloud = layer.scene.pointcloud;
+			pointCloudVBO->SetSubData(pointcloud.points[0].ptr(), pointcloud.points.size() * 3, pointOffset * 3);
+
+			std::vector<float> colors;
+			colors.reserve(pointcloud.points.size() * 3);
+			if (layer.usePointSolidColor) {
+				for (size_t i = 0; i < pointcloud.points.size(); ++i) {
+					colors.push_back(layer.pointColor.x);
+					colors.push_back(layer.pointColor.y);
+					colors.push_back(layer.pointColor.z);
+				}
+			} else if (pointcloud.colors.size() == pointcloud.points.size()) {
+				for (const Pixel8U& color : pointcloud.colors) {
+					colors.push_back(color.r / 255.f);
+					colors.push_back(color.g / 255.f);
+					colors.push_back(color.b / 255.f);
+				}
+			} else {
+				colors.resize(pointcloud.points.size() * 3, 1.f);
+			}
+			pointCloudColorVBO->SetSubData(colors, pointOffset * 3);
+
+			if (pointcloud.normals.size() == pointcloud.points.size()) {
+				std::vector<float> normalLines;
+				normalLines.reserve(pointcloud.normals.size() * 6);
+				for (size_t i = 0; i < pointcloud.points.size(); ++i) {
+					const MVS::PointCloud::Point& point = pointcloud.points[i];
+					const MVS::PointCloud::Normal& normal = pointcloud.normals[i];
+					normalLines.push_back(point.x);
+					normalLines.push_back(point.y);
+					normalLines.push_back(point.z);
+					normalLines.push_back(point.x + normal.x * normalLength);
+					normalLines.push_back(point.y + normal.y * normalLength);
+					normalLines.push_back(point.z + normal.z * normalLength);
+				}
+				pointCloudNormalsVBO->SetSubData(normalLines, normalOffset * 3);
+				normalOffset += pointcloud.normals.size() * 2;
+			}
+			pointOffset += pointcloud.points.size();
+		}
+		ASSERT(pointOffset == pointCount && normalOffset == pointNormalCount);
+	}
+}
+
+void Renderer::UploadMeshes(const Scene& sceneController)
+{
+	meshFaceCounts.clear();
+	meshTextures.clear();
+	meshTextureIndices.clear();
+	meshSubMeshLayerIDs.clear();
+	meshLayerFaceMaps.clear();
+	faceRefs.clear();
+	globalFaceSubMeshIndices.clear();
+
+	// Aggregate visible meshes into a combined GPU upload.
+	struct PreparedLayerMesh
+	{
+		uint32_t layerID{NO_ID};
+		size_t originalFaceCount{0};
+		const MVS::Mesh* directMesh{nullptr};
+		std::vector<MVS::Mesh> submeshes;
+		MVS::Mesh::FaceIdxArr faceSubsetIndices;
+		std::vector<uint32_t> faceSubmeshIndices;
+
+		size_t GetSubmeshCount() const { return directMesh == nullptr ? submeshes.size() : 1; }
+		const MVS::Mesh& GetSubmesh(size_t idx) const
+		{
+			ASSERT(idx < GetSubmeshCount());
+			return directMesh == nullptr ? submeshes[idx] : *directMesh;
+		}
+	};
+	std::vector<PreparedLayerMesh> preparedMeshes;
+	size_t totalVertices = 0;
+	size_t totalIndices = 0;
+	size_t totalTexCoords = 0;
+	size_t totalFaces = 0;
+	for (const Scene::Layer& layer : sceneController.GetLayers()) {
+		if (!layer.visible || layer.scene.mesh.IsEmpty() || layer.scene.mesh.faces.empty())
+			continue;
+		PreparedLayerMesh prepared;
+		prepared.layerID = layer.id;
+		prepared.originalFaceCount = layer.scene.mesh.faces.size();
+		if (layer.scene.mesh.HasTexture()) {
+			if (layer.scene.mesh.texturesDiffuse.size() > 1) {
+				std::vector<MVS::Mesh> textureSubmeshes(layer.scene.mesh.SplitMeshPerTextureBlob(&prepared.faceSubsetIndices));
+				std::vector<uint32_t> textureToSubmesh(textureSubmeshes.size(), NO_ID);
+				for (size_t textureIdx = 0; textureIdx < textureSubmeshes.size(); ++textureIdx) {
+					MVS::Mesh& submesh(textureSubmeshes[textureIdx]);
+					if (submesh.IsEmpty())
+						continue;
+					MVS::Mesh convertedMesh;
+					submesh.ConvertTexturePerVertex(convertedMesh);
+					if (convertedMesh.vertexNormals.size() != convertedMesh.vertices.size())
+						convertedMesh.ComputeNormalVertices();
+					textureToSubmesh[textureIdx] = (uint32_t)prepared.submeshes.size();
+					prepared.submeshes.emplace_back(std::move(convertedMesh));
+				}
+				prepared.faceSubmeshIndices.resize(layer.scene.mesh.faces.size());
+				FOREACH(faceIdx, layer.scene.mesh.faces) {
+					const uint32_t textureIdx(layer.scene.mesh.GetFaceTextureIndex(faceIdx));
+					ASSERT(textureIdx < textureToSubmesh.size() && textureToSubmesh[textureIdx] != NO_ID);
+					prepared.faceSubmeshIndices[faceIdx] = textureToSubmesh[textureIdx];
+				}
+			} else {
+				MVS::Mesh convertedMesh;
+				layer.scene.mesh.ConvertTexturePerVertex(convertedMesh);
+				if (convertedMesh.vertexNormals.size() != convertedMesh.vertices.size())
+					convertedMesh.ComputeNormalVertices();
+				prepared.submeshes.emplace_back(std::move(convertedMesh));
+			}
+		} else {
+			if (layer.scene.mesh.vertexNormals.size() != layer.scene.mesh.vertices.size()) {
+				prepared.submeshes.emplace_back(layer.scene.mesh);
+				prepared.submeshes.back().ComputeNormalVertices();
+			} else {
+				prepared.directMesh = &layer.scene.mesh;
+			}
+		}
+		for (size_t submeshIdx = 0; submeshIdx < prepared.GetSubmeshCount(); ++submeshIdx) {
+			const MVS::Mesh& submesh(prepared.GetSubmesh(submeshIdx));
+			totalVertices += submesh.vertices.size();
+			totalIndices += submesh.faces.size() * 3;
+			totalTexCoords += submesh.vertices.size();
+			totalFaces += submesh.faces.size();
+		}
+		preparedMeshes.emplace_back(std::move(prepared));
+	}
+	if (!preparedMeshes.empty()) {
+		meshVBO->AllocateBuffer(totalVertices * 3 * sizeof(float));
+		meshNormalVBO->AllocateBuffer(totalVertices * 3 * sizeof(float));
+		meshTexCoordVBO->AllocateBuffer(totalTexCoords * 2 * sizeof(float));
+		meshEBO->AllocateBuffer(totalIndices * sizeof(uint32_t));
+		faceRefs.assign(totalFaces, {});
+		globalFaceSubMeshIndices.assign(totalFaces, NO_ID);
+
+		uint32_t vertexOffset = 0;
+		uint32_t globalFaceOffset = 0;
+		for (const PreparedLayerMesh& prepared : preparedMeshes) {
+			LayerFaceMap layerFaceMap;
+			layerFaceMap.layerID = prepared.layerID;
+			layerFaceMap.localToGlobalFace.assign(prepared.originalFaceCount, NO_ID);
+			const uint32_t layerFaceBase = globalFaceOffset;
+			std::vector<uint32_t> layerSubmeshFaceOffsets(prepared.GetSubmeshCount(), 0);
+			for (size_t submeshIdx = 1; submeshIdx < prepared.GetSubmeshCount(); ++submeshIdx)
+				layerSubmeshFaceOffsets[submeshIdx] = layerSubmeshFaceOffsets[submeshIdx - 1] + prepared.GetSubmesh(submeshIdx - 1).faces.size();
+			const uint32_t globalSubmeshBase = meshFaceCounts.size();
+
+			for (size_t submeshIdx = 0; submeshIdx < prepared.GetSubmeshCount(); ++submeshIdx) {
+				const MVS::Mesh& submesh(prepared.GetSubmesh(submeshIdx));
+				MVS::Mesh::TexCoordArr normFaceTexcoords;
+				if (!submesh.faceTexcoords.empty())
+					submesh.FaceTexcoordsNormalize(normFaceTexcoords, false);
+				else
+					normFaceTexcoords.resize(submesh.vertices.size());
+				ASSERT(submesh.vertexNormals.size() == submesh.vertices.size());
+
+				std::vector<uint32_t> adjustedIndices;
+				adjustedIndices.reserve(submesh.faces.size() * 3);
+				for (const MVS::Mesh::Face& face : submesh.faces) {
+					adjustedIndices.push_back(vertexOffset + face.x);
+					adjustedIndices.push_back(vertexOffset + face.y);
+					adjustedIndices.push_back(vertexOffset + face.z);
+				}
+
+				meshVBO->SetSubData(&submesh.vertices[0].x, submesh.vertices.size() * 3, vertexOffset * 3);
+				meshNormalVBO->SetSubData(&submesh.vertexNormals[0].x, submesh.vertexNormals.size() * 3, vertexOffset * 3);
+				meshTexCoordVBO->SetSubData(&normFaceTexcoords[0].x, normFaceTexcoords.size() * 2, vertexOffset * 2);
+
+				const MVS::Mesh::FIndex faceCountPrev = meshFaceCounts.empty() ? 0 : meshFaceCounts.back();
+				meshEBO->SetSubData(adjustedIndices, faceCountPrev * 3);
+				uint32_t textureIndex = NO_ID;
+				if (submesh.HasTexture()) {
+					ASSERT(submesh.texturesDiffuse.size() == 1);
+					textureIndex = (uint32_t)meshTextures.size();
+					Image& image = meshTextures.emplace_back((MVS::IIndex)textureIndex);
+					image.SetImageLoading();
+					image.AssignImage(submesh.texturesDiffuse.front());
+					image.TransferImage();
+				}
+				meshTextureIndices.emplace_back(textureIndex);
+				meshSubMeshLayerIDs.emplace_back(prepared.layerID);
+				meshFaceCounts.emplace_back(faceCountPrev + submesh.faces.size());
+
+				for (size_t localFace = 0; localFace < submesh.faces.size(); ++localFace)
+					globalFaceSubMeshIndices[globalFaceOffset + localFace] = globalSubmeshBase + submeshIdx;
+
+				globalFaceOffset += submesh.faces.size();
+				vertexOffset += submesh.vertices.size();
+			}
+
+			if (!prepared.faceSubsetIndices.empty()) {
+				FOREACH(faceIdx, prepared.faceSubsetIndices) {
+					const uint32_t submeshIdx = prepared.faceSubmeshIndices[faceIdx];
+					const uint32_t globalFaceIndex = layerFaceBase + layerSubmeshFaceOffsets[submeshIdx] + prepared.faceSubsetIndices[faceIdx];
+					layerFaceMap.localToGlobalFace[faceIdx] = globalFaceIndex;
+					faceRefs[globalFaceIndex] = {prepared.layerID, (uint32_t)faceIdx};
+				}
+			} else {
+				for (uint32_t faceIdx = 0; faceIdx < prepared.originalFaceCount; ++faceIdx) {
+					const uint32_t globalFaceIndex = layerFaceBase + faceIdx;
+					layerFaceMap.localToGlobalFace[faceIdx] = globalFaceIndex;
+					faceRefs[globalFaceIndex] = {prepared.layerID, faceIdx};
+				}
+			}
+			meshLayerFaceMaps.emplace_back(std::move(layerFaceMap));
+		}
+		ASSERT(vertexOffset == totalVertices && globalFaceOffset == totalFaces);
+		ASSERT(meshFaceCounts.size() == meshTextureIndices.size());
+		ASSERT(meshFaceCounts.size() == meshSubMeshLayerIDs.size());
+	}
 }
 
 void Renderer::CreateShaders() {
@@ -578,169 +907,6 @@ void Renderer::SetupGizmoBuffers() {
 	gizmoVAO->Unbind();
 }
 
-void Renderer::UploadPointCloud(const MVS::PointCloud& pointcloud, float normalLength) {
-	pointCount = pointcloud.GetSize();
-	pointNormalCount = 0;
-	if (pointCount == 0)
-		return;
-	// Convert colors to float array
-	std::vector<float> colors;
-	colors.reserve(pointcloud.colors.size() * 3);
-	if (!pointcloud.colors.empty()) {
-		for (const auto& color : pointcloud.colors) {
-			colors.push_back(color.r / 255.f);
-			colors.push_back(color.g / 255.f);
-			colors.push_back(color.b / 255.f);
-		}
-	} else {
-		// Default white color for all points
-		colors.resize(pointcloud.points.size() * 3, 1.f);
-	}
-	// Upload to GPU
-	pointCloudVBO->SetData(pointcloud.points[0].ptr(), pointcloud.points.size() * 3);
-	pointCloudColorVBO->SetData(colors);
-
-	// Upload normals if available
-	if (!pointcloud.normals.empty()) {
-		ASSERT(pointcloud.normals.size() == pointcloud.points.size());
-		// Create line segments for normals: each normal gets 2 vertices (start and end)
-		std::vector<float> normalLines;
-		normalLines.reserve(pointcloud.normals.size() * 6); // 2 points * 3 components each
-		for (size_t i = 0; i < pointcloud.points.size(); ++i) {
-			const MVS::PointCloud::Point& point = pointcloud.points[i];
-			const MVS::PointCloud::Normal& normal = pointcloud.normals[i];
-			// Start point (the actual point)
-			normalLines.push_back(point.x);
-			normalLines.push_back(point.y);
-			normalLines.push_back(point.z);
-			// End point (point + normal * length)
-			normalLines.push_back(point.x + normal.x * normalLength);
-			normalLines.push_back(point.y + normal.y * normalLength);
-			normalLines.push_back(point.z + normal.z * normalLength);
-		}
-		pointCloudNormalsVBO->SetData(normalLines);
-		pointNormalCount = normalLines.size() / 3; // Total vertices for normal lines
-	}
-}
-
-void Renderer::UploadMesh(MVS::Mesh& mesh) {
-	mapFaceSubsetIndices.clear();
-	mapSubsetFaceIndices.clear();
-	meshFaceCounts.clear();
-	meshTextures.clear();
-	if (mesh.IsEmpty())
-		return;
-
-	if (mesh.HasTexture()) {
-		// Convert mesh to use texture per vertex and
-		// split it in sub-meshes if multiple textures are present
-		std::vector<MVS::Mesh> meshes;
-		if (mesh.texturesDiffuse.size() > 1) {
-			meshes = mesh.SplitMeshPerTextureBlob(&mapFaceSubsetIndices);
-			for (MVS::Mesh& submesh: meshes) {
-				MVS::Mesh convertedMesh;
-				submesh.ConvertTexturePerVertex(convertedMesh);
-				submesh.Swap(convertedMesh);
-			}
-		} else {
-			MVS::Mesh convertedMesh;
-			mesh.ConvertTexturePerVertex(convertedMesh);
-			meshes.emplace_back(std::move(convertedMesh));
-		}
-
-		// Calculate total buffer sizes for all sub-meshes
-		size_t totalVertices = 0;
-		size_t totalIndices = 0;
-		size_t totalTexCoords = 0;
-		for (const MVS::Mesh& submesh : meshes) {
-			totalVertices += submesh.vertices.size();
-			totalIndices += submesh.faces.size() * 3;
-			totalTexCoords += submesh.vertices.size(); // One tex coord per vertex after conversion
-		}
-
-		// Allocate total buffer sizes using VBO wrapper functions
-		meshVBO->AllocateBuffer(totalVertices * 3 * sizeof(float));
-		meshNormalVBO->AllocateBuffer(totalVertices * 3 * sizeof(float));
-		meshTexCoordVBO->AllocateBuffer(totalTexCoords * 2 * sizeof(float));
-		meshEBO->AllocateBuffer(totalIndices * sizeof(uint32_t));
-
-		// Upload each sub-mesh using glBufferSubData
-		uint32_t vertexOffset = 0;
-		meshTextures.reserve(meshes.size());
-		meshFaceCounts.reserve(meshes.size());
-		for (MVS::Mesh& submesh : meshes) {
-			// convert texture coordinates
-			MVS::Mesh::TexCoordArr normFaceTexcoords;
-			if (!submesh.faceTexcoords.empty()) {
-				// normalize texture coordinates
-				submesh.FaceTexcoordsNormalize(normFaceTexcoords, false);
-			} else {
-				// default texture coordinates
-				normFaceTexcoords.resize(submesh.vertices.size());
-			}
-			// convert normals to float array
-			if (submesh.vertexNormals.empty())
-				submesh.ComputeNormalVertices();
-			// adjust face indices to account for previous sub-meshes
-			std::vector<uint32_t> adjustedIndices;
-			adjustedIndices.reserve(submesh.faces.size() * 3);
-			for (const MVS::Mesh::Face& face : submesh.faces) {
-				adjustedIndices.push_back(vertexOffset + face.x);
-				adjustedIndices.push_back(vertexOffset + face.y);
-				adjustedIndices.push_back(vertexOffset + face.z);
-			}
-			// upload vertices using VBO wrapper functions
-			meshVBO->SetSubData(&submesh.vertices[0].x, submesh.vertices.size() * 3, vertexOffset * 3);
-			// upload normals using VBO wrapper functions
-			meshNormalVBO->SetSubData(&submesh.vertexNormals[0].x, submesh.vertexNormals.size() * 3, vertexOffset * 3);
-			// upload texture coordinates using VBO wrapper functions
-			meshTexCoordVBO->SetSubData(&normFaceTexcoords[0].x, normFaceTexcoords.size() * 2, vertexOffset * 2);
-			// upload indices using VBO wrapper functions
-			const MVS::Mesh::FIndex faceCountPrev = meshFaceCounts.empty() ? 0 : meshFaceCounts.back();
-			const size_t indexOffset = faceCountPrev * 3;
-			meshEBO->SetSubData(adjustedIndices, indexOffset);
-			// load texture for this sub-mesh
-			if (submesh.HasTexture()) {
-				ASSERT(submesh.texturesDiffuse.size() == 1, "Sub-mesh should have exactly one texture");
-				const MVS::IIndex i = (MVS::IIndex)meshTextures.size();
-				Image& image = meshTextures.emplace_back(i);
-				image.SetImageLoading();
-				image.AssignImage(submesh.texturesDiffuse.front());
-				image.TransferImage();
-			}
-			// track this sub-mesh
-			meshFaceCounts.emplace_back(faceCountPrev + submesh.faces.size());
-			// update offsets for next sub-mesh
-			vertexOffset += submesh.vertices.size();
-		}
-		// map subset face indices for selection highlighting
-		if (!mapFaceSubsetIndices.empty()) {
-			mapSubsetFaceIndices.resize(mapFaceSubsetIndices.size());
-			FOREACH(faceIdx, mapFaceSubsetIndices) {
-				const MVS::Mesh::TexIndex submeshIdx = mesh.GetFaceTextureIndex(faceIdx);
-				ASSERT(submeshIdx < meshFaceCounts.size());
-				const MVS::Mesh::FIndex faceCountOffset = submeshIdx ? meshFaceCounts[submeshIdx - 1] : 0u;
-				mapSubsetFaceIndices[faceCountOffset + mapFaceSubsetIndices[faceIdx]] = faceIdx;
-			}
-		}
-	} else {
-		// single mesh without texture - simpler case
-		// convert normals to float array
-		bool hasNormals = true;
-		if (mesh.vertexNormals.empty()) {
-			mesh.ComputeNormalVertices();
-			hasNormals = false;
-		}
-		// upload to GPU using traditional method
-		meshVBO->SetData(mesh.vertices[0].ptr(), mesh.vertices.size() * 3);
-		meshEBO->SetData(mesh.faces[0].ptr(), mesh.faces.size() * 3);
-		meshNormalVBO->SetData(mesh.vertexNormals[0].ptr(), mesh.vertexNormals.size() * 3);
-		if (!hasNormals)
-			mesh.vertexNormals.Release();
-		meshFaceCounts.emplace_back(mesh.faces.size());
-	}
-}
-
 // Helper function to compute camera frustum corners in world space
 // This function correctly accounts for the principal point by using image coordinates
 // and TransformPointI2W instead of assuming the principal point is at the image center
@@ -774,8 +940,7 @@ static uint32_t CreateCameraFrustumGeometry(
 	std::vector<float>& vertices,
 	std::vector<float>& colors,
 	std::vector<uint32_t>& indices,
-	size_t baseIndex
-) {
+	size_t baseIndex) {
 	// Camera center (apex of the pyramid)
 	const Point3f center = imageData.camera.C;
 	vertices.insert(vertices.end(), {center.x, center.y, center.z});
@@ -827,60 +992,116 @@ static uint32_t CreateCameraFrustumGeometry(
 
 void Renderer::UploadCameras(const Window& window) {
 	cameraPointIndexCount = cameraLineIndexCount = imageOverlayIndexCount = 0;
-	if (window.GetScene().GetImages().empty())
+	cameraLayerRanges.clear();
+
+	const Scene& sceneController = window.GetScene();
+	size_t imageCount = 0;
+	for (const Scene::Layer& layer : sceneController.GetLayers()) {
+		if (!layer.visible)
+			continue;
+		imageCount += layer.images.size();
+	}
+	if (imageCount == 0)
 		return;
+
 	const float depth = window.GetCamera().GetSceneDistance() * window.cameraSize;
-	const bool useJetColors = window.cameraDisplayColor == Window::CAMERA_COLOR_JET;
 	const bool displayDots = window.cameraDisplayType == Window::CAMERA_DISPLAY_DOT;
 	const bool showLookAt = window.showCameraLookAt;
-	const MVS::ImageArr& images = window.GetScene().GetScene().images;
-	const ImageArr& viewerImages = window.GetScene().GetImages();
-	const size_t imageCount = viewerImages.size();
 
-	// Generate camera frustum geometry
 	std::vector<float> cameraVertices;
 	std::vector<float> cameraColors;
 	std::vector<uint32_t> cameraPointIndices;
 	std::vector<uint32_t> cameraLineIndices;
-	for (size_t cameraIdx = 0; cameraIdx < imageCount; ++cameraIdx) {
-		const MVS::Image& imageData = images[viewerImages[cameraIdx].idx];
-		ASSERT(imageData.IsValid());
-		const float colorValue = imageCount > 1 ? ((float)cameraIdx / (float)(imageCount - 1)) : 0.5f;
-		const Pixel32F cameraColor = useJetColors ? Pixel32F::gray2color(colorValue) : Pixel32F::YELLOW;
+	std::vector<float> allVertices;
+	std::vector<uint32_t> allIndices;
 
-		// Dot mode: draw only camera centers.
-		if (displayDots) {
-			const uint32_t baseIndex = (uint32_t)(cameraVertices.size() / 3);
-			const Point3f center = imageData.camera.C;
-			cameraVertices.insert(cameraVertices.end(), {center.x, center.y, center.z});
-			cameraColors.insert(cameraColors.end(), {cameraColor.c2, cameraColor.c1, cameraColor.c0});
-			cameraPointIndices.push_back((uint32_t)baseIndex);
-			++cameraPointIndexCount;
-			if (showLookAt) {
-				const Point2 pp = imageData.camera.GetPrincipalPoint();
-				const Point3f worldPrincipalPoint = imageData.camera.TransformPointI2W(Point3(pp.x, pp.y, depth));
-				cameraVertices.insert(cameraVertices.end(), {worldPrincipalPoint.x, worldPrincipalPoint.y, worldPrincipalPoint.z});
-				cameraColors.insert(cameraColors.end(), {0.f, 1.f, 0.f}); // Green look-at target
-				cameraLineIndices.push_back(baseIndex);
-				cameraLineIndices.push_back(baseIndex + 1);
-				cameraLineIndexCount += 2;
-			}
+	size_t globalCameraOffset = 0;
+	for (const Scene::Layer& layer : sceneController.GetLayers()) {
+		if (!layer.visible || layer.images.empty())
 			continue;
-		}
+		CameraLayerRange range;
+		range.layerID = layer.id;
+		range.offset = globalCameraOffset;
+		range.count = layer.images.size();
+		range.pointIndexOffset = cameraPointIndices.size();
+		range.lineIndexOffset = cameraLineIndices.size();
+		size_t layerCameraIdx = 0;
+		for (const Image& image : layer.images) {
+			const MVS::Image& imageData = layer.scene.images[image.idx];
+			ASSERT(imageData.IsValid());
+			const float colorValue = layer.useCameraJetColor
+			                             ? (layer.images.size() > 1 ? ((float)layerCameraIdx / (float)(layer.images.size() - 1)) : 0.5f)
+			                             : 0.5f;
+			const Pixel32F cameraColor = layer.useCameraJetColor ? Pixel32F::gray2color(colorValue) : Pixel32F(layer.cameraColor.x, layer.cameraColor.y, layer.cameraColor.z);
 
-		// Frustum mode: draw full camera wireframe.
-		const size_t baseIndex = cameraVertices.size() / 3;
-		cameraLineIndexCount += CreateCameraFrustumGeometry(
-			imageData,
-			depth,
-			showLookAt,
-			cameraColor,
-			cameraColor,
-			cameraVertices,
-			cameraColors,
-			cameraLineIndices,
-			baseIndex
-		);
+			if (displayDots) {
+				const uint32_t baseIndex = (uint32_t)(cameraVertices.size() / 3);
+				const Point3f center = imageData.camera.C;
+				cameraVertices.insert(cameraVertices.end(), {center.x, center.y, center.z});
+				cameraColors.insert(cameraColors.end(), {cameraColor.c2, cameraColor.c1, cameraColor.c0});
+				cameraPointIndices.push_back(baseIndex);
+				++cameraPointIndexCount;
+				if (showLookAt) {
+					const Point2 pp = imageData.camera.GetPrincipalPoint();
+					const Point3f worldPrincipalPoint = imageData.camera.TransformPointI2W(Point3(pp.x, pp.y, depth));
+					cameraVertices.insert(cameraVertices.end(), {worldPrincipalPoint.x, worldPrincipalPoint.y, worldPrincipalPoint.z});
+					cameraColors.insert(cameraColors.end(), {0.f, 1.f, 0.f});
+					cameraLineIndices.push_back(baseIndex);
+					cameraLineIndices.push_back(baseIndex + 1);
+					cameraLineIndexCount += 2;
+				}
+			} else {
+				const size_t baseIndex = cameraVertices.size() / 3;
+				cameraLineIndexCount += CreateCameraFrustumGeometry(
+				    imageData,
+				    depth,
+				    showLookAt,
+				    cameraColor,
+				    cameraColor,
+				    cameraVertices,
+				    cameraColors,
+				    cameraLineIndices,
+				    baseIndex);
+			}
+
+			std::array<Point3f, 4> worldCorners = ComputeCameraFrustumCorners(imageData, depth);
+			const uint32_t baseVertex = (uint32_t)(allVertices.size() / 5);
+			for (int i = 0; i < 4; ++i) {
+				const Point3f& worldCorner = worldCorners[i];
+				allVertices.push_back(worldCorner.x);
+				allVertices.push_back(worldCorner.y);
+				allVertices.push_back(worldCorner.z);
+				switch (i) {
+				case 0:
+					allVertices.push_back(0.f);
+					allVertices.push_back(0.f);
+					break;
+				case 1:
+					allVertices.push_back(1.f);
+					allVertices.push_back(0.f);
+					break;
+				case 2:
+					allVertices.push_back(1.f);
+					allVertices.push_back(1.f);
+					break;
+				default:
+					allVertices.push_back(0.f);
+					allVertices.push_back(1.f);
+					break;
+				}
+			}
+			allIndices.push_back(baseVertex + 0);
+			allIndices.push_back(baseVertex + 1);
+			allIndices.push_back(baseVertex + 2);
+			allIndices.push_back(baseVertex + 0);
+			allIndices.push_back(baseVertex + 2);
+			allIndices.push_back(baseVertex + 3);
+			++layerCameraIdx;
+		}
+		range.pointIndexCount = cameraPointIndices.size() - range.pointIndexOffset;
+		range.lineIndexCount = cameraLineIndices.size() - range.lineIndexOffset;
+		cameraLayerRanges.push_back(range);
+		globalCameraOffset += layer.images.size();
 	}
 
 	std::vector<uint32_t> cameraIndices;
@@ -888,62 +1109,14 @@ void Renderer::UploadCameras(const Window& window) {
 	cameraIndices.insert(cameraIndices.end(), cameraPointIndices.begin(), cameraPointIndices.end());
 	cameraIndices.insert(cameraIndices.end(), cameraLineIndices.begin(), cameraLineIndices.end());
 
-	// Upload camera geometry to GPU buffers
 	if (!cameraIndices.empty()) {
 		cameraVBO->SetData(cameraVertices);
 		cameraColorVBO->SetData(cameraColors);
 		cameraEBO->SetData(cameraIndices);
 	}
 
-	// Collect all overlay geometry for images with valid textures
-	std::vector<float> allVertices;
-	std::vector<uint32_t> allIndices;
-	for (const auto& image : window.GetScene().GetImages()) {
-		const MVS::Image& imageData = window.GetScene().GetScene().images[image.idx];
-		ASSERT(imageData.IsValid());
-		// Get frustum corners using the same helper function as CreateCameraFrustumGeometry
-		std::array<Point3f, 4> worldCorners = ComputeCameraFrustumCorners(imageData, depth);
-		// Create quad vertices for this overlay
-		const uint32_t baseVertex = allVertices.size() / 5;
-		for (int i = 0; i < 4; ++i) {
-			const Point3f& worldCorner = worldCorners[i];
-			// Add 3D world position
-			allVertices.push_back(worldCorner.x);
-			allVertices.push_back(worldCorner.y);
-			allVertices.push_back(worldCorner.z);
-			// Add texture coordinates
-			// Map image corners to texture coordinates:
-			// top-left -> (0,0), top-right -> (1,0), bottom-right -> (1,1), bottom-left -> (0,1)
-			switch(i) {
-			case 0: // top-left corner
-				allVertices.push_back(0.f); // U
-				allVertices.push_back(0.f); // V (top of image)
-				break;
-			case 1: // top-right corner
-				allVertices.push_back(1.f); // U
-				allVertices.push_back(0.f); // V (top of image)
-				break;
-			case 2: // bottom-right corner
-				allVertices.push_back(1.f); // U
-				allVertices.push_back(1.f); // V (bottom of image)
-				break;
-			case 3: // bottom-left corner
-				allVertices.push_back(0.f); // U
-				allVertices.push_back(1.f); // V (bottom of image)
-				break;
-			}
-		}
-		// Add indices for this quad (2 triangles)
-		allIndices.push_back(baseVertex + 0); // top-left
-		allIndices.push_back(baseVertex + 1); // top-right
-		allIndices.push_back(baseVertex + 2); // bottom-right
-		allIndices.push_back(baseVertex + 0); // top-left
-		allIndices.push_back(baseVertex + 2); // bottom-right
-		allIndices.push_back(baseVertex + 3); // bottom-left
-		imageOverlayIndexCount += 6; // 2 triangles * 3 indices each
-	}
-	// Upload all overlay geometry to GPU buffers
-	if (imageOverlayIndexCount) {
+	if (!allIndices.empty()) {
+		imageOverlayIndexCount = allIndices.size();
 		imageOverlayVBO->SetData(allVertices);
 		imageOverlayEBO->SetData(allIndices);
 	}
@@ -952,15 +1125,10 @@ void Renderer::UploadCameras(const Window& window) {
 void Renderer::UploadUncertaintyEllipsoids(const Window& window) {
 	ellipsoidIndexCount = 0;
 	ellipsoidCenters.clear();
-	const Scene& scene = window.GetScene();
-	if (!scene.HasCameraUncertainty())
+	ellipsoidLayerIDs.clear();
+	const Scene& sceneController = window.GetScene();
+	if (!sceneController.HasCameraUncertainty())
 		return;
-	const MVS::ImageArr& images = scene.GetScene().images;
-	const ImageArr& viewerImages = scene.GetImages();
-	ASSERT(scene.cameraUncertainty.size() == viewerImages.size());
-	const float norm = scene.cameraUncertaintyNorm > 0.f ? scene.cameraUncertaintyNorm : 1.f;
-	// effective radius scale = scene auto-fit (sizes the median ellipsoid to the scene) x user slider
-	const float scale = window.uncertaintyEllipsoidScale * scene.cameraUncertaintyAutoScale;
 
 	// Solid unit-sphere template (UV sphere): a shared vertex grid + triangle list that is
 	// transformed per camera into an oriented, shaded error ellipsoid. Per-vertex unit-sphere
@@ -988,44 +1156,55 @@ void Renderer::UploadUncertaintyEllipsoids(const Window& window) {
 
 	std::vector<float> vertices, normals, colors;
 	std::vector<uint32_t> indices;
-	FOREACH(cameraIdx, viewerImages) {
-		const Scene::CameraUncertainty& u = scene.cameraUncertainty[cameraIdx];
-		if (!u.IsComputed())
+	for (const Scene::Layer& layer : sceneController.GetLayers()) {
+		if (!layer.visible || layer.cameraUncertainty.empty())
 			continue;
-		// Oriented world-frame error ellipsoid: eigen-decompose the position covariance
-		const Matrix3x3f& cov = u.posCov;
-		Eigen::Matrix3f ecov;
-		ecov << cov(0,0), cov(0,1), cov(0,2),
-		        cov(1,0), cov(1,1), cov(1,2),
-		        cov(2,0), cov(2,1), cov(2,2);
-		const Eigen::SelfAdjointEigenSolver<Eigen::Matrix3f> es(ecov);
-		if (es.info() != Eigen::Success)
-			continue;
-		const Eigen::Vector3f radii = es.eigenvalues().cwiseMax(0.f).cwiseSqrt() * scale;
-		if (radii.maxCoeff() <= 0.f)
-			continue; // gauge datum (or degenerate): nothing to draw
-		const Eigen::Matrix3f R = es.eigenvectors();
-		// Ellipsoid surface normal is R * diag(1/radii) * u (gradient of the implicit form);
-		// clamp the reciprocal so a near-degenerate (thin) axis does not blow up the normal.
-		const Eigen::Vector3f invRadii = radii.cwiseMax(1e-9f).cwiseInverse();
-		const MVS::Image& imageData = images[viewerImages[cameraIdx].idx];
-		const Point3f center = imageData.camera.C;
-		const Eigen::Vector3f C(center.x, center.y, center.z);
-		ellipsoidCenters.push_back(C); // one per accepted ellipsoid, aligned with the EBO slot order
-		// gray2color maps 0 = red, 1 = blue: invert so blue = best localized, red = worst
-		const float colorValue = MINF(u.MaxPosSigma() / norm, 1.f);
-		const Pixel32F color = Pixel32F::gray2color(1.f - colorValue);
-		const uint32_t baseIndex = (uint32_t)(vertices.size() / 3);
-		for (const Point3f& v : unitVertices) {
-			const Eigen::Vector3f dir(v.x, v.y, v.z);
-			const Eigen::Vector3f p = C + R * radii.cwiseProduct(dir);
-			const Eigen::Vector3f n = (R * invRadii.cwiseProduct(dir)).normalized();
-			vertices.insert(vertices.end(), {p.x(), p.y(), p.z()});
-			normals.insert(normals.end(), {n.x(), n.y(), n.z()});
-			colors.insert(colors.end(), {color.c2, color.c1, color.c0});
+		const MVS::ImageArr& images(layer.scene.images);
+		const ImageArr& viewerImages(layer.images);
+		ASSERT(layer.cameraUncertainty.size() == viewerImages.size());
+		const float norm = layer.cameraUncertaintyNorm > 0.f ? layer.cameraUncertaintyNorm : 1.f;
+		// Effective radius scale = per-layer auto-fit x the global user magnification slider.
+		const float scale = window.uncertaintyEllipsoidScale * layer.cameraUncertaintyAutoScale;
+		FOREACH(cameraIdx, viewerImages) {
+			const Scene::CameraUncertainty& u = layer.cameraUncertainty[cameraIdx];
+			if (!u.IsComputed())
+				continue;
+			// Oriented world-frame error ellipsoid: eigen-decompose the position covariance
+			const Matrix3x3f& cov = u.posCov;
+			Eigen::Matrix3f ecov;
+			ecov << cov(0, 0), cov(0, 1), cov(0, 2),
+			    cov(1, 0), cov(1, 1), cov(1, 2),
+			    cov(2, 0), cov(2, 1), cov(2, 2);
+			const Eigen::SelfAdjointEigenSolver<Eigen::Matrix3f> es(ecov);
+			if (es.info() != Eigen::Success)
+				continue;
+			const Eigen::Vector3f radii = es.eigenvalues().cwiseMax(0.f).cwiseSqrt() * scale;
+			if (radii.maxCoeff() <= 0.f)
+				continue; // gauge datum (or degenerate): nothing to draw
+			const Eigen::Matrix3f R = es.eigenvectors();
+			// Ellipsoid surface normal is R * diag(1/radii) * u (gradient of the implicit form);
+			// clamp the reciprocal so a near-degenerate (thin) axis does not blow up the normal.
+			const Eigen::Vector3f invRadii = radii.cwiseMax(1e-9f).cwiseInverse();
+			const MVS::Image& imageData = images[viewerImages[cameraIdx].idx];
+			const Point3f center = imageData.camera.C;
+			const Eigen::Vector3f C(center.x, center.y, center.z);
+			ellipsoidCenters.push_back(C); // one per accepted ellipsoid, aligned with the EBO slot order
+			ellipsoidLayerIDs.push_back(layer.id);
+			// gray2color maps 0 = red, 1 = blue: invert so blue = best localized, red = worst
+			const float colorValue = MINF(u.MaxPosSigma() / norm, 1.f);
+			const Pixel32F color = Pixel32F::gray2color(1.f - colorValue);
+			const uint32_t baseIndex = (uint32_t)(vertices.size() / 3);
+			for (const Point3f& v : unitVertices) {
+				const Eigen::Vector3f dir(v.x, v.y, v.z);
+				const Eigen::Vector3f p = C + R * radii.cwiseProduct(dir);
+				const Eigen::Vector3f n = (R * invRadii.cwiseProduct(dir)).normalized();
+				vertices.insert(vertices.end(), {p.x(), p.y(), p.z()});
+				normals.insert(normals.end(), {n.x(), n.y(), n.z()});
+				colors.insert(colors.end(), {color.c2, color.c1, color.c0});
+			}
+			for (const uint32_t idx : unitIndices)
+				indices.push_back(baseIndex + idx);
 		}
-		for (const uint32_t idx : unitIndices)
-			indices.push_back(baseIndex + idx);
 	}
 	if (indices.empty())
 		return;
@@ -1071,6 +1250,8 @@ void Renderer::RenderUncertaintyEllipsoids(const Window& window) {
 			return (ellipsoidCenters[a] - eye).squaredNorm() > (ellipsoidCenters[b] - eye).squaredNorm();
 		});
 	for (const uint32_t k : ellipsoidDrawOrder) {
+		if (!IsLayerInPass(ellipsoidLayerIDs[k]))
+			continue;
 		const void* off = reinterpret_cast<const void*>((size_t)k * per * sizeof(uint32_t));
 		GL_CHECK(glCullFace(GL_FRONT));
 		GL_CHECK(glDrawElements(GL_TRIANGLES, per, GL_UNSIGNED_INT, off)); // far (back) faces
@@ -1086,6 +1267,7 @@ void Renderer::RenderUncertaintyEllipsoids(const Window& window) {
 
 void Renderer::UploadSelection(const Window& window) {
 	selectionPrimitiveCount = 0;
+	neighborSelectionPrimitiveCount = 0;
 	if (window.selectionType == Window::SEL_NA)
 		return;
 	const bool requiresSelectionIndex = window.selectionType == Window::SEL_POINT || window.selectionType == Window::SEL_CAMERA;
@@ -1184,6 +1366,7 @@ void Renderer::UploadSelection(const Window& window) {
 
 	// Add neighbor camera geometry if selected
 	if (window.selectedNeighborCamera != NO_ID) {
+		const size_t neighborVertexOffset = selectionVertices.size() / 3;
 		const Image& image = window.GetScene().GetImages()[window.selectedNeighborCamera];
 		const MVS::Image& neighborImage = scene.images[image.idx];
 		ASSERT(neighborImage.IsValid());
@@ -1205,6 +1388,7 @@ void Renderer::UploadSelection(const Window& window) {
 			selectionVertices.insert(selectionVertices.end(), {corner1.x, corner1.y, corner1.z});
 			selectionVertices.insert(selectionVertices.end(), {corner2.x, corner2.y, corner2.z});
 		}
+		neighborSelectionPrimitiveCount = selectionVertices.size() / 3 - neighborVertexOffset;
 	}
 
 	// Upload all selection geometry to GPU if we have any
@@ -1299,7 +1483,13 @@ void Renderer::RenderPointCloud(const Window& window) {
 
 	pointCloudVAO->Bind();
 
-	GL_CHECK(glDrawArrays(GL_POINTS, 0, pointCount));
+	if (layerPassFilter.empty()) {
+		GL_CHECK(glDrawArrays(GL_POINTS, 0, pointCount));
+	} else {
+		for (const LayerIndexRange& range : pointLayerRanges)
+			if (IsLayerInPass(range.layerID))
+				GL_CHECK(glDrawArrays(GL_POINTS, (GLint)range.offset, (GLsizei)range.count));
+	}
 
 	pointCloudVAO->Unbind();
 }
@@ -1315,7 +1505,13 @@ void Renderer::RenderPointCloudNormals(const Window& window) {
 
 	pointCloudNormalsVAO->Bind();
 
-	GL_CHECK(glDrawArrays(GL_LINES, 0, pointNormalCount));
+	if (layerPassFilter.empty()) {
+		GL_CHECK(glDrawArrays(GL_LINES, 0, pointNormalCount));
+	} else {
+		for (const LayerIndexRange& range : pointLayerRanges)
+			if (range.normalCount > 0 && IsLayerInPass(range.layerID))
+				GL_CHECK(glDrawArrays(GL_LINES, (GLint)range.normalOffset, (GLsizei)range.normalCount));
+	}
 
 	pointCloudNormalsVAO->Unbind();
 }
@@ -1343,7 +1539,10 @@ void Renderer::RenderMesh(const Window& window) {
 		// check if this sub-mesh should be rendered
 		if (!window.meshSubMeshVisible.empty() && !window.meshSubMeshVisible[i])
 			continue;
-		const bool textureValid = (i < meshTextures.size()) && meshTextures[i].IsValid();
+		if (!IsLayerInPass(GetMeshSubMeshLayerID(i)))
+			continue;
+		const uint32_t textureIndex = i < meshTextureIndices.size() ? meshTextureIndices[i] : NO_ID;
+		const bool textureValid = textureIndex < meshTextures.size() && meshTextures[textureIndex].IsValid();
 		// check if this sub-mesh has a valid texture
 		const bool hasTexture = texturesEnabled && textureValid;
 		// select the appropriate shader based on texture availability for this sub-mesh
@@ -1353,7 +1552,7 @@ void Renderer::RenderMesh(const Window& window) {
 		currentMeshShader->SetBool("wireframe", isWireframe);
 		if (hasTexture) {
 			GL_CHECK(glActiveTexture(GL_TEXTURE0));
-			GL_CHECK(glBindTexture(GL_TEXTURE_2D, meshTextures[i].GetID()));
+			GL_CHECK(glBindTexture(GL_TEXTURE_2D, meshTextures[textureIndex].GetID()));
 			currentMeshShader->SetInt("diffuseTexture", 0);
 		} else {
 			currentMeshShader->SetVector3("meshColor", Eigen::Vector3f(0.8f, 0.8f, 0.8f));
@@ -1381,24 +1580,57 @@ void Renderer::RenderCameras(const Window& window) {
 	cameraVAO->Bind();
 	cameraEBO->Bind();
 
-	if (window.cameraDisplayType == Window::CAMERA_DISPLAY_DOT) {
-		if (cameraPointIndexCount > 0)
-			GL_CHECK(glDrawElements(GL_POINTS, static_cast<GLsizei>(cameraPointIndexCount), GL_UNSIGNED_INT, 0));
-		if (window.showCameraLookAt && cameraLineIndexCount > 0) {
-			const void* lineOffset = reinterpret_cast<const void*>(cameraPointIndexCount * sizeof(uint32_t));
-			GL_CHECK(glDrawElements(GL_LINES, static_cast<GLsizei>(cameraLineIndexCount), GL_UNSIGNED_INT, lineOffset));
+	// The camera EBO stores all point indices first, then all line indices; each layer owns a
+	// contiguous sub-range in both blocks, so a pass filter reduces to per-layer draw calls.
+	const bool displayDots = window.cameraDisplayType == Window::CAMERA_DISPLAY_DOT;
+	if (layerPassFilter.empty()) {
+		if (displayDots) {
+			if (cameraPointIndexCount > 0)
+				GL_CHECK(glDrawElements(GL_POINTS, static_cast<GLsizei>(cameraPointIndexCount), GL_UNSIGNED_INT, 0));
+			if (window.showCameraLookAt && cameraLineIndexCount > 0) {
+				const void* lineOffset = reinterpret_cast<const void*>(cameraPointIndexCount * sizeof(uint32_t));
+				GL_CHECK(glDrawElements(GL_LINES, static_cast<GLsizei>(cameraLineIndexCount), GL_UNSIGNED_INT, lineOffset));
+			}
+		} else {
+			if (cameraLineIndexCount > 0)
+				GL_CHECK(glDrawElements(GL_LINES, static_cast<GLsizei>(cameraLineIndexCount), GL_UNSIGNED_INT, 0));
 		}
 	} else {
-		if (cameraLineIndexCount > 0)
-			GL_CHECK(glDrawElements(GL_LINES, static_cast<GLsizei>(cameraLineIndexCount), GL_UNSIGNED_INT, 0));
+		for (const CameraLayerRange& range : cameraLayerRanges) {
+			if (!IsLayerInPass(range.layerID))
+				continue;
+			if (displayDots && range.pointIndexCount > 0) {
+				const void* pointOffset = reinterpret_cast<const void*>(range.pointIndexOffset * sizeof(uint32_t));
+				GL_CHECK(glDrawElements(GL_POINTS, static_cast<GLsizei>(range.pointIndexCount), GL_UNSIGNED_INT, pointOffset));
+			}
+			if ((!displayDots || window.showCameraLookAt) && range.lineIndexCount > 0) {
+				const void* lineOffset = reinterpret_cast<const void*>((cameraPointIndexCount + range.lineIndexOffset) * sizeof(uint32_t));
+				GL_CHECK(glDrawElements(GL_LINES, static_cast<GLsizei>(range.lineIndexCount), GL_UNSIGNED_INT, lineOffset));
+			}
+		}
 	}
 
 	cameraVAO->Unbind();
 }
 
 void Renderer::RenderImageOverlays(const Window& window) {
-	if (imageOverlayIndexCount == 0)
+	const Camera& camera(window.GetCamera());
+	if (imageOverlayIndexCount == 0 || !camera.IsCameraViewMode())
 		return;
+	const Scene& sceneController(window.GetScene());
+	const Scene::Layer* layer(sceneController.GetActiveLayer());
+	if (layer == nullptr || !layer->visible)
+		return;
+	const CameraLayerRange* range(FindCameraLayerRange(layer->id));
+	const MVS::IIndex cameraID(camera.GetCurrentCamID());
+	if (range == nullptr || cameraID >= layer->images.size())
+		return;
+	Image& image(const_cast<Image&>(layer->images[cameraID]));
+	if (!image.IsValid()) {
+		if (!image.IsImageValid())
+			return;
+		image.TransferImage();
+	}
 
 	// Set up for 3D rendering with special handling for transparency
 	GL_CHECK(glDisable(GL_DEPTH_TEST)); // Temporarily disable depth testing to ensure visibility
@@ -1416,22 +1648,10 @@ void Renderer::RenderImageOverlays(const Window& window) {
 	imageOverlayVAO->Bind();
 	imageOverlayEBO->Bind();
 
-	FOREACH(imgIdx, window.GetScene().GetImages()) {
-		// Load the image if not already loaded
-		Image& image = window.GetScene().GetImages()[imgIdx];
-		if (!image.IsValid()) {
-			if (!image.IsImageValid())
-				continue; // Image asynchronously loading
-			// Image loaded, create the texture
-			image.TransferImage();
-		}
-		// Bind the camera image texture
-		GL_CHECK(glActiveTexture(GL_TEXTURE0));
-		image.Bind();
-		// Calculate the actual byte offset for glDrawElements
-		const void* indexOffset = reinterpret_cast<const void*>(imgIdx * 6 * sizeof(uint32_t));
-		GL_CHECK(glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, indexOffset));
-	}
+	GL_CHECK(glActiveTexture(GL_TEXTURE0));
+	image.Bind();
+	const void* indexOffset = reinterpret_cast<const void*>((range->offset + cameraID) * 6 * sizeof(uint32_t));
+	GL_CHECK(glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, indexOffset));
 
 	imageOverlayVAO->Unbind();
 
@@ -1443,6 +1663,8 @@ void Renderer::RenderImageOverlays(const Window& window) {
 void Renderer::RenderSelection(const Window& window) {
 	// Highlight selected point in point cloud if applicable
 	if (window.showPointCloud && window.selectionType == Window::SEL_POINT && pointCount > 0 && window.HasSelectionIds()) {
+		const Scene::Layer* activeLayer = window.GetScene().GetActiveLayer();
+		const LayerIndexRange* pointRange = activeLayer != nullptr ? FindPointLayerRange(activeLayer->id) : nullptr;
 		// Use the geometry selection shader for highlighting
 		geometrySelectionShader->Use();
 		geometrySelectionShader->SetBool("useHighlight", true);
@@ -1457,9 +1679,9 @@ void Renderer::RenderSelection(const Window& window) {
 
 		// Render each selected point individually using glDrawArrays with offset
 		for (IDX selectedIdx : window.GetSelectionIds()) {
-			if (selectedIdx >= pointCount)
+			if (pointRange == nullptr || selectedIdx >= pointRange->count)
 				continue;
-			GL_CHECK(glDrawArrays(GL_POINTS, static_cast<GLint>(selectedIdx), 1));
+			GL_CHECK(glDrawArrays(GL_POINTS, static_cast<GLint>(pointRange->offset + selectedIdx), 1));
 		}
 
 		pointCloudVAO->Unbind();
@@ -1497,11 +1719,11 @@ void Renderer::RenderSelection(const Window& window) {
 	GL_CHECK(glDrawArrays(GL_LINES, 0, selectionPrimitiveCount));
 
 	// Render neighbor camera with different color
-	if (window.selectedNeighborCamera != NO_ID) {
+	if (window.selectedNeighborCamera != NO_ID && neighborSelectionPrimitiveCount > 0) {
 		selectionShader->SetFloat("lineWidth", 1.f);
 		selectionShader->SetVector3("selectionColor", Eigen::Vector3f(1.f, 0.f, 1.f)); // Magenta for neighbor camera
 		// Render neighbor camera geometry as lines (starting after primary selection vertices)
-		GL_CHECK(glDrawArrays(GL_LINES, selectionPrimitiveCount, selectionPrimitiveCount));
+		GL_CHECK(glDrawArrays(GL_LINES, selectionPrimitiveCount, neighborSelectionPrimitiveCount));
 	}
 
 	selectionVAO->Unbind();
@@ -1896,6 +2118,9 @@ void Renderer::RenderSelectedGeometry(const Window& window) {
 	const SelectionController& selectionController = window.GetSelectionController();
 	if (!selectionController.hasSelection())
 		return;
+	const Scene::Layer* activeLayer = window.GetScene().GetActiveLayer();
+	if (activeLayer == nullptr)
+		return;
 
 	// Enable blending for highlighting effect
 	GL_CHECK(glEnable(GL_BLEND));
@@ -1909,13 +2134,17 @@ void Renderer::RenderSelectedGeometry(const Window& window) {
 	// Render selected points with highlighting
 	const auto& selectedPointIndices = selectionController.getSelectedPointIndices();
 	if (window.showPointCloud && !selectedPointIndices.empty() && pointCount > 0) {
+		const LayerIndexRange* pointRange = FindPointLayerRange(activeLayer->id);
 		// set highlight size and color for points (red)
 		geometrySelectionShader->SetVector3("highlightColor", Eigen::Vector3f(1.f, 0.f, 0.f));
 		geometrySelectionShader->SetFloat("pointSize", window.pointSize * 2.5f);
 		// render each selected point individually using glDrawArrays with offset
 		pointCloudVAO->Bind();
-		for (const auto& pointIdx : selectedPointIndices)
-			GL_CHECK(glDrawArrays(GL_POINTS, pointIdx, 1));
+		for (const auto& pointIdx : selectedPointIndices) {
+			if (pointRange == nullptr || pointIdx >= pointRange->count)
+				continue;
+			GL_CHECK(glDrawArrays(GL_POINTS, pointRange->offset + pointIdx, 1));
+		}
 		pointCloudVAO->Unbind();
 	}
 
@@ -1931,19 +2160,21 @@ void Renderer::RenderSelectedGeometry(const Window& window) {
 		GL_CHECK(glPolygonOffset(-1.f, -1.f)); // more aggressive offset
 		meshVAO->Bind();
 		meshEBO->Bind();
-		// render only selected faces individually, each face consists of 3 vertices (triangle)
-		const MVS::Scene& scene = window.GetScene().GetScene();
 		for (const auto& faceIdx : selectedFaceIndices) {
-			// get which submesh this face belongs to and its index within that submesh
-			const MVS::Mesh::TexIndex submeshIdx = scene.mesh.GetFaceTextureIndex(faceIdx);
-			ASSERT(submeshIdx < meshFaceCounts.size());
+			uint32_t globalFaceIdx;
+			if (!MapLocalFace(activeLayer->id, faceIdx, globalFaceIdx))
+				continue;
+			if (globalFaceIdx >= globalFaceSubMeshIndices.size())
+				continue;
+			const uint32_t submeshIdx = globalFaceSubMeshIndices[globalFaceIdx];
+			if (submeshIdx >= meshFaceCounts.size())
+				continue;
 			// check if this submesh is visible
 			if (!window.meshSubMeshVisible.empty() && !window.meshSubMeshVisible[submeshIdx])
 				continue;
-			// calculate the actual byte offset for this face in the EBO
-			MVS::Mesh::FIndex submeshOffset = meshFaceCounts[submeshIdx];
-			MVS::Mesh::FIndex faceIdxInSubmesh(mapFaceSubsetIndices.empty() ? faceIdx :  mapFaceSubsetIndices[faceIdx]);
-			const void* indexPtr = reinterpret_cast<const void*>((submeshOffset + faceIdxInSubmesh) * 3 * sizeof(uint32_t));
+			const MVS::Mesh::FIndex faceCountOffset = submeshIdx > 0 ? meshFaceCounts[submeshIdx - 1] : 0u;
+			const MVS::Mesh::FIndex faceIdxInSubmesh = globalFaceIdx - faceCountOffset;
+			const void* indexPtr = reinterpret_cast<const void*>((faceCountOffset + faceIdxInSubmesh) * 3 * sizeof(uint32_t));
 			// render this single face (3 indices)
 			GL_CHECK(glDrawElements(GL_TRIANGLES, 3, GL_UNSIGNED_INT, indexPtr));
 		}
@@ -2006,8 +2237,8 @@ void Renderer::EnsurePickFBOSize(int width, int height) {
 // if a primitive is found returns valid PickResult, where
 // pick.idx is the primitive index (point index or face index) depending on isPoint
 Renderer::PickResult Renderer::PickPrimitiveAt(const Point2f& screenPos, int radius, const Window& window) {
-	// Ensure FBO matches viewport size
-	const cv::Size& vpSize = window.GetCamera().GetSize();
+	// Ensure FBO matches the window framebuffer size
+	const cv::Size& vpSize = window.GetSize();
 	EnsurePickFBOSize(vpSize.width, vpSize.height);
 
 	// Bind pick FBO
@@ -2032,6 +2263,24 @@ Renderer::PickResult Renderer::PickPrimitiveAt(const Point2f& screenPos, int rad
 	GL_CHECK(glEnable(GL_SCISSOR_TEST));
 	GL_CHECK(glScissor(minX, minY, w, h));
 
+	// In compare view each layer is displayed only on its assigned side, so restrict
+	// the pick pass to the layers actually shown under the cursor and rasterize it
+	// with that side's camera and viewport, matching the on-screen rendering.
+	std::vector<uint32_t> cursorSideLayers;
+	if (window.compareMode) {
+		const int cursorSide = screenPos.x >= (float)window.GetCompareSplitX() ? 1 : 0;
+		for (const Scene::Layer& layer : window.GetScene().GetLayers())
+			if (layer.visible && layer.compareRight == (cursorSide == 1))
+				cursorSideLayers.push_back(layer.id);
+		const cv::Rect viewport = window.GetCompareViewport(cursorSide);
+		GL_CHECK(glViewport(viewport.x, viewport.y, viewport.width, viewport.height));
+		UpdateViewProjection(window.GetSideCamera(cursorSide));
+	}
+	const auto layerAtCursor = [&](uint32_t layerID) {
+		return !window.compareMode ||
+			std::find(cursorSideLayers.begin(), cursorSideLayers.end(), layerID) != cursorSideLayers.end();
+	};
+
 	// Render mesh (triangles) into pick FBO only if mesh rendering is enabled and we have mesh data
 	unsigned baseFace = 0;
 	if (window.showMesh && !meshFaceCounts.empty()) {
@@ -2041,6 +2290,8 @@ Renderer::PickResult Renderer::PickPrimitiveAt(const Point2f& screenPos, int rad
 		FOREACH(i, meshFaceCounts) {
 			// skip invisible submeshes if window indicates it
 			if (!window.meshSubMeshVisible.empty() && !window.meshSubMeshVisible[i])
+				continue;
+			if (!layerAtCursor(GetMeshSubMeshLayerID(i)))
 				continue;
 			const MVS::Mesh::FIndex faceCountOffset = i > 0 ? meshFaceCounts[i - 1] : 0u;
 			const MVS::Mesh::FIndex faceCountTotal = meshFaceCounts[i];
@@ -2058,7 +2309,13 @@ Renderer::PickResult Renderer::PickPrimitiveAt(const Point2f& screenPos, int rad
 		pickerPointsShader->Use();
 		pickerPointsShader->SetUInt("uBaseID", baseFace);
 		pointCloudVAO->Bind();
-		GL_CHECK(glDrawArrays(GL_POINTS, 0, pointCount));
+		if (window.compareMode) {
+			for (const LayerIndexRange& range : pointLayerRanges)
+				if (layerAtCursor(range.layerID))
+					GL_CHECK(glDrawArrays(GL_POINTS, (GLint)range.offset, (GLsizei)range.count));
+		} else {
+			GL_CHECK(glDrawArrays(GL_POINTS, 0, pointCount));
+		}
 		pointCloudVAO->Unbind();
 	}
 
@@ -2076,6 +2333,10 @@ Renderer::PickResult Renderer::PickPrimitiveAt(const Point2f& screenPos, int rad
 	// Unbind and restore state
 	GL_CHECK(glDisable(GL_SCISSOR_TEST));
 	GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, 0));
+	if (window.compareMode) {
+		GL_CHECK(glViewport(0, 0, vpSize.width, vpSize.height));
+		UpdateViewProjection(window.GetCamera());
+	}
 
 	// Find nearest non-zero id (smallest depth)
 	float bestDepth = FLT_MAX;
@@ -2099,22 +2360,21 @@ Renderer::PickResult Renderer::PickPrimitiveAt(const Point2f& screenPos, int rad
 	if (bestID < baseFace) {
 		// hit a mesh face
 		result.isPoint = false;
-		result.index = bestID;
+		if (!MapGlobalFace(bestID, result.layerID, result.index))
+			return {};
 		ASSERT(meshEBO && meshVBO);
 		MVS::Mesh::Face face;
-		meshEBO->GetSubData<uint32_t>(face.ptr(), 3, static_cast<size_t>(result.index) * 3);
+		meshEBO->GetSubData<uint32_t>(face.ptr(), 3, static_cast<size_t>(bestID) * 3);
 		meshVBO->GetSubData<float>(result.points[0].ptr(), 3, static_cast<size_t>(face[0]) * 3);
 		meshVBO->GetSubData<float>(result.points[1].ptr(), 3, static_cast<size_t>(face[1]) * 3);
 		meshVBO->GetSubData<float>(result.points[2].ptr(), 3, static_cast<size_t>(face[2]) * 3);
-		// convert face index from subset to original if necessary
-		if (!mapSubsetFaceIndices.empty())
-			result.index = mapSubsetFaceIndices[result.index];
 	} else {
 		// hit a point
 		result.isPoint = true;
-		result.index = bestID - baseFace;
+		if (!MapGlobalPoint(bestID - baseFace, result.layerID, result.index))
+			return {};
 		ASSERT(pointCloudVBO);
-		pointCloudVBO->GetSubData<float>(result.points[0].ptr(), 3, static_cast<size_t>(result.index) * 3);
+		pointCloudVBO->GetSubData<float>(result.points[0].ptr(), 3, static_cast<size_t>(bestID - baseFace) * 3);
 	}
 	return result;
 }

--- a/apps/Viewer/Renderer.h
+++ b/apps/Viewer/Renderer.h
@@ -40,6 +40,7 @@ namespace VIEWER {
 
 // Forward declarations
 class Window;
+class Scene;
 
 struct ViewProjectionData {
 	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -74,16 +75,40 @@ private:
 	std::unique_ptr<VBO> pointCloudNormalsVBO;
 	size_t pointCount;
 	size_t pointNormalCount;
+	struct LayerPrimitiveRef
+	{
+		uint32_t layerID{NO_ID};
+		uint32_t localIndex{NO_ID};
+	};
+	struct LayerIndexRange
+	{
+		uint32_t layerID{NO_ID};
+		size_t offset{0};
+		size_t count{0};
+		size_t normalOffset{0}; // normal-line vertex sub-range (points only)
+		size_t normalCount{0};
+	};
+	std::vector<LayerIndexRange> pointLayerRanges;
+	// Compare split view: scene passes draw only these layers (empty = draw all)
+	std::vector<uint32_t> layerPassFilter;
 
 	// Mesh rendering
 	std::unique_ptr<Shader> meshShader;
 	std::unique_ptr<Shader> meshTexturedShader;
 	std::unique_ptr<VAO> meshVAO;
 	std::unique_ptr<VBO> meshVBO, meshEBO, meshNormalVBO, meshTexCoordVBO;
-	MVS::Mesh::FaceIdxArr mapFaceSubsetIndices; // maps face indices from original mesh to sub-mesh when rendering subsets
-	MVS::Mesh::FaceIdxArr mapSubsetFaceIndices; // maps face indices from sub-mesh to original mesh when rendering subsets
 	std::vector<unsigned> meshFaceCounts; // number of faces till each sub-mesh (subtract the previous to get count per sub-mesh)
 	ImageArr meshTextures;
+	std::vector<uint32_t> meshTextureIndices; // texture index per sub-mesh (NO_ID for untextured sub-meshes)
+	std::vector<uint32_t> meshSubMeshLayerIDs; // owning layer ID per sub-mesh
+	struct LayerFaceMap
+	{
+		uint32_t layerID{NO_ID};
+		std::vector<uint32_t> localToGlobalFace;
+	};
+	std::vector<LayerFaceMap> meshLayerFaceMaps;
+	std::vector<LayerPrimitiveRef> faceRefs;
+	std::vector<uint32_t> globalFaceSubMeshIndices;
 
 	// Geometry selection highlighting (for SelectionController)
 	std::unique_ptr<Shader> geometrySelectionShader;
@@ -94,6 +119,17 @@ private:
 	std::unique_ptr<VBO> cameraVBO, cameraEBO, cameraColorVBO;
 	size_t cameraPointIndexCount;
 	size_t cameraLineIndexCount;
+	struct CameraLayerRange
+	{
+		uint32_t layerID{NO_ID};
+		size_t offset{0}; // first camera slot (indexes the image-overlay quads)
+		size_t count{0};
+		size_t pointIndexOffset{0}; // sub-range in the point block of the camera EBO
+		size_t pointIndexCount{0};
+		size_t lineIndexOffset{0}; // sub-range in the line block of the camera EBO
+		size_t lineIndexCount{0};
+	};
+	std::vector<CameraLayerRange> cameraLayerRanges;
 
 	// Pose-uncertainty ellipsoid rendering (translucent shaded solids, lit + per-vertex color)
 	std::unique_ptr<Shader> ellipsoidShader;
@@ -101,6 +137,7 @@ private:
 	std::unique_ptr<VBO> ellipsoidVBO, ellipsoidNormalVBO, ellipsoidEBO, ellipsoidColorVBO;
 	size_t ellipsoidIndexCount;
 	std::vector<Eigen::Vector3f> ellipsoidCenters; // world-space center per accepted ellipsoid, aligned with the EBO slots
+	std::vector<uint32_t> ellipsoidLayerIDs; // owning layer per accepted ellipsoid, aligned with ellipsoidCenters
 	std::vector<uint32_t> ellipsoidDrawOrder; // reused scratch for the per-frame back-to-front sort
 
 	// 3D image overlay rendering (pre-computed for all images with valid textures)
@@ -115,6 +152,7 @@ private:
 	std::unique_ptr<VAO> selectionVAO;
 	std::unique_ptr<VBO> selectionVBO;
 	size_t selectionPrimitiveCount;
+	size_t neighborSelectionPrimitiveCount;
 
 	// Selection overlay rendering (2D screen space)
 	std::unique_ptr<Shader> selectionOverlayShader;
@@ -162,8 +200,8 @@ public:
 	void Reset();
 
 	// Data upload
-	void UploadPointCloud(const MVS::PointCloud& pointcloud, float normalLength);
-	void UploadMesh(MVS::Mesh& mesh);
+	void UploadLayers(const Scene& sceneController, const Window& window);
+	void UploadPointClouds(const Scene& sceneController, float normalLength);
 	void UploadCameras(const Window& window);
 	void UploadUncertaintyEllipsoids(const Window& window);
 	void UploadSelection(const Window& window);
@@ -171,6 +209,9 @@ public:
 
 	// Rendering
 	void BeginFrame(const Camera& camera, const Eigen::Vector4f& clearColor);
+	// Re-prime the cached view-projection matrices; called by the compare view to
+	// render each side with its own camera (BeginFrame primes the main camera)
+	void UpdateViewProjection(const Camera& camera);
 	void SetLighting(const Eigen::Vector3f& direction, float intensity, const Eigen::Vector3f& color);
 
 	void RenderPointCloud(const Window& window);
@@ -195,9 +236,10 @@ public:
 
 	struct PickResult {
 		uint32_t index{NO_ID};
+		uint32_t layerID{NO_ID};
 		Point3f points[3];
 		bool isPoint;
-		bool IsValid() const { return index != NO_ID; }
+		bool IsValid() const { return index != NO_ID && layerID != NO_ID; }
 	};
 	PickResult PickPrimitiveAt(const Point2f& screenPos, int radius, const Window& window);
 
@@ -205,12 +247,25 @@ public:
 
 	// Getters
 	size_t GetMeshSubMeshCount() const { return meshFaceCounts.size(); }
+	uint32_t GetMeshSubMeshLayerID(size_t submeshIdx) const
+	{
+		return submeshIdx < meshSubMeshLayerIDs.size() ? meshSubMeshLayerIDs[submeshIdx] : NO_ID;
+	}
+
+	// Compare split view: restrict the scene render passes to a subset of layers (empty = all)
+	void SetLayerPassFilter(std::vector<uint32_t> layerIDs) { layerPassFilter = std::move(layerIDs); }
+	void ClearLayerPassFilter() { layerPassFilter.clear(); }
+	bool IsLayerInPass(uint32_t layerID) const
+	{
+		return layerPassFilter.empty() ||
+			std::find(layerPassFilter.begin(), layerPassFilter.end(), layerID) != layerPassFilter.end();
+	}
 
 private:
 	void CreateShaders();
 	void CreateBuffers();
-	void UpdateViewProjection(const Camera& camera);
 	void UpdateLighting();
+	void UploadMeshes(const Scene& sceneController);
 
 	// Utility methods
 	void SetupPointCloudBuffers();
@@ -236,10 +291,17 @@ private:
 	                                    std::vector<uint32_t>& indices,
 	                                    uint32_t baseIndex = 0);
 
-    // Ensure pick FBO matches requested size (creates or recreates textures/renderbuffers)
-    void EnsurePickFBOSize(int width, int height);
-    // Release picker buffers (textures, renderbuffers, FBO)
-    void ReleasePickerBuffers();
+	// Ensure pick FBO matches requested size (creates or recreates textures/renderbuffers)
+	void EnsurePickFBOSize(int width, int height);
+	// Release picker buffers (textures, renderbuffers, FBO)
+	void ReleasePickerBuffers();
+
+	const LayerIndexRange* FindPointLayerRange(uint32_t layerID) const;
+	const CameraLayerRange* FindCameraLayerRange(uint32_t layerID) const;
+	const LayerFaceMap* FindMeshLayerMap(uint32_t layerID) const;
+	bool MapGlobalPoint(size_t globalIndex, uint32_t& layerID, uint32_t& localIndex) const;
+	bool MapGlobalFace(size_t globalIndex, uint32_t& layerID, uint32_t& localIndex) const;
+	bool MapLocalFace(uint32_t layerID, uint32_t localIndex, uint32_t& globalIndex) const;
 };
 /*----------------------------------------------------------------*/
 

--- a/apps/Viewer/Scene.cpp
+++ b/apps/Viewer/Scene.cpp
@@ -1845,7 +1845,7 @@ void Scene::OnCastRay(const Point2f& screenPos, const Ray3d& ray, int button, in
 		const Layer* previousActiveLayer = GetActiveLayer();
 		const uint32_t previousActiveLayerID = previousActiveLayer != NULL ? previousActiveLayer->id : NO_ID;
 		uint32_t newSelectionLayerID = previousActiveLayerID;
-		Point3f newSelectionPoints[4];
+		Point3f newSelectionPoints[4]{};
 		const Renderer::PickResult pickResult = window.GetRenderer().PickPrimitiveAt(screenPos, pickRadius, window);
 		if (pickResult.IsValid()) {
 			newSelectionLayerID = pickResult.layerID;
@@ -1898,7 +1898,7 @@ void Scene::OnCastRay(const Point2f& screenPos, const Ray3d& ray, int button, in
 			const bool selectionLayerChanged = previousActiveLayerID != newSelectionLayerID;
 			SetActiveLayerByID(newSelectionLayerID, false);
 			Layer* activeLayer = GetActiveLayer();
-			ASSERT(activeLayer != NULL);
+			ASSERT(activeLayer != NULL && activeLayer->id == newSelectionLayerID);
 			const ImageArr& images(activeLayer->images);
 			MVS::Scene& scene(activeLayer->scene);
 			window.selectionType = newSelectionType;

--- a/apps/Viewer/Scene.cpp
+++ b/apps/Viewer/Scene.cpp
@@ -316,7 +316,7 @@ void ActivateWorkingFolder(const Scene::Layer& layer)
 
 String MakeUniqueLayerLabel(const Scene::LayerArr& layers, const String& requestedLabel, uint32_t ignoredLayerID = NO_ID)
 {
-	const String baseLabel(requestedLabel.empty() ? _T("Untitled") : requestedLabel);
+	const String baseLabel(requestedLabel.empty() ? String(_T("Untitled")) : requestedLabel);
 	String label(baseLabel);
 	for (unsigned suffix = 2;; ++suffix) {
 		bool duplicate = false;

--- a/apps/Viewer/Scene.cpp
+++ b/apps/Viewer/Scene.cpp
@@ -62,23 +62,32 @@ class EVTLoadImage : public Event
 {
 public:
 	Scene* pScene;
+	uint32_t layerID;
 	MVS::IIndex idx;
 	unsigned nMaxResolution;
 	bool Run(void*) {
-		Image& image = pScene->images[idx];
+		const auto finish = [&](bool success) {
+			pScene->pendingImageLoads.fetch_sub(1);
+			return success;
+		};
+		Scene::Layer* layer = pScene->GetLayerByID(layerID);
+		if (layer == NULL || idx >= layer->images.size())
+			return finish(false);
+		Image& image = layer->images[idx];
 		ASSERT(image.idx != NO_ID);
-		MVS::Image& imageData = pScene->scene.images[image.idx];
+		MVS::Image& imageData = layer->scene.images[image.idx];
 		ASSERT(imageData.IsValid());
-		if (imageData.image.empty() && !imageData.ReloadImage(nMaxResolution))
-			return false;
-		imageData.UpdateCamera(pScene->scene.platforms);
+		if (imageData.image.empty() && !imageData.ReloadImage(nMaxResolution)) {
+			image.CancelImageLoading();
+			return finish(false);
+		}
+		imageData.UpdateCamera(layer->scene.platforms);
 		image.AssignImage(imageData.image);
 		imageData.ReleaseImage();
 		glfwPostEmptyEvent();
-		return true;
+		return finish(true);
 	}
-	EVTLoadImage(Scene* _pScene, MVS::IIndex _idx, unsigned _nMaxResolution=0)
-		: Event(EVT_JOB), pScene(_pScene), idx(_idx), nMaxResolution(_nMaxResolution) {}
+	EVTLoadImage(Scene* _pScene, uint32_t _layerID, MVS::IIndex _idx, unsigned _nMaxResolution = 0) : Event(EVT_JOB), pScene(_pScene), layerID(_layerID), idx(_idx), nMaxResolution(_nMaxResolution) {}
 };
 
 // Base class for workflow events
@@ -86,9 +95,9 @@ class EventWorkflow : public Event
 {
 public:
 	Scene* pScene;
+	uint32_t layerID;
 
-	EventWorkflow(Scene* _pScene)
-		: Event(EVT_JOB), pScene(_pScene) {}
+	EventWorkflow(Scene* _pScene, uint32_t _layerID) : Event(EVT_JOB), pScene(_pScene), layerID(_layerID) {}
 
 	virtual ~EventWorkflow() {}
 
@@ -110,18 +119,27 @@ public:
 class EVTWorkflowEstimateROI : public EventWorkflow
 {
 public:
+	const Scene::EstimateROIWorkflowOptions options;
+
 	bool Execute() override {
-		const auto& options = pScene->estimateROIOptions;
-		return pScene->scene.EstimateROI(options.scaleROI, options.upAxis);
+		Scene::Layer* layer = pScene->GetLayerByID(layerID);
+		if (layer == NULL)
+			return false;
+		return layer->scene.EstimateROI(options.scaleROI, options.upAxis);
 	}
-	EVTWorkflowEstimateROI(Scene* _pScene) : EventWorkflow(_pScene) {}
+	EVTWorkflowEstimateROI(Scene* _pScene, uint32_t _layerID, const Scene::EstimateROIWorkflowOptions& _options)
+		: EventWorkflow(_pScene, _layerID), options(_options) {}
 };
 
 class EVTWorkflowDensify : public EventWorkflow
 {
 public:
+	const Scene::DensifyWorkflowOptions options;
+
 	bool Execute() override {
-		const auto& options = pScene->densifyOptions;
+		Scene::Layer* layer = pScene->GetLayerByID(layerID);
+		if (layer == NULL)
+			return false;
 		// Set MVS options
 		MVS::OPTDENSE::init();
 		MVS::OPTDENSE::update();
@@ -142,17 +160,22 @@ public:
 		MVS::OPTDENSE::bRemoveDmaps = options.removeDepthMaps;
 		MVS::OPTDENSE::nOptimize = options.postprocess ? (unsigned)MVS::OPTDENSE::OPTIMIZE : 0u;
 
-		return pScene->scene.DenseReconstruction(options.fusionMode, options.cropToROI, options.borderROI, options.sampleMeshNeighbors);
+		return layer->scene.DenseReconstruction(options.fusionMode, options.cropToROI, options.borderROI, options.sampleMeshNeighbors);
 	}
-	EVTWorkflowDensify(Scene* _pScene) : EventWorkflow(_pScene) {}
+	EVTWorkflowDensify(Scene* _pScene, uint32_t _layerID, const Scene::DensifyWorkflowOptions& _options)
+		: EventWorkflow(_pScene, _layerID), options(_options) {}
 };
 
 class EVTWorkflowReconstructMesh : public EventWorkflow
 {
 public:
+	const Scene::ReconstructMeshWorkflowOptions options;
+
 	bool Execute() override {
-		const auto& options = pScene->reconstructOptions;
-		MVS::Scene& mvsScene = pScene->scene;
+		Scene::Layer* layer = pScene->GetLayerByID(layerID);
+		if (layer == NULL)
+			return false;
+		MVS::Scene& mvsScene = layer->scene;
 
 		// Remove point weights if constant weight requested
 		if (options.constantWeight)
@@ -185,29 +208,39 @@ public:
 		mvsScene.mesh.Clean(decimate, options.removeSpurious, options.removeSpikes, options.closeHoles, options.smoothSteps, options.edgeLength);
 		return true;
 	}
-	EVTWorkflowReconstructMesh(Scene* _pScene) : EventWorkflow(_pScene) {}
+	EVTWorkflowReconstructMesh(Scene* _pScene, uint32_t _layerID, const Scene::ReconstructMeshWorkflowOptions& _options)
+		: EventWorkflow(_pScene, _layerID), options(_options) {}
 };
 
 class EVTWorkflowRefineMesh : public EventWorkflow
 {
 public:
+	const Scene::RefineMeshWorkflowOptions options;
+
 	bool Execute() override {
-		const auto& options = pScene->refineOptions;
-		return pScene->scene.RefineMesh(options.resolutionLevel, options.minResolution, options.maxViews,
-			options.decimateMesh, options.closeHoles, options.ensureEdgeSize, options.maxFaceArea,
-			options.scales, options.scaleStep, options.alternatePair, options.regularityWeight,
-			options.rigidityElasticityRatio, options.gradientStep, options.planarVertexRatio,
-			options.reduceMemory);
+		Scene::Layer* layer = pScene->GetLayerByID(layerID);
+		if (layer == NULL)
+			return false;
+		return layer->scene.RefineMesh(options.resolutionLevel, options.minResolution, options.maxViews,
+		                               options.decimateMesh, options.closeHoles, options.ensureEdgeSize, options.maxFaceArea,
+		                               options.scales, options.scaleStep, options.alternatePair, options.regularityWeight,
+		                               options.rigidityElasticityRatio, options.gradientStep, options.planarVertexRatio,
+		                               options.reduceMemory);
 	}
-	EVTWorkflowRefineMesh(Scene* _pScene) : EventWorkflow(_pScene) {}
+	EVTWorkflowRefineMesh(Scene* _pScene, uint32_t _layerID, const Scene::RefineMeshWorkflowOptions& _options)
+		: EventWorkflow(_pScene, _layerID), options(_options) {}
 };
 
 class EVTWorkflowTextureMesh : public EventWorkflow
 {
 public:
+	const Scene::TextureMeshWorkflowOptions options;
+
 	bool Execute() override {
-		const auto& options = pScene->textureOptions;
-		MVS::Scene& mvsScene = pScene->scene;
+		Scene::Layer* layer = pScene->GetLayerByID(layerID);
+		if (layer == NULL)
+			return false;
+		MVS::Scene& mvsScene = layer->scene;
 
 		// Clean and decimate mesh
 		float decimate = CLAMP(options.decimateMesh, 0.f, 1.f);
@@ -221,7 +254,8 @@ public:
 			options.localSeamLeveling, options.textureSizeMultiple,
 			Pixel8U(options.emptyColor), options.sharpnessWeight, options.ignoreMaskLabel, options.maxTextureSize);
 	}
-	EVTWorkflowTextureMesh(Scene* _pScene) : EventWorkflow(_pScene) {}
+	EVTWorkflowTextureMesh(Scene* _pScene, uint32_t _layerID, const Scene::TextureMeshWorkflowOptions& _options)
+		: EventWorkflow(_pScene, _layerID), options(_options) {}
 };
 
 void* Scene::ThreadWorker(void*) {
@@ -247,16 +281,81 @@ void* Scene::ThreadWorker(void*) {
 SEACAVE::EventQueue Scene::events;
 SEACAVE::Thread Scene::thread;
 
+namespace {
+bool IsSceneProjectFile(const String& fileName)
+{
+	const String ext(Util::getFileExt(fileName).ToLower());
+	return ext == _T(".mvs") || ext == _T(".sfm") || ext == _T(".dmap");
+}
+
+bool IsGeometryFile(const String& fileName)
+{
+	const String ext(Util::getFileExt(fileName).ToLower());
+	return ext == _T(".ply") || ext == _T(".obj") || ext == _T(".gltf") || ext == _T(".glb");
+}
+
+String GetDefaultSaveFileName(const Scene::Layer& layer)
+{
+	if (IsSceneProjectFile(layer.sceneName))
+		return Util::insertBeforeFileExt(layer.sceneName, _T("_new"));
+	return Util::getFileFullName(layer.sceneName) + _T("_new.mvs");
+}
+
+void ActivateWorkingFolder(const String& folder)
+{
+	if (folder.empty())
+		return;
+	WORKING_FOLDER = folder;
+	INIT_WORKING_FOLDER;
+}
+
+void ActivateWorkingFolder(const Scene::Layer& layer)
+{
+	ActivateWorkingFolder(layer.workingFolder);
+}
+
+template <typename Geometry>
+AABB3f ComputeViewerBounds(const Geometry& geometry, size_t elementCount)
+{
+	// Percentile bounds keep reconstruction outliers from making the useful
+	// geometry tiny. Small inputs need their full extent, because trimming only
+	// a handful of samples can collapse an axis or discard most of the model.
+	constexpr size_t MIN_ROBUST_BOUNDS_ELEMENTS = 100;
+	AABB3f bounds(elementCount < MIN_ROBUST_BOUNDS_ELEMENTS
+	                  ? geometry.GetAABB()
+	                  : geometry.GetAABB(0.1f, 0.9f));
+	if (bounds.IsEmpty())
+		bounds = geometry.GetAABB();
+
+	float maxExtent = 0.f;
+	for (int axis = 0; axis < 3; ++axis) {
+		if (!std::isfinite(bounds.ptMin[axis]) || !std::isfinite(bounds.ptMax[axis]))
+			return AABB3f(true);
+		maxExtent = MAXF(maxExtent, bounds.ptMax[axis] - bounds.ptMin[axis]);
+	}
+	const float padding = MAXF(maxExtent * 0.005f, 0.001f);
+	for (int axis = 0; axis < 3; ++axis) {
+		if (bounds.ptMin[axis] < bounds.ptMax[axis])
+			continue;
+		const float center = (bounds.ptMin[axis] + bounds.ptMax[axis]) * 0.5f;
+		bounds.ptMin[axis] = center - padding;
+		bounds.ptMax[axis] = center + padding;
+	}
+	return bounds;
+}
+} // unnamed namespace
+
 Scene::Scene(ARCHIVE_TYPE _nArchiveType)
 	: nArchiveType(_nArchiveType)
-	, geometryMesh(false)
 	, estimateSfMNormals(false)
 	, estimateSfMPatches(false)
-	, cameraUncertaintyNorm(0.f)
-	, cameraUncertaintyAutoScale(1.f)
+	, activeLayerIndex(-1)
+	, nextLayerID(1)
+	, workflowLayerID(NO_ID)
 	, workflowState(WF_STATE_IDLE)
 	, currentWorkflowType(WF_NONE)
 	, geometryModified(false)
+	, pendingImageLoads(0)
 	, workflowStartTime(0.0)
 {
 }
@@ -269,19 +368,18 @@ void Scene::Reset()
 {
 	window.Reset();
 	trackBasedNeighbors.Release();
-	cameraUncertainty.Release();
-	cameraUncertaintyNorm = 0.f;
-	cameraUncertaintyAutoScale = 1.f;
-	images.Release();
-	scene.Release();
-	sceneName.clear();
-	geometryName.clear();
+	batchWorkflowActive = false;
+	batchWorkflowQueue.clear();
+	ClearLayers();
+	geometryModified.store(false);
+	UpdateWindowTitle();
 }
+
 void Scene::Release()
 {
 	if (window.IsValid())
 		window.SetVisible(false);
-	if (!thread.isRunning()) {
+	if (thread.isRunning()) {
 		events.AddEvent(new EVTClose());
 		thread.join();
 	}
@@ -298,15 +396,20 @@ bool Scene::Initialize(const cv::Size& size, const String& windowName, const Str
 	}
 	VERBOSE("OpenGL: %s %s", glGetString(GL_RENDERER), glGetString(GL_VERSION));
 	name = windowName;
+	window.GetCamera().SetCameraViewModeCallback([this](MVS::IIndex camID) {
+		OnSetCameraViewMode(camID);
+	});
 
 	// init working thread
 	thread.start(ThreadWorker);
 
 	// open scene or init empty scene
-	if (!fileName.empty())
-		Open(fileName, geometryFileName);
-	else
+	if (!fileName.empty()) {
+		if (!Open(fileName, geometryFileName))
+			return false;
+	} else {
 		window.SetVisible(true);
+	}
 	return true;
 }
 
@@ -317,7 +420,7 @@ void Scene::Run() {
 // Set the view camera from a transform file (12 or 16 whitespace-separated
 // values, row-major; camera-to-world: columns are the camera X,Y,Z axes in
 // world space, last column is the camera center). Returns false if the file
-// is missing or malformed, leaving the current (auto-fit) view unchanged.
+// is missing or malformed, leaving the current view unchanged.
 bool Scene::SetViewFromFile(const String& viewFileName) {
 	Matrix3x4 m;
 	if (!Util::loadMatrix3x4(viewFileName, m)) {
@@ -329,196 +432,567 @@ bool Scene::SetViewFromFile(const String& viewFileName) {
 	return true;
 }
 
-// Set the view camera to exactly match a scene camera's pose and FOV — what
-// the photo would have framed (camIndex is clamped to the available valid
-// cameras). Returns false if the scene has no cameras.
+// Set the view camera to exactly match an active-layer scene camera's pose and FOV.
 bool Scene::SetViewFromCamera(unsigned camIndex) {
-	if (!IsOpen() || images.empty()) {
+	Layer* layer = GetActiveLayer();
+	if (layer == NULL || layer->images.empty()) {
 		DEBUG("error: no scene cameras to set the view from");
 		return false;
 	}
-	if (camIndex >= images.size())
-		camIndex = images.size() / 2; // sensible default: a central view
-	const MVS::Image& imageData = scene.images[images[camIndex].idx];
-	// pose + FOV exactly as captured (no camera-view-mode, so no image overlay)
+	if (camIndex >= layer->images.size())
+		camIndex = layer->images.size() / 2;
+	const MVS::Image& imageData = layer->scene.images[layer->images[camIndex].idx];
 	window.GetCamera().SetCameraFromSceneData(imageData);
 	DEBUG("View set from scene camera %u", camIndex);
 	return true;
 }
 
-double Scene::GetWorkflowElapsedTime() const {
-	if (workflowState.load() != WF_STATE_RUNNING || workflowStartTime == 0.0)
-		return 0.0;
-	return glfwGetTime() - workflowStartTime;
+void Scene::ClearLayers()
+{
+	ASSERT(!HasPendingImageLoads());
+	layers.clear();
+	activeLayerIndex = -1;
+	nextLayerID = 1;
+	workflowLayerID = NO_ID;
 }
 
-void Scene::CheckWorkflowCompletion() {
-	const WorkflowState state = workflowState.load();
-	if (state == WF_STATE_COMPLETED || state == WF_STATE_FAILED) {
-		// Workflow completed, finalize it on the main thread
-		const bool success = (state == WF_STATE_COMPLETED);
-		FinalizeWorkflow(success);
-	}
+Scene::Layer* Scene::GetLayer(size_t idx)
+{
+	return idx < layers.size() ? &layers[idx] : NULL;
 }
 
-void Scene::FinalizeWorkflow(bool success) {
-	SEACAVE::Lock lock(workflowMutex);
+const Scene::Layer* Scene::GetLayer(size_t idx) const
+{
+	return idx < layers.size() ? &layers[idx] : NULL;
+}
 
-	// Check if we need to finalize (already done or not running)
-	const WorkflowState state = workflowState.load();
-	if (state != WF_STATE_COMPLETED && state != WF_STATE_FAILED)
-		return;
+Scene::Layer* Scene::GetActiveLayer()
+{
+	return activeLayerIndex >= 0 && (size_t)activeLayerIndex < layers.size() ? &layers[activeLayerIndex] : NULL;
+}
 
-	// Calculate duration directly (can't use GetWorkflowElapsedTime since state is no longer RUNNING)
-	const double currentTime = glfwGetTime();
-	const double duration = (workflowStartTime > 0.0) ? (currentTime - workflowStartTime) : 0.0;
-	const WorkflowType type = currentWorkflowType.load();
+const Scene::Layer* Scene::GetActiveLayer() const
+{
+	return activeLayerIndex >= 0 && (size_t)activeLayerIndex < layers.size() ? &layers[activeLayerIndex] : NULL;
+}
 
-	// Add to workflow history
-	workflowHistory.push_back({type, duration, success});
+Scene::Layer* Scene::GetLayerByID(uint32_t layerID)
+{
+	for (Layer& layer : layers)
+		if (layer.id == layerID)
+			return &layer;
+	return NULL;
+}
 
-	if (success) {
-		DEBUG("Workflow completed successfully: %s (%.2f seconds)",
-			type == WF_ESTIMATE_ROI ? "Estimate ROI" :
-			type == WF_DENSIFY ? "Densify" :
-			type == WF_RECONSTRUCT ? "Reconstruct Mesh" :
-			type == WF_REFINE ? "Refine Mesh" :
-			type == WF_TEXTURE ? "Texture Mesh" : "Unknown",
-			duration);
+const Scene::Layer* Scene::GetLayerByID(uint32_t layerID) const
+{
+	for (const Layer& layer : layers)
+		if (layer.id == layerID)
+			return &layer;
+	return NULL;
+}
 
-		// Re-upload geometry to GPU buffers
-		window.UploadRenderData();
+bool Scene::HasVisibleLayers() const
+{
+	for (const Layer& layer : layers)
+		if (layer.visible)
+			return true;
+	return false;
+}
 
-		// Mark geometry as modified
-		geometryModified.store(true);
+bool Scene::HasCameraUncertainty() const
+{
+	for (const Layer& layer : layers)
+		if (!layer.cameraUncertainty.empty())
+			return true;
+	return false;
+}
 
-		// Request window redraw
-		window.RequestRedraw();
+void Scene::RefreshLayerState(Layer& layer, bool rebuildImages)
+{
+	MVS::Scene& scene(layer.scene);
+	AABB3f bounds(true);
+	AABB3f imageBounds(true);
+
+	if (scene.IsBounded()) {
+		bounds = scene.obb.GetAABB();
 	} else {
-		DEBUG("Workflow failed: %s",
-			type == WF_ESTIMATE_ROI ? "Estimate ROI" :
-			type == WF_DENSIFY ? "Densify" :
-			type == WF_RECONSTRUCT ? "Reconstruct Mesh" :
-			type == WF_REFINE ? "Refine Mesh" :
-			type == WF_TEXTURE ? "Texture Mesh" : "Unknown");
+		if (!scene.pointcloud.IsEmpty())
+			bounds = ComputeViewerBounds(scene.pointcloud, scene.pointcloud.points.size());
+		if (!scene.mesh.IsEmpty()) {
+			scene.mesh.ComputeNormalFaces();
+			bounds.Insert(ComputeViewerBounds(scene.mesh, scene.mesh.vertices.size()));
+		}
 	}
 
-	// Reset workflow state
-	workflowState.store(WF_STATE_IDLE);
-	currentWorkflowType.store(WF_NONE);
-	workflowStartTime = 0.0;
+	if (rebuildImages)
+		layer.images.Release();
+	if (rebuildImages || layer.images.empty()) {
+		layer.images.Reserve(scene.images.size());
+		FOREACH(idxImage, scene.images) {
+			const MVS::Image& imageData = scene.images[idxImage];
+			if (!imageData.IsValid())
+				continue;
+			layer.images.emplace_back(idxImage);
+			imageBounds.InsertFull(Cast<float>(imageData.camera.C));
+		}
+	} else {
+		for (const Image& image : layer.images)
+			imageBounds.InsertFull(Cast<float>(scene.images[image.idx].camera.C));
+	}
+	if (bounds.IsEmpty() && !imageBounds.IsEmpty()) {
+		imageBounds.Enlarge(0.5);
+		bounds = imageBounds;
+	}
+
+	layer.bounds = bounds;
+	if (bounds.IsEmpty())
+		layer.sceneSize = Point3f(1, 1, 1);
+	else
+		layer.sceneSize = Point3f(bounds.GetSize().cast<float>());
+	layer.sceneDistance = layer.images.empty() ? 1.f : scene.ComputeDistanceCameras2Scene(0.1f, true);
+	if (layer.label.empty()) {
+		layer.label = Util::getFileName(layer.sceneName);
+	}
 }
 
-bool Scene::Open(const String& fileName, String geometryFileName) {
+float Scene::ComputeVisibleSceneDistance() const
+{
+	float sceneDistance = 1.f;
+	bool foundVisibleLayer = false;
+	for (const Layer& layer : layers) {
+		if (!layer.visible)
+			continue;
+		sceneDistance = MAXF(sceneDistance, layer.sceneDistance);
+		foundVisibleLayer = true;
+	}
+	if (!foundVisibleLayer) {
+		const Layer* layer = GetActiveLayer();
+		if (layer != NULL)
+			sceneDistance = MAXF(sceneDistance, layer->sceneDistance);
+	}
+	return sceneDistance;
+}
+
+void Scene::UpdateWindowSceneBounds(bool resetView)
+{
+	if (!window.IsValid())
+		return;
+	AABB3f bounds(true);
+	for (const Layer& layer : layers) {
+		if (!layer.visible || layer.bounds.IsEmpty())
+			continue;
+		bounds.Insert(layer.bounds);
+	}
+	if (bounds.IsEmpty()) {
+		const Layer* layer = GetActiveLayer();
+		if (layer != NULL && !layer->bounds.IsEmpty())
+			bounds = layer->bounds;
+	}
+	if (bounds.IsEmpty())
+		return;
+	if (resetView)
+		window.SetSceneBounds(bounds.GetCenter(), bounds.GetSize().cast<float>());
+}
+
+void Scene::RefreshVisibleLayers()
+{
+	window.GetCamera().SetSceneDistance(ComputeVisibleSceneDistance());
+	window.UploadRenderData();
+}
+
+void Scene::UpdateWindowTitle()
+{
+	if (!window.IsValid())
+		return;
+	if (!IsOpen()) {
+		window.SetTitle(name);
+		return;
+	}
+	const Layer* activeLayer(GetActiveLayer());
+	ASSERT(activeLayer != NULL);
+	window.SetTitle(String::FormatString((name + _T(": %s [%u layers]")).c_str(), activeLayer->label.c_str(), (unsigned)layers.size()));
+}
+
+void Scene::UpdateGeometryModifiedFlag()
+{
+	bool modified = false;
+	for (const Layer& layer : layers) {
+		if (layer.dirty) {
+			modified = true;
+			break;
+		}
+	}
+	geometryModified.store(modified);
+}
+
+void Scene::SetGeometryModified(bool modified)
+{
+	Layer* layer = GetActiveLayer();
+	if (layer != NULL)
+		layer->dirty = modified;
+	if (modified)
+		geometryModified.store(true);
+	else
+		UpdateGeometryModifiedFlag();
+}
+
+bool Scene::SetActiveLayer(size_t layerIndex, bool requestRedraw)
+{
+	if (HasBackgroundWork()) {
+		DEBUG("Cannot change the active layer while background work is running");
+		return false;
+	}
+	if (layerIndex >= layers.size())
+		return false;
+	if ((int)layerIndex == activeLayerIndex) {
+		ActivateWorkingFolder(layers[layerIndex]);
+		return true;
+	}
+	activeLayerIndex = (int)layerIndex;
+	const Layer& layer(layers[layerIndex]);
+	ActivateWorkingFolder(layer);
+	PrecomputeTrackBasedNeighbors();
+	window.GetCamera().SetMaxCamID(layer.images.size());
+	window.GetCamera().SetSceneDistance(ComputeVisibleSceneDistance());
+	window.GetCamera().DisableCameraViewMode();
+	window.GetSelectionController().clearSelection();
+	window.selectionType = Window::SEL_NA;
+	window.ClearSelectionIds();
+	window.selectedNeighborCamera = NO_ID;
+	window.GetRenderer().UploadSelection(window);
+	window.GetRenderer().UploadBounds(layer.scene);
+	UpdateWindowTitle();
+	if (requestRedraw)
+		window.RequestRedraw();
+	return true;
+}
+
+bool Scene::SetActiveLayerByID(uint32_t layerID, bool requestRedraw)
+{
+	for (size_t i = 0; i < layers.size(); ++i) {
+		if (layers[i].id == layerID)
+			return SetActiveLayer(i, requestRedraw);
+	}
+	return false;
+}
+
+void Scene::SetLayerVisible(size_t layerIndex, bool visible)
+{
+	if (HasBackgroundWork()) {
+		DEBUG("Cannot change layer visibility while background work is running");
+		return;
+	}
+	Layer* layer = GetLayer(layerIndex);
+	if (layer == NULL || layer->visible == visible)
+		return;
+	layer->visible = visible;
+	RefreshVisibleLayers();
+}
+
+void Scene::SetAllLayersVisible(bool visible)
+{
+	if (HasBackgroundWork()) {
+		DEBUG("Cannot change layer visibility while background work is running");
+		return;
+	}
+	bool visibilityChanged = false;
+	for (Layer& layer : layers) {
+		if (layer.visible != visible) {
+			layer.visible = visible;
+			visibilityChanged = true;
+		}
+	}
+	if (!visibilityChanged)
+		return;
+	RefreshVisibleLayers();
+}
+
+void Scene::SoloLayer(size_t layerIndex)
+{
+	if (HasBackgroundWork()) {
+		DEBUG("Cannot solo a layer while background work is running");
+		return;
+	}
+	if (layerIndex >= layers.size())
+		return;
+	bool alreadySolo = layers[layerIndex].visible;
+	for (size_t i = 0; i < layers.size(); ++i) {
+		if (i == layerIndex)
+			continue;
+		if (layers[i].visible) {
+			alreadySolo = false;
+			break;
+		}
+	}
+	if (alreadySolo) {
+		for (Layer& layer : layers)
+			layer.visible = true;
+	} else {
+		for (size_t i = 0; i < layers.size(); ++i)
+			layers[i].visible = (i == layerIndex);
+	}
+	if (layers.size() == 1 && alreadySolo)
+		return;
+	RefreshVisibleLayers();
+}
+
+void Scene::ActivateNextLayer(int direction)
+{
+	if (layers.empty())
+		return;
+	const int layerCount((int)layers.size());
+	const int nextIndex((activeLayerIndex + direction + layerCount) % layerCount);
+	SetActiveLayer((size_t)nextIndex);
+}
+
+void Scene::EnableCompareMode(Window::CompareMode mode)
+{
+	const bool wasEnabled = window.IsCompareEnabled();
+	window.compareMode = layers.empty() ? Window::COMPARE_DISABLED : mode;
+	if (window.IsCompareEnabled() && !wasEnabled) {
+		// Default side assignment: active layer on the left (A), everything else on
+		// the right (B); switching between swipe and split keeps the assignment.
+		const Layer* activeLayer = GetActiveLayer();
+		for (Layer& layer : layers)
+			layer.compareRight = (&layer != activeLayer);
+	}
+	window.RequestRedraw();
+}
+
+bool Scene::AlignLayersToActive()
+{
+	if (HasBackgroundWork()) {
+		DEBUG("Cannot align layers while background work is running");
+		return false;
+	}
+	const Layer* refLayer = GetActiveLayer();
+	if (refLayer == NULL || layers.size() < 2)
+		return false;
+	// Reference camera centers keyed by image file name and by preserved SFM image ID:
+	// the same capture reconstructed twice keeps its photo names, and scenes exported
+	// from the same SFM keep their image IDs, so either key identifies shared cameras.
+	std::unordered_map<std::string, Point3> nameToCenter;
+	std::unordered_map<uint32_t, Point3> idToCenter;
+	for (const Image& image : refLayer->images) {
+		const MVS::Image& imageData = refLayer->scene.images[image.idx];
+		nameToCenter[Util::getFileNameExt(imageData.name).ToLower()] = Point3(imageData.camera.C);
+		if (imageData.ID != NO_ID)
+			idToCenter[imageData.ID] = Point3(imageData.camera.C);
+	}
+	unsigned alignedLayers = 0;
+	for (Layer& layer : layers) {
+		if (layer.id == refLayer->id)
+			continue;
+		Point3Arr points, pointsRef;
+		for (const Image& image : layer.images) {
+			const MVS::Image& imageData = layer.scene.images[image.idx];
+			const auto it = nameToCenter.find(Util::getFileNameExt(imageData.name).ToLower());
+			if (it == nameToCenter.end())
+				continue;
+			points.emplace_back(imageData.camera.C);
+			pointsRef.emplace_back(it->second);
+		}
+		if (points.size() < 3) {
+			points.Empty();
+			pointsRef.Empty();
+			for (const Image& image : layer.images) {
+				const MVS::Image& imageData = layer.scene.images[image.idx];
+				const auto it = imageData.ID != NO_ID ? idToCenter.find(imageData.ID) : idToCenter.end();
+				if (it == idToCenter.end())
+					continue;
+				points.emplace_back(imageData.camera.C);
+				pointsRef.emplace_back(it->second);
+			}
+		}
+		if (points.size() < 3) {
+			DEBUG("Layer '%s' not aligned: only %u camera(s) match the active layer", layer.label.c_str(), points.size());
+			continue;
+		}
+		const Matrix4x4 transform = SimilarityTransform(points, pointsRef);
+		Matrix3x3 rotation; Point3 translation; REAL scale;
+		DecomposeSimilarityTransform(transform, rotation, translation, scale);
+		layer.scene.Transform(rotation, translation, scale);
+		RefreshLayerState(layer, false);
+		layer.dirty = true;
+		++alignedLayers;
+		DEBUG("Layer '%s' aligned to '%s' using %u matched cameras (scale %g)",
+			layer.label.c_str(), refLayer->label.c_str(), points.size(), scale);
+	}
+	if (alignedLayers == 0)
+		return false;
+	UpdateGeometryModifiedFlag();
+	// Keep the current viewpoint: the moved layers now coincide with the active layer,
+	// which the view is already framing.
+	window.GetCamera().SetSceneDistance(ComputeVisibleSceneDistance());
+	window.UploadRenderData();
+	return true;
+}
+
+bool Scene::LoadLayer(Layer& layer, const String& fileName, String geometryFileName)
+{
+	ASSERT(!fileName.empty());
+	const String sceneFileName(MAKE_PATH_FULL(WORKING_FOLDER_FULL, fileName));
+	layer.sceneName = sceneFileName;
+	layer.workingFolder = Util::getFilePath(sceneFileName);
+	layer.label = Util::getFileName(sceneFileName);
+	ActivateWorkingFolder(layer);
+
+	const MVS::Scene::SCENE_TYPE sceneType(layer.scene.Load(sceneFileName, true));
+	if (sceneType == MVS::Scene::SCENE_NA) {
+		DEBUG("error: can not open scene '%s'", sceneFileName.c_str());
+		return false;
+	}
+	if (geometryFileName.empty() && sceneType == MVS::Scene::SCENE_INTERFACE) {
+		const String defaultGeometryFileName(Util::getFileFullName(sceneFileName) + _T(".ply"));
+		if (File::isFile(defaultGeometryFileName))
+			geometryFileName = defaultGeometryFileName;
+	}
+	if (!geometryFileName.empty()) {
+		const String geometryPath(MAKE_PATH_FULL(layer.workingFolder, geometryFileName));
+		MVS::Mesh mesh;
+		MVS::PointCloud pointcloud;
+		if (mesh.Load(geometryPath)) {
+			layer.scene.mesh.Swap(mesh);
+		} else if (pointcloud.Load(geometryPath)) {
+			layer.scene.pointcloud.Swap(pointcloud);
+		}
+	}
+	if (!layer.scene.pointcloud.IsEmpty()) {
+		layer.scene.pointcloud.PrintStatistics(layer.scene.images.data(), &layer.scene.obb);
+		layer.usePointSolidColor = layer.scene.pointcloud.colors.empty();
+		if (estimateSfMNormals && layer.scene.EstimatePointCloudNormals())
+			if (estimateSfMPatches && layer.scene.mesh.IsEmpty())
+				layer.scene.EstimateSparseSurface();
+	}
+	RefreshLayerState(layer, true);
+	return true;
+}
+
+bool Scene::Open(const String& fileName, String geometryFileName)
+{
+	if (HasBackgroundWork()) {
+		DEBUG("Cannot open a scene while background work is running");
+		return false;
+	}
+	Reset();
+	return AddLayer(fileName, geometryFileName, true);
+}
+
+bool Scene::OpenFiles(const std::vector<String>& fileNames, bool replaceExisting)
+{
+	if (HasBackgroundWork()) {
+		DEBUG("Cannot open layers while background work is running");
+		return false;
+	}
+	if (fileNames.empty())
+		return false;
+	if (replaceExisting)
+		Reset();
+
+	bool loadedAny = false;
+	if (fileNames.size() == 2) {
+		const String& firstFile(fileNames.front());
+		const String& secondFile(fileNames.back());
+		const bool firstIsScene(IsSceneProjectFile(firstFile));
+		const bool secondIsScene(IsSceneProjectFile(secondFile));
+		const bool firstIsGeometry(IsGeometryFile(firstFile));
+		const bool secondIsGeometry(IsGeometryFile(secondFile));
+		if (firstIsScene && secondIsGeometry && !secondIsScene) {
+			loadedAny = AddLayer(firstFile, secondFile, true);
+		} else if (secondIsScene && firstIsGeometry && !firstIsScene) {
+			loadedAny = AddLayer(secondFile, firstFile, true);
+		}
+	}
+	if (!loadedAny) {
+		for (const String& fileName : fileNames) {
+			if (!IsSceneProjectFile(fileName) && !IsGeometryFile(fileName))
+				continue;
+			loadedAny = AddLayer(fileName, String(), !loadedAny) || loadedAny;
+		}
+	}
+	if (!loadedAny && replaceExisting)
+		window.SetVisible(true);
+	return loadedAny;
+}
+
+bool Scene::AddLayer(const String& fileName, String geometryFileName, bool makeActive)
+{
+	if (HasBackgroundWork()) {
+		DEBUG("Cannot add a layer while background work is running");
+		return false;
+	}
 	ASSERT(!fileName.empty());
 	window.SetVisible(false);
-	DEBUG_EXTRA("Loading: '%s'", Util::getFileNameExt(fileName).c_str());
-	Reset();
-	sceneName = fileName;
+	DEBUG_EXTRA("Loading layer: '%s'", Util::getFileNameExt(fileName).c_str());
 
-	// load the scene
-	if (Util::isFullPath(fileName)) {
-		WORKING_FOLDER = Util::getFilePath(fileName);
-		INIT_WORKING_FOLDER;
-	}
-	const MVS::Scene::SCENE_TYPE sceneType(scene.Load(MAKE_PATH_FULL(WORKING_FOLDER_FULL, fileName), true));
-	if (sceneType == MVS::Scene::SCENE_NA) {
-		DEBUG("error: can not open scene '%s'", fileName.c_str());
+	Layer layer;
+	layer.id = nextLayerID++;
+	if (!LoadLayer(layer, fileName, geometryFileName)) {
+		if (const Layer* activeLayer = GetActiveLayer())
+			ActivateWorkingFolder(*activeLayer);
 		window.SetVisible(true);
 		return false;
 	}
-	if (geometryFileName.empty() && sceneType == MVS::Scene::SCENE_INTERFACE)
-		geometryFileName = Util::getFileFullName(fileName) + _T(".ply");
-	if (!geometryFileName.empty()) {
-		// try to load given mesh
-		MVS::Mesh mesh;
-		MVS::PointCloud pointcloud;
-		if (mesh.Load(MAKE_PATH_FULL(WORKING_FOLDER_FULL, geometryFileName))) {
-			scene.mesh.Swap(mesh);
-			geometryName = geometryFileName;
-			geometryMesh = true;
-		} else
-		// try to load as a point-cloud
-		if (pointcloud.Load(MAKE_PATH_FULL(WORKING_FOLDER_FULL, geometryFileName))) {
-			scene.pointcloud.Swap(pointcloud);
-			geometryName = geometryFileName;
-			geometryMesh = false;
-		}
-	}
-	if (!scene.pointcloud.IsEmpty()) {
-		scene.pointcloud.PrintStatistics(scene.images.data(), &scene.obb);
-		if (estimateSfMNormals && scene.EstimatePointCloudNormals())
-			if (estimateSfMPatches && scene.mesh.IsEmpty())
-				scene.EstimateSparseSurface();
-	}
-
-	// init scene
-	AABB3f bounds(true);
-	Point3f sceneCenter(0, 0, 0);
-	if (scene.IsBounded()) {
-		bounds = scene.obb.GetAABB();
-		sceneCenter = bounds.GetCenter();
-	} else {
-		if (!scene.pointcloud.IsEmpty()) {
-			bounds = scene.pointcloud.GetAABB(0.1f, 0.9f);
-			sceneCenter = scene.pointcloud.GetCenter();
-		}
-		if (!scene.mesh.IsEmpty()) {
-			scene.mesh.ComputeNormalFaces();
-			bounds.Insert(scene.mesh.GetAABB(0.1f, 0.9f));
-			sceneCenter = scene.mesh.GetCenter();
-		}
-	}
-
-	// init images
-	AABB3f imageBounds(true);
-	images.Reserve(scene.images.size());
-	FOREACH(idxImage, scene.images) {
-		const MVS::Image& imageData = scene.images[idxImage];
-		if (!imageData.IsValid())
-			continue;
-		images.emplace_back(idxImage);
-		imageBounds.InsertFull(Cast<float>(imageData.camera.C));
-	}
-	if (bounds.IsEmpty() && !imageBounds.IsEmpty()) {
-		// if no geometry is present, use image bounds
-		imageBounds.Enlarge(0.5);
-		bounds = imageBounds;
-		sceneCenter = imageBounds.GetCenter();
-	}
-
-	// Precompute neighbors based on shared tracks
+	layers.emplace_back(std::move(layer));
+	if (makeActive || activeLayerIndex < 0)
+		activeLayerIndex = (int)layers.size() - 1;
+	const Layer& activeLayer(*GetActiveLayer());
+	ActivateWorkingFolder(activeLayer);
 	PrecomputeTrackBasedNeighbors();
-
-	// fit camera to scene
-	if (!bounds.IsEmpty()) {
-		const Point3f sceneSize = bounds.GetSize().cast<float>();
-		window.SetSceneBounds(sceneCenter, sceneSize);
-	}
-
-	// Set images size for camera view mode
-	if (!images.empty()) {
-		window.GetCamera().SetMaxCamID(images.size());
-		window.GetCamera().SetSceneDistance(scene.ComputeDistanceCameras2Scene(0.1f, true));
-	}
-
-	// Set up camera view mode callback
-	window.GetCamera().SetCameraViewModeCallback([this](MVS::IIndex camID) {
-		OnSetCameraViewMode(camID);
-	});
-
-	// set window title
-	window.SetTitle(String::FormatString((name + _T(": %s")).c_str(), Util::getFileName(fileName).c_str()));
-
-	// upload render data
+	window.GetCamera().SetMaxCamID(activeLayer.images.size());
+	window.GetCamera().SetSceneDistance(ComputeVisibleSceneDistance());
+	UpdateWindowSceneBounds(true);
+	UpdateWindowTitle();
 	window.UploadRenderData();
-
 	window.SetVisible(true);
 	return true;
 }
 
+bool Scene::RemoveLayer(size_t layerIndex)
+{
+	if (layerIndex >= layers.size())
+		return false;
+	if (HasBackgroundWork()) {
+		DEBUG("Cannot remove a layer while background work is running");
+		return false;
+	}
+	const Layer* previousActiveLayer = GetActiveLayer();
+	const uint32_t previousActiveLayerID = previousActiveLayer != NULL ? previousActiveLayer->id : NO_ID;
+	const uint32_t removedLayerID = layers[layerIndex].id;
+	layers.erase(layers.begin() + layerIndex);
+	if (layers.empty()) {
+		Reset();
+		window.SetVisible(true);
+		return true;
+	}
+	size_t newActiveLayerIndex = MINF(layerIndex, layers.size() - 1);
+	if (previousActiveLayerID != NO_ID && previousActiveLayerID != removedLayerID) {
+		for (size_t i = 0; i < layers.size(); ++i) {
+			if (layers[i].id == previousActiveLayerID) {
+				newActiveLayerIndex = i;
+				break;
+			}
+		}
+	}
+	activeLayerIndex = -1; // force SetActiveLayer() to rebuild dependent state
+	SetActiveLayer(newActiveLayerIndex, false);
+	UpdateGeometryModifiedFlag();
+	UpdateWindowSceneBounds(true);
+	window.UploadRenderData();
+	return true;
+}
+
 bool Scene::Save(const String& _fileName, bool bRescaleImages) {
-	if (!IsOpen())
+	if (HasBackgroundWork()) {
+		DEBUG("Cannot save a scene while background work is running");
+		return false;
+	}
+	Layer* layer = GetActiveLayer();
+	if (layer == NULL)
+		return false;
+	MVS::Scene& scene(layer->scene);
+	if (!layer->IsOpen())
 		return false;
 	REAL imageScale = 0;
 	if (bRescaleImages) {
@@ -529,42 +1003,69 @@ bool Scene::Save(const String& _fileName, bool bRescaleImages) {
 		window.SetVisible(true);
 		imageScale = strScale.From<REAL>(0);
 	}
-	const String fileName(!_fileName.empty() ? _fileName : Util::insertBeforeFileExt(sceneName, _T("_new")));
-	MVS::Mesh mesh;
-	if (!scene.mesh.IsEmpty() && !geometryName.empty() && geometryMesh)
-		mesh.Swap(scene.mesh);
-	MVS::PointCloud pointcloud;
-	if (!scene.pointcloud.IsEmpty() && !geometryName.empty() && !geometryMesh)
-		pointcloud.Swap(scene.pointcloud);
+	const String requestedFileName(!_fileName.empty() ? _fileName : GetDefaultSaveFileName(*layer));
+	const String fileName(MAKE_PATH_FULL(layer->workingFolder, requestedFileName));
+	const String previousWorkingFolder(layer->workingFolder);
+	const String saveWorkingFolder(Util::getFilePath(fileName));
+	ActivateWorkingFolder(saveWorkingFolder);
 	if (imageScale > 0 && imageScale < 1) {
-		// scale and save images
 		const String folderName(Util::getFilePath(MAKE_PATH_FULL(WORKING_FOLDER_FULL, fileName)) + String::FormatString("images%d" PATH_SEPARATOR_STR, ROUND2INT(imageScale*100)));
 		if (!scene.ScaleImages(0, imageScale, folderName)) {
 			DEBUG("error: can not scale scene images to '%s'", folderName.c_str());
+			ActivateWorkingFolder(previousWorkingFolder);
 			return false;
 		}
 	}
 	if (!scene.Save(fileName, nArchiveType)) {
 		DEBUG("error: can not save scene to '%s'", fileName.c_str());
+		ActivateWorkingFolder(previousWorkingFolder);
 		return false;
 	}
-	if (!mesh.IsEmpty())
-		scene.mesh.Swap(mesh);
-	if (!pointcloud.IsEmpty())
-		scene.pointcloud.Swap(pointcloud);
-	sceneName = fileName;
+	layer->sceneName = fileName;
+	layer->workingFolder = saveWorkingFolder;
+	layer->label = Util::getFileName(fileName);
+	layer->dirty = false;
+	UpdateGeometryModifiedFlag();
+	UpdateWindowTitle();
 	return true;
 }
 
-bool Scene::Export(const String& _fileName, const String& exportType, bool bViews) const {
-	if (!IsOpen())
+bool Scene::SaveModifiedLayers()
+{
+	if (!IsOpen() || HasBackgroundWork())
 		return false;
-	ASSERT(!sceneName.IsEmpty());
+	const int previousActiveLayer = activeLayerIndex;
+	bool savedAny = false;
+	bool success = true;
+	for (size_t i = 0; i < layers.size(); ++i) {
+		if (!layers[i].dirty)
+			continue;
+		SetActiveLayer(i, false);
+		success = Save(String(), false) && success;
+		savedAny = true;
+	}
+	if (previousActiveLayer >= 0 && previousActiveLayer < (int)layers.size())
+		SetActiveLayer((size_t)previousActiveLayer, false);
+	return success && savedAny;
+}
+
+bool Scene::Export(const String& _fileName, const String& exportType, bool bViews, ExportGeometry geometry) const {
+	if (HasBackgroundWork()) {
+		DEBUG("Cannot export a scene while background work is running");
+		return false;
+	}
+	const Layer* layer = GetActiveLayer();
+	if (layer == NULL || !layer->IsOpen())
+		return false;
+	const MVS::Scene& scene(layer->scene);
+	ASSERT(!layer->sceneName.IsEmpty());
 	String lastFileName;
-	const String fileName(!_fileName.empty() ? _fileName : sceneName);
+	const String fileName(!_fileName.empty() ? _fileName : layer->sceneName);
 	const String baseFileName(Util::getFileFullName(fileName));
-	const bool bPoints(scene.pointcloud.Save(lastFileName=(baseFileName+_T("_pointcloud")+(!exportType.empty()?exportType.c_str():(Util::getFileExt(fileName)==_T(".glb")?_T(".glb"):_T(".ply")))), nArchiveType==ARCHIVE_MVS && bViews));
-	const bool bMesh(scene.mesh.Save(lastFileName=(baseFileName+_T("_mesh")+(!exportType.empty()?exportType.c_str():(Util::getFileExt(fileName)==_T(".obj")?_T(".obj"):_T(".ply")))), {}, true));
+	const bool exportPoints = geometry != EXPORT_MESH && !scene.pointcloud.IsEmpty();
+	const bool exportMesh = geometry != EXPORT_POINT_CLOUD && !scene.mesh.IsEmpty() && !scene.mesh.faces.empty();
+	const bool bPoints(exportPoints && scene.pointcloud.Save(lastFileName=(baseFileName+_T("_pointcloud")+(!exportType.empty()?exportType.c_str():(Util::getFileExt(fileName)==_T(".glb")?_T(".glb"):_T(".ply")))), nArchiveType==ARCHIVE_MVS && bViews));
+	const bool bMesh(exportMesh && scene.mesh.Save(lastFileName=(baseFileName+_T("_mesh")+(!exportType.empty()?exportType.c_str():(Util::getFileExt(fileName)==_T(".obj")?_T(".obj"):_T(".ply")))), {}, true));
 	#if TD_VERBOSE != TD_VERBOSE_OFF
 	if (VERBOSITY_LEVEL > 2 && (bPoints || bMesh))
 		scene.ExportCamerasMLP(Util::getFileFullName(lastFileName)+_T(".mlp"), lastFileName);
@@ -590,14 +1091,215 @@ bool Scene::Export(const String& _fileName, const String& exportType, bool bView
 	return bPoints || bMesh;
 }
 
+bool Scene::BuildMergedVisiblePointCloud(MVS::PointCloud& pointcloud) const
+{
+	pointcloud.Release();
+	size_t totalPoints = 0;
+	bool exportColors = false;
+	bool exportNormals = false;
+	for (const Layer& layer : layers) {
+		if (!layer.visible || layer.scene.pointcloud.IsEmpty())
+			continue;
+		totalPoints += layer.scene.pointcloud.points.size();
+		exportColors = exportColors || layer.scene.pointcloud.colors.size() == layer.scene.pointcloud.points.size();
+		exportNormals = exportNormals || layer.scene.pointcloud.normals.size() == layer.scene.pointcloud.points.size();
+	}
+	if (totalPoints == 0)
+		return false;
+
+	pointcloud.points.Reserve(totalPoints);
+	if (exportColors)
+		pointcloud.colors.Reserve(totalPoints);
+	if (exportNormals)
+		pointcloud.normals.Reserve(totalPoints);
+
+	for (const Layer& layer : layers) {
+		if (!layer.visible || layer.scene.pointcloud.IsEmpty())
+			continue;
+		const MVS::PointCloud& layerPointCloud(layer.scene.pointcloud);
+		pointcloud.points.Join(layerPointCloud.points);
+		if (exportColors) {
+			if (layerPointCloud.colors.size() == layerPointCloud.points.size())
+				pointcloud.colors.Join(layerPointCloud.colors);
+			else {
+				FOREACH(i, layerPointCloud.points)
+					pointcloud.colors.emplace_back(255, 255, 255);
+			}
+		}
+		if (exportNormals) {
+			if (layerPointCloud.normals.size() == layerPointCloud.points.size())
+				pointcloud.normals.Join(layerPointCloud.normals);
+			else {
+				FOREACH(i, layerPointCloud.points)
+					pointcloud.normals.emplace_back(0.f, 0.f, 0.f);
+			}
+		}
+	}
+	return !pointcloud.IsEmpty();
+}
+
+bool Scene::BuildMergedVisibleMesh(MVS::Mesh& mesh) const
+{
+	mesh.Release();
+	bool hasMesh = false;
+	for (const Layer& layer : layers) {
+		if (!layer.visible || layer.scene.mesh.IsEmpty() || layer.scene.mesh.faces.empty())
+			continue;
+		MVS::Mesh layerMesh(layer.scene.mesh);
+		if (layerMesh.HasTexture()) {
+			layerMesh.faceTexcoords.Release();
+			layerMesh.faceTexindices.Release();
+			layerMesh.texturesDiffuse.Release();
+		}
+		layerMesh.vertexNormals.Release();
+		layerMesh.faceNormals.Release();
+		mesh.Join(layerMesh);
+		hasMesh = true;
+	}
+	if (hasMesh)
+		mesh.ComputeNormalVertices();
+	return hasMesh && !mesh.IsEmpty();
+}
+
+bool Scene::ExportVisibleLayers(const String& _fileName, const String& exportType, ExportGeometry geometry) const
+{
+	if (HasBackgroundWork()) {
+		DEBUG("Cannot export layers while background work is running");
+		return false;
+	}
+	if (!HasVisibleLayers())
+		return false;
+	String lastFileName;
+	const Layer* activeLayer(GetActiveLayer());
+	const String fileName(!_fileName.empty() ? _fileName : (activeLayer != NULL ? activeLayer->sceneName : String()));
+	const String baseFileName(Util::getFileFullName(fileName));
+
+	MVS::PointCloud mergedPointCloud;
+	MVS::Mesh mergedMesh;
+	const bool hasPoints(geometry != EXPORT_MESH && BuildMergedVisiblePointCloud(mergedPointCloud));
+	const bool hasMesh(geometry != EXPORT_POINT_CLOUD && BuildMergedVisibleMesh(mergedMesh));
+	if (!hasPoints && !hasMesh)
+		return false;
+
+	const bool bPoints = hasPoints && mergedPointCloud.Save(lastFileName = (baseFileName + _T("_pointcloud") + (!exportType.empty() ? exportType.c_str() : (Util::getFileExt(fileName) == _T(".glb") ? _T(".glb") : _T(".ply")))), false);
+	const bool bMesh = hasMesh && mergedMesh.Save(lastFileName = (baseFileName + _T("_mesh") + (!exportType.empty() ? exportType.c_str() : (Util::getFileExt(fileName) == _T(".obj") ? _T(".obj") : _T(".ply")))), {}, true);
+
+	AABB3f aabb(true);
+	if (bPoints)
+		aabb = mergedPointCloud.GetAABB();
+	if (bMesh)
+		aabb.Insert(mergedMesh.GetAABB());
+	if (!aabb.IsEmpty()) {
+		std::ofstream fs(baseFileName + _T("_roi_box.txt"));
+		if (fs)
+			fs << aabb;
+	}
+	return bPoints || bMesh;
+}
+
+double Scene::GetWorkflowElapsedTime() const
+{
+	if (workflowState.load() != WF_STATE_RUNNING || workflowStartTime == 0.0)
+		return 0.0;
+	return glfwGetTime() - workflowStartTime;
+}
+
+const char* Scene::GetWorkflowName(WorkflowType type, bool shortName)
+{
+	switch (type) {
+	case WF_ESTIMATE_ROI: return shortName ? "ROI" : "Estimate ROI";
+	case WF_DENSIFY: return "Densify";
+	case WF_RECONSTRUCT: return shortName ? "Reconstruct" : "Reconstruct Mesh";
+	case WF_REFINE: return shortName ? "Refine" : "Refine Mesh";
+	case WF_TEXTURE: return shortName ? "Texture" : "Texture Mesh";
+	default: return shortName ? "?" : "Unknown";
+	}
+}
+
+void Scene::CheckWorkflowCompletion()
+{
+	const WorkflowState state = workflowState.load();
+	if (state == WF_STATE_COMPLETED || state == WF_STATE_FAILED) {
+		// Workflow completed, finalize it on the main thread
+		const bool success = (state == WF_STATE_COMPLETED);
+		FinalizeWorkflow(success);
+	}
+}
+
+void Scene::FinalizeWorkflow(bool success)
+{
+	SEACAVE::Lock lock(workflowMutex);
+
+	// Check if we need to finalize (already done or not running)
+	const WorkflowState state = workflowState.load();
+	if (state != WF_STATE_COMPLETED && state != WF_STATE_FAILED)
+		return;
+
+	// Calculate duration directly (can't use GetWorkflowElapsedTime since state is no longer RUNNING)
+	const double currentTime = glfwGetTime();
+	const double duration = (workflowStartTime > 0.0) ? (currentTime - workflowStartTime) : 0.0;
+	const WorkflowType type = currentWorkflowType.load();
+	const char* workflowName(Scene::GetWorkflowName(type));
+
+	// Add to workflow history
+	workflowHistory.push_back({type, duration, success});
+
+	if (success) {
+		DEBUG("Workflow completed successfully: %s (%.2f seconds)", workflowName, duration);
+	} else {
+		DEBUG("Workflow failed: %s", workflowName);
+	}
+
+	// A failed workflow can still modify its input before reporting failure (for example,
+	// mesh cleaning or point-weight removal), so always refresh and mark its layer dirty.
+	Layer* layer = GetLayerByID(workflowLayerID);
+	if (layer != NULL) {
+		RefreshLayerState(*layer, false);
+		if (layer == GetActiveLayer())
+			PrecomputeTrackBasedNeighbors();
+		layer->dirty = true;
+		UpdateGeometryModifiedFlag();
+		window.GetCamera().SetSceneDistance(ComputeVisibleSceneDistance());
+		window.UploadRenderData();
+		window.RequestRedraw();
+	}
+
+	// Reset workflow state
+	workflowState.store(WF_STATE_IDLE);
+	currentWorkflowType.store(WF_NONE);
+	workflowStartTime = 0.0;
+	workflowLayerID = NO_ID;
+	if (!success) {
+		batchWorkflowActive = false;
+		batchWorkflowQueue.clear();
+	} else if (!batchWorkflowQueue.empty()) {
+		if (!StartNextBatchWorkflow()) {
+			batchWorkflowActive = false;
+			DEBUG("Batch workflow stopped because the next stage could not start");
+		}
+	} else if (batchWorkflowActive) {
+		batchWorkflowActive = false;
+		DEBUG_EXTRA("Workflow queue completed");
+	}
+}
+
 // Load the per-image pose uncertainty from a CreateStructure pose-quality CSV report
 // (--export-pose-quality) and enable the uncertainty-ellipsoids display.
 // Rows are matched to the scene images by ID (ExportMVS preserves the SFM image ID).
 bool Scene::LoadPoseUncertainty(const String& fileName) {
-	cameraUncertainty.Release();
-	cameraUncertaintyNorm = 0.f;
-	if (!IsOpen()) {
+	Layer* layer = GetActiveLayer();
+	if (layer == NULL) {
 		DEBUG("error: pose uncertainty requires an open scene");
+		return false;
+	}
+	if (HasBackgroundWork()) {
+		DEBUG("Cannot load pose uncertainty while background work is running");
+		return false;
+	}
+	const ImageArr& images(layer->images);
+	const MVS::Scene& scene(layer->scene);
+	if (images.empty()) {
+		DEBUG("error: pose uncertainty requires calibrated images in the active layer");
 		return false;
 	}
 	std::ifstream is(fileName);
@@ -626,9 +1328,12 @@ bool Scene::LoadPoseUncertainty(const String& fileName) {
 		if (fields[2] == "0")
 			continue; // image without computed uncertainty
 		const Point3f sigmaPos((float)std::atof(fields[4].c_str()), (float)std::atof(fields[5].c_str()), (float)std::atof(fields[6].c_str()));
-		if (sigmaPos.x < 0.f)
+		if (sigmaPos.x < 0.f || sigmaPos.y < 0.f || sigmaPos.z < 0.f ||
+			!std::isfinite(sigmaPos.x) || !std::isfinite(sigmaPos.y) || !std::isfinite(sigmaPos.z))
 			continue;
 		const Point3f covOff((float)std::atof(fields[7].c_str()), (float)std::atof(fields[8].c_str()), (float)std::atof(fields[9].c_str()));
+		if (!std::isfinite(covOff.x) || !std::isfinite(covOff.y) || !std::isfinite(covOff.z))
+			continue;
 		CameraUncertainty& u = mapUncertainty[(uint32_t)id];
 		u.posCov = Matrix3x3f(
 			SQUARE(sigmaPos.x), covOff.x, covOff.y,
@@ -643,9 +1348,7 @@ bool Scene::LoadPoseUncertainty(const String& fileName) {
 		return false;
 	}
 	// match the entries to the scene images by ID
-	cameraUncertainty.resize(images.size());
-	FOREACH(i, cameraUncertainty)
-		cameraUncertainty[i] = CameraUncertainty();
+	CameraUncertaintyArr loadedUncertainty(images.size());
 	unsigned matched = 0;
 	FloatArr sigmas;
 	FOREACH(i, images) {
@@ -653,22 +1356,22 @@ bool Scene::LoadPoseUncertainty(const String& fileName) {
 		const auto it = mapUncertainty.find(imageData.ID);
 		if (it == mapUncertainty.end())
 			continue;
-		cameraUncertainty[i] = it->second;
+		loadedUncertainty[i] = it->second;
 		++matched;
 		if (it->second.state == CameraUncertainty::COMPUTED)
 			sigmas.push_back(it->second.MaxPosSigma());
 	}
 	if (matched == 0) {
 		DEBUG("error: no pose uncertainty entries in '%s' match the scene image IDs", fileName.c_str());
-		cameraUncertainty.Release();
 		return false;
 	}
 	// robust colormap normalization: 95th-percentile of the max-axis sigma
+	float uncertaintyNorm = 0.f;
 	if (!sigmas.empty()) {
 		sigmas.Sort();
-		cameraUncertaintyNorm = sigmas[(sigmas.size() - 1) * 95 / 100];
-		if (cameraUncertaintyNorm <= 0.f)
-			cameraUncertaintyNorm = MAXF(sigmas.Last(), 1.f);
+		uncertaintyNorm = sigmas[(sigmas.size() - 1) * 95 / 100];
+		if (uncertaintyNorm <= 0.f)
+			uncertaintyNorm = MAXF(sigmas.Last(), 1.f);
 	}
 	// Auto-size the ellipsoids to the scene: raw 1-sigma radii are in world units and can be far
 	// smaller (metric/GPS scenes) or far larger (datum-relative scenes, where the unanchored scale
@@ -680,10 +1383,13 @@ bool Scene::LoadPoseUncertainty(const String& fileName) {
 	// small enough not to overlap their neighbours at the default x1 slider). This is kept SEPARATE
 	// from the user-facing `Window::uncertaintyEllipsoidScale` (which multiplies it, defaulting to 1)
 	// so the deferred ImGui-ini load of that persisted slider value cannot clobber the auto fit.
-	const float sceneExtent = window.GetCamera().GetSceneSize().norm();
+	const float sceneExtent = norm(layer->sceneSize);
 	const float medianSigma = sigmas.empty() ? 0.f : sigmas[sigmas.size() / 2]; // sigmas is sorted above
-	cameraUncertaintyAutoScale = (sceneExtent > 0.f && medianSigma > 0.f) ?
+	const float uncertaintyAutoScale = (sceneExtent > 0.f && medianSigma > 0.f) ?
 		MINF(MAXF(0.03f * sceneExtent / medianSigma, 1e-6f), 1e6f) : 1.f;
+	layer->cameraUncertainty.Swap(loadedUncertainty);
+	layer->cameraUncertaintyNorm = uncertaintyNorm;
+	layer->cameraUncertaintyAutoScale = uncertaintyAutoScale;
 	window.showUncertaintyEllipsoids = true;
 	window.GetRenderer().UploadUncertaintyEllipsoids(window);
 	Window::RequestRedraw();
@@ -692,119 +1398,128 @@ bool Scene::LoadPoseUncertainty(const String& fileName) {
 	DEBUG("Pose uncertainty loaded from '%s': %u/%u images matched (%u drawable ellipsoids, %u datum), "
 		"sigma norm %.3g, auto-fit ellipsoid scale %.3g (x%.3g slider)%s",
 		Util::getFileNameExt(fileName).c_str(), matched, images.size(),
-		drawable, matched - drawable, cameraUncertaintyNorm, cameraUncertaintyAutoScale,
+		drawable, matched - drawable, uncertaintyNorm, uncertaintyAutoScale,
 		window.uncertaintyEllipsoidScale,
 		drawable == 0 ? " -- WARNING: nothing to draw (all matched entries are gauge datum)" : "");
 	return true;
 }
 
 // Estimate ROI workflow wrapper (async execution)
-bool Scene::RunEstimateROIWorkflow(const EstimateROIWorkflowOptions& options) {
-	ASSERT(IsOpen() && "No scene loaded");
-	ASSERT(scene.pointcloud.IsValid() && "Point-cloud is empty");
-	ASSERT(!IsWorkflowRunning() && "A workflow is already running");
-
-	// Update options in scene
-	estimateROIOptions = options;
-
-	// Set workflow state
+bool Scene::StartWorkflow(WorkflowType type, Layer& layer, SEACAVE::Event* event)
+{
+	ASSERT(event != NULL && workflowState.load() == WF_STATE_IDLE);
+	ActivateWorkingFolder(layer);
 	workflowState.store(WF_STATE_RUNNING);
-	currentWorkflowType.store(WF_ESTIMATE_ROI);
+	currentWorkflowType.store(type);
 	workflowStartTime = glfwGetTime();
-
-	// Submit workflow event to queue for async execution
-	events.AddEvent(new EVTWorkflowEstimateROI(this));
-
-	DEBUG("Estimate ROI workflow started (async)");
+	workflowLayerID = layer.id;
+	events.AddEvent(event);
+	DEBUG("%s workflow started (async)", GetWorkflowName(type));
 	return true;
+}
+
+bool Scene::RunEstimateROIWorkflow(const EstimateROIWorkflowOptions& options)
+{
+	Layer* layer = GetActiveLayer();
+	if (layer == NULL || !layer->scene.pointcloud.IsValid() || HasBackgroundWork()) {
+		DEBUG("Cannot start Estimate ROI: an active point-cloud layer is required and no background work can be running");
+		return false;
+	}
+	estimateROIOptions = options;
+	return StartWorkflow(WF_ESTIMATE_ROI, *layer, new EVTWorkflowEstimateROI(this, layer->id, options));
 }
 
 // Densify point-cloud workflow wrapper (async execution)
 bool Scene::RunDensifyWorkflow(const DensifyWorkflowOptions& options) {
-	ASSERT(IsOpen() && "No scene loaded");
-	ASSERT(!scene.images.empty() && "Scene has no images");
-	ASSERT(!IsWorkflowRunning() && "A workflow is already running");
-
-	// Update options in scene
+	Layer* layer = GetActiveLayer();
+	if (layer == NULL || !layer->scene.IsValid() || HasBackgroundWork()) {
+		DEBUG("Cannot start Densify: an active calibrated-image layer is required and no background work can be running");
+		return false;
+	}
 	densifyOptions = options;
-
-	// Set workflow state
-	workflowState.store(WF_STATE_RUNNING);
-	currentWorkflowType.store(WF_DENSIFY);
-	workflowStartTime = glfwGetTime();
-
-	DEBUG("Densify workflow started (async) at time %.3f", workflowStartTime);
-
-	// Submit workflow event to queue for async execution
-	events.AddEvent(new EVTWorkflowDensify(this));
-
-	return true;
+	return StartWorkflow(WF_DENSIFY, *layer, new EVTWorkflowDensify(this, layer->id, options));
 }
 
 // Reconstruct mesh workflow wrapper (async execution)
 bool Scene::RunReconstructMeshWorkflow(const ReconstructMeshWorkflowOptions& options) {
-	ASSERT(IsOpen() && "No scene loaded");
-	ASSERT(scene.pointcloud.IsValid() && "Point-cloud is empty");
-	ASSERT(!IsWorkflowRunning() && "A workflow is already running");
-
-	// Update options in scene
+	Layer* layer = GetActiveLayer();
+	if (layer == NULL || !layer->scene.pointcloud.IsValid() || HasBackgroundWork()) {
+		DEBUG("Cannot start Reconstruct Mesh: an active point-cloud layer is required and no background work can be running");
+		return false;
+	}
 	reconstructOptions = options;
-
-	// Set workflow state
-	workflowState.store(WF_STATE_RUNNING);
-	currentWorkflowType.store(WF_RECONSTRUCT);
-	workflowStartTime = glfwGetTime();
-
-	// Submit workflow event to queue for async execution
-	events.AddEvent(new EVTWorkflowReconstructMesh(this));
-
-	DEBUG("Reconstruct Mesh workflow started (async)");
-	return true;
+	return StartWorkflow(WF_RECONSTRUCT, *layer, new EVTWorkflowReconstructMesh(this, layer->id, options));
 }
 
 // Refine mesh workflow wrapper (async execution)
 bool Scene::RunRefineMeshWorkflow(const RefineMeshWorkflowOptions& options) {
-	ASSERT(IsOpen() && "No scene loaded");
-	ASSERT(!scene.mesh.IsEmpty() && "Mesh is empty");
-	ASSERT(!IsWorkflowRunning() && "A workflow is already running");
-
-	// Update options in scene
+	Layer* layer = GetActiveLayer();
+	if (layer == NULL || !layer->scene.IsValid() || layer->scene.mesh.IsEmpty() || HasBackgroundWork()) {
+		DEBUG("Cannot start Refine Mesh: an active mesh-and-image layer is required and no background work can be running");
+		return false;
+	}
 	refineOptions = options;
-
-	// Set workflow state
-	workflowState.store(WF_STATE_RUNNING);
-	currentWorkflowType.store(WF_REFINE);
-	workflowStartTime = glfwGetTime();
-
-	// Submit workflow event to queue for async execution
-	events.AddEvent(new EVTWorkflowRefineMesh(this));
-
-	DEBUG("Refine Mesh workflow started (async)");
-	return true;
+	return StartWorkflow(WF_REFINE, *layer, new EVTWorkflowRefineMesh(this, layer->id, options));
 }
 
 // Texture mesh workflow wrapper (async execution)
 bool Scene::RunTextureMeshWorkflow(const TextureMeshWorkflowOptions& options) {
-	ASSERT(IsOpen() && "No scene loaded");
-	ASSERT(!scene.mesh.IsEmpty() && "Mesh is empty");
-	ASSERT(!IsWorkflowRunning() && "A workflow is already running");
-
-	// Update options in scene
+	Layer* layer = GetActiveLayer();
+	if (layer == NULL || !layer->scene.IsValid() || layer->scene.mesh.IsEmpty() || HasBackgroundWork()) {
+		DEBUG("Cannot start Texture Mesh: an active mesh-and-image layer is required and no background work can be running");
+		return false;
+	}
 	textureOptions = options;
+	return StartWorkflow(WF_TEXTURE, *layer, new EVTWorkflowTextureMesh(this, layer->id, options));
+}
 
-	// Set workflow state
-	workflowState.store(WF_STATE_RUNNING);
-	currentWorkflowType.store(WF_TEXTURE);
-	workflowStartTime = glfwGetTime();
+bool Scene::RunBatchWorkflow(const std::vector<WorkflowType>& workflowTypes)
+{
+	if (workflowTypes.empty() || HasBackgroundWork() || GetActiveLayer() == NULL)
+		return false;
+	for (WorkflowType type : workflowTypes) {
+		if (type <= WF_NONE || type > WF_TEXTURE)
+			return false;
+	}
+	batchWorkflowQueue.assign(workflowTypes.begin(), workflowTypes.end());
+	batchWorkflowActive = true;
+	batchEstimateROIOptions = estimateROIOptions;
+	batchDensifyOptions = densifyOptions;
+	batchReconstructOptions = reconstructOptions;
+	batchRefineOptions = refineOptions;
+	batchTextureOptions = textureOptions;
+	if (StartNextBatchWorkflow())
+		return true;
+	batchWorkflowActive = false;
+	batchWorkflowQueue.clear();
+	return false;
+}
 
-	// Submit workflow event to queue for async execution
-	events.AddEvent(new EVTWorkflowTextureMesh(this));
-
-	DEBUG("Texture Mesh workflow started (async)");
-	return true;
+bool Scene::StartNextBatchWorkflow()
+{
+	if (batchWorkflowQueue.empty())
+		return false;
+	const WorkflowType type(batchWorkflowQueue.front());
+	batchWorkflowQueue.pop_front();
+	bool started = false;
+	switch (type) {
+	case WF_ESTIMATE_ROI: started = RunEstimateROIWorkflow(batchEstimateROIOptions); break;
+	case WF_DENSIFY: started = RunDensifyWorkflow(batchDensifyOptions); break;
+	case WF_RECONSTRUCT: started = RunReconstructMeshWorkflow(batchReconstructOptions); break;
+	case WF_REFINE: started = RunRefineMeshWorkflow(batchRefineOptions); break;
+	case WF_TEXTURE: started = RunTextureMeshWorkflow(batchTextureOptions); break;
+	default: break;
+	}
+	if (!started)
+		batchWorkflowQueue.clear();
+	return started;
 }
 
 MVS::IIndex Scene::ImageIdxMVS2Viewer(MVS::IIndex idx) const {
+	const Layer* layer = GetActiveLayer();
+	if (layer == NULL)
+		return NO_ID;
+	const ImageArr& images(layer->images);
 	// Convert MVS image index to viewer index
 	// The list of images in the viewer is a subset of the MVS images,
 	// more exactly only the valid images are stored in the viewer.
@@ -819,6 +1534,11 @@ MVS::IIndex Scene::ImageIdxMVS2Viewer(MVS::IIndex idx) const {
 
 void Scene::PrecomputeTrackBasedNeighbors() {
 	trackBasedNeighbors.clear();
+	Layer* layer = GetActiveLayer();
+	if (layer == NULL)
+		return;
+	const ImageArr& images(layer->images);
+	const MVS::Scene& scene(layer->scene);
 	trackBasedNeighbors.resize(images.size());
 	if (!scene.IsValid() || !scene.pointcloud.IsValid() || images.empty())
 		return;
@@ -870,7 +1590,6 @@ void Scene::PrecomputeTrackBasedNeighbors() {
 				const Point3f V2(otherImage.camera.C - Cast<REAL>(point));
 				stat.angleSum += ACOS(ComputeAngle(V1.ptr(), V2.ptr()));
 				++stat.sumCount;
-				// Compute scale ratio (footprint1 / footprint2)
 				const float footprint2 = otherImage.camera.GetFootprintImage(otherDepth);
 				stat.scaleSum += footprint1 / footprint2;
 			}
@@ -910,7 +1629,7 @@ void Scene::PrecomputeTrackBasedNeighbors() {
 			neighbor.score.angle = stat.sumCount > 0 ? stat.angleSum / stat.sumCount : 0.f;
 			neighbor.score.area = area;
 			neighbor.score.score = (float)stat.points*MAXF(area,0.01f);
-			neighbor.sharedPoints = stat.sharedPoints; // Store shared point indices
+			neighbor.sharedPoints = stat.sharedPoints;
 		}
 
 		neighbors.Sort([](const ViewScoreWithPoints& a, const ViewScoreWithPoints& b) {
@@ -921,8 +1640,10 @@ void Scene::PrecomputeTrackBasedNeighbors() {
 
 void Scene::CropToBounds()
 {
-	if (!IsOpen())
+	Layer* layer = GetActiveLayer();
+	if (layer == NULL)
 		return;
+	MVS::Scene& scene(layer->scene);
 	if (!scene.IsBounded())
 		return;
 	const size_t numPoints = scene.pointcloud.points.size();
@@ -931,14 +1652,17 @@ void Scene::CropToBounds()
 	scene.mesh.RemoveFacesOutside(scene.obb);
 	// Mark as modified if anything was removed
 	if (numPoints != scene.pointcloud.points.size() || numFaces != scene.mesh.faces.size())
-		geometryModified.store(true);
+		SetGeometryModified(true);
+	RefreshLayerState(*layer, false);
 	window.SetSceneBounds(scene.obb.GetCenter(), scene.obb.GetSize());
 }
 
 void Scene::TogleSceneBox()
 {
-	if (!IsOpen())
+	Layer* layer = GetActiveLayer();
+	if (layer == NULL)
 		return;
+	MVS::Scene& scene(layer->scene);
 	if (scene.IsBounded()) {
 		ClearBoundingBox();
 		return;
@@ -989,7 +1713,7 @@ void Scene::OnCenterScene(const Point3f& center) {
 }
 
 void Scene::OnCastRay(const Point2f& screenPos, const Ray3d& ray, int button, int action, int mods) {
-	if (!IsOpen())
+	if (!IsOpen() || HasBackgroundWork())
 		return;
 	const double timeClick(0.2);
 	const double timeDblClick(0.4);
@@ -1019,18 +1743,23 @@ void Scene::OnCastRay(const Point2f& screenPos, const Ray3d& ray, int button, in
 		}
 		const Window::SELECTION prevSelectionType = window.selectionType;
 		window.selectionType = Window::SEL_NA;
+		Window::SELECTION newSelectionType = Window::SEL_NA;
 		REAL minDist = REAL(FLT_MAX);
 		IDX newSelectionIdx = NO_IDX;
+		const Layer* previousActiveLayer = GetActiveLayer();
+		const uint32_t previousActiveLayerID = previousActiveLayer != NULL ? previousActiveLayer->id : NO_ID;
+		uint32_t newSelectionLayerID = previousActiveLayerID;
 		Point3f newSelectionPoints[4];
 		const Renderer::PickResult pickResult = window.GetRenderer().PickPrimitiveAt(screenPos, pickRadius, window);
 		if (pickResult.IsValid()) {
+			newSelectionLayerID = pickResult.layerID;
 			if (pickResult.isPoint) {
-				window.selectionType = Window::SEL_POINT;
+				newSelectionType = Window::SEL_POINT;
 				newSelectionIdx = pickResult.index;
 				newSelectionPoints[0] = pickResult.points[0];
 				minDist = norm(Point3f(ray.m_pOrig.cast<float>()) - pickResult.points[0]);
 			} else {
-				window.selectionType = Window::SEL_TRIANGLE;
+				newSelectionType = Window::SEL_TRIANGLE;
 				newSelectionIdx = pickResult.index;
 				newSelectionPoints[0] = pickResult.points[0];
 				newSelectionPoints[1] = pickResult.points[1];
@@ -1045,30 +1774,55 @@ void Scene::OnCastRay(const Point2f& screenPos, const Ray3d& ray, int button, in
 			}
 			newSelectionPoints[3] = ray.GetPoint(minDist).cast<float>();
 		}
-		// check for camera intersection
-		const TCone<REAL, 3> cone(ray, D2R(REAL(0.5)));
-		const TConeIntersect<REAL, 3> coneIntersect(cone);
-		FOREACH(idx, images) {
-			const Image& image = images[idx];
-			const MVS::Image& imageData = scene.images[image.idx];
-			ASSERT(imageData.IsValid());
-			REAL dist;
-			if (coneIntersect.Classify(imageData.camera.C, dist) == VISIBLE && dist < minDist) {
-				window.selectionType = Window::SEL_CAMERA;
-				minDist = dist;
-				newSelectionIdx = idx;
-				newSelectionPoints[0] = newSelectionPoints[3] = imageData.camera.C;
+		// Check for camera intersection only when camera geometry is visible.
+		if (window.showCameras) {
+			const TCone<REAL, 3> cone(ray, D2R(REAL(0.5)));
+			const TConeIntersect<REAL, 3> coneIntersect(cone);
+			for (const Layer& layer : layers) {
+				if (!layer.visible)
+					continue;
+				FOREACH(idx, layer.images) {
+					const Image& image = layer.images[idx];
+					const MVS::Image& imageData = layer.scene.images[image.idx];
+					ASSERT(imageData.IsValid());
+					REAL dist;
+					if (coneIntersect.Classify(imageData.camera.C, dist) == VISIBLE && dist < minDist) {
+						newSelectionType = Window::SEL_CAMERA;
+						minDist = dist;
+						newSelectionIdx = idx;
+						newSelectionLayerID = layer.id;
+						newSelectionPoints[0] = newSelectionPoints[3] = imageData.camera.C;
+					}
+				}
 			}
 		}
 		// check if we have a new selection
-		if (window.selectionType != Window::SEL_NA) {
-			if (window.selectionType == Window::SEL_CAMERA && (mods & GLFW_MOD_ALT)) {
-				// If alt is pressed, set view camera mode
-				window.selectionType = prevSelectionType; // Restore previous selection type
+		if (newSelectionType != Window::SEL_NA) {
+			const bool selectionLayerChanged = previousActiveLayerID != newSelectionLayerID;
+			SetActiveLayerByID(newSelectionLayerID, false);
+			Layer* activeLayer = GetActiveLayer();
+			ASSERT(activeLayer != NULL);
+			const ImageArr& images(activeLayer->images);
+			MVS::Scene& scene(activeLayer->scene);
+			window.selectionType = newSelectionType;
+			if (newSelectionType == Window::SEL_CAMERA && (mods & GLFW_MOD_ALT)) {
+				// If alt is pressed, set view camera mode. Keep the previous selection only if it belongs to this layer.
+				window.selectionType = selectionLayerChanged ? Window::SEL_NA : prevSelectionType;
 				window.GetCamera().SetCameraViewMode(newSelectionIdx);
-			} else if (window.selectionType == Window::SEL_CAMERA && (mods & GLFW_MOD_CONTROL)) {
-				// If control is pressed, select neighbor camera
-				window.selectedNeighborCamera = newSelectionIdx;
+			} else if (newSelectionType == Window::SEL_CAMERA && (mods & GLFW_MOD_CONTROL)) {
+				// If control is pressed, select a neighbor camera when a primary camera is already selected in this layer.
+				const bool hasPrimaryCameraSelection = !selectionLayerChanged && prevSelectionType == Window::SEL_CAMERA && window.HasSelectionIds();
+				if (!hasPrimaryCameraSelection) {
+					window.SetSelectionId(newSelectionIdx);
+					window.selectedNeighborCamera = NO_ID;
+					window.selectionPoints[0] = newSelectionPoints[0];
+					window.selectionPoints[1] = newSelectionPoints[1];
+					window.selectionPoints[2] = newSelectionPoints[2];
+					window.selectionPoints[3] = newSelectionPoints[3];
+					window.selectionTime = now;
+				} else {
+					window.selectedNeighborCamera = newSelectionIdx;
+				}
 			} else {
 				// Normal selection
 				window.SetSelectionId(newSelectionIdx);
@@ -1081,7 +1835,7 @@ void Scene::OnCastRay(const Point2f& screenPos, const Ray3d& ray, int button, in
 			}
 			switch (window.selectionType) {
 			case Window::SEL_TRIANGLE: {
-				MVS::Mesh::Face face(IsWorkflowRunning() ? MVS::Mesh::Face() :  scene.mesh.faces[newSelectionIdx]);
+				const MVS::Mesh::Face& face(scene.mesh.faces[newSelectionIdx]);
 				DEBUG("Face selected:\n\tindex: %u\n\tvertex 1: %u (%g, %g, %g)\n\tvertex 2: %u (%g, %g, %g)\n\tvertex 3: %u (%g, %g, %g)",
 					newSelectionIdx,
 					face[0], newSelectionPoints[0].x, newSelectionPoints[0].y, newSelectionPoints[0].z,
@@ -1146,7 +1900,8 @@ void Scene::OnCastRay(const Point2f& screenPos, const Ray3d& ray, int button, in
 }
 
 void Scene::OnSetCameraViewMode(MVS::IIndex camID) {
-	if (!IsOpen() || camID >= images.size())
+	Layer* layer = GetActiveLayer();
+	if (layer == NULL || camID >= layer->images.size())
 		return;
 
 	// Save current camera state if entering camera view mode for the first time
@@ -1155,14 +1910,15 @@ void Scene::OnSetCameraViewMode(MVS::IIndex camID) {
 	window.GetCamera().SetCurrentCamID(camID);
 
 	// Get the Image from images and then access the MVS::Image via its index
-	Image& image = images[camID];
-	const MVS::Image& imageData = scene.images[image.idx];
+	Image& image = layer->images[camID];
+	const MVS::Image& imageData = layer->scene.images[image.idx];
 
 	// Load the image if not already loaded
 	if (!image.IsValid() && !image.IsImageLoading()) {
 		// Load image asynchronously
 		image.SetImageLoading();
-		events.AddEvent(new EVTLoadImage(this, camID, IMAGE_MAX_RESOLUTION));
+		pendingImageLoads.fetch_add(1);
+		events.AddEvent(new EVTLoadImage(this, layer->id, camID, IMAGE_MAX_RESOLUTION));
 	}
 
 	// Update camera with the scene data and viewport
@@ -1170,6 +1926,11 @@ void Scene::OnSetCameraViewMode(MVS::IIndex camID) {
 }
 
 void Scene::OnSelectPointsByCamera(bool highlightCameraVisiblePoints) {
+	Layer* layer = GetActiveLayer();
+	if (layer == NULL)
+		return;
+	MVS::Scene& scene(layer->scene);
+	ImageArr& images(layer->images);
 	if (!scene.pointcloud.IsValid() || scene.images.empty())
 		return;
 	SelectionController& selectionController = window.GetSelectionController();
@@ -1213,8 +1974,16 @@ void Scene::OnSelectPointsByCamera(bool highlightCameraVisiblePoints) {
 
 // Remove selected geometry (points and faces)
 void Scene::RemoveSelectedGeometry() {
+	if (HasBackgroundWork()) {
+		DEBUG("Cannot remove geometry while background work is running");
+		return;
+	}
 	if (!window.GetSelectionController().hasSelection())
 		return;
+	Layer* layer = GetActiveLayer();
+	if (layer == NULL)
+		return;
+	MVS::Scene& scene(layer->scene);
 
 	bool bDirtyScene = false;
 	SelectionController& selectionController = window.GetSelectionController();
@@ -1244,7 +2013,8 @@ void Scene::RemoveSelectedGeometry() {
 
 	// If any geometry was modified, update the scene
 	if (bDirtyScene) {
-		geometryModified.store(true);
+		SetGeometryModified(true);
+		RefreshLayerState(*layer, false);
 		window.UploadRenderData();
 	}
 }
@@ -1252,8 +2022,14 @@ void Scene::RemoveSelectedGeometry() {
 // Set the ROI (region of interest) based on the current selection
 //  - aabb: if true, use axis-aligned bounding box; if false, use oriented bounding box
 void Scene::SetROIFromSelection(bool aabb) {
-	if (!IsOpen())
+	if (HasBackgroundWork()) {
+		DEBUG("Cannot set ROI while background work is running");
 		return;
+	}
+	Layer* layer = GetActiveLayer();
+	if (layer == NULL)
+		return;
+	MVS::Scene& scene(layer->scene);
 
 	SelectionController& selectionController = window.GetSelectionController();
 	if (!selectionController.hasSelection())
@@ -1318,25 +2094,45 @@ void Scene::SetROIFromSelection(bool aabb) {
 // Centralizes the invariant: any code path that mutates scene.obb must refresh GPU
 // buffers and request a redraw. Call this from menu actions, workflows, and controllers.
 void Scene::ClearBoundingBox() {
-	if (!IsOpen())
+	if (HasBackgroundWork()) {
+		DEBUG("Cannot clear the bounding box while background work is running");
 		return;
+	}
+	Layer* layer = GetActiveLayer();
+	if (layer == NULL)
+		return;
+	MVS::Scene& scene(layer->scene);
 	scene.obb = OBB3f(true); // zero-extent => IsValid() == false
+	SetGeometryModified(true);
 	window.GetRenderer().UploadBounds(scene);
+	RefreshLayerState(*layer, false);
 	window.RequestRedraw();
 }
 
 // Replace the scene bounding box and refresh GPU buffers.
 // See ClearBoundingBox() for the rationale.
 void Scene::SetBoundingBox(const OBB3f& obb) {
-	if (!IsOpen())
+	if (HasBackgroundWork()) {
+		DEBUG("Cannot change the bounding box while background work is running");
 		return;
+	}
+	Layer* layer = GetActiveLayer();
+	if (layer == NULL)
+		return;
+	MVS::Scene& scene(layer->scene);
 	scene.obb = obb;
+	SetGeometryModified(true);
 	window.GetRenderer().UploadBounds(scene);
+	RefreshLayerState(*layer, false);
 	window.RequestRedraw();
 }
 
 // Crop scene to only images that see at least minPoints of the selected points
 MVS::Scene Scene::CropToPoints(const MVS::PointCloud::IndexArr& selectedPointIndices, unsigned minPoints) const {
+	const Layer* layer = GetActiveLayer();
+	if (layer == NULL)
+		return MVS::Scene();
+	const MVS::Scene& scene(layer->scene);
 	if (!scene.IsValid() || !scene.pointcloud.IsValid())
 		return MVS::Scene(); // Return empty scene
 

--- a/apps/Viewer/Scene.cpp
+++ b/apps/Viewer/Scene.cpp
@@ -314,6 +314,66 @@ void ActivateWorkingFolder(const Scene::Layer& layer)
 	ActivateWorkingFolder(layer.workingFolder);
 }
 
+String MakeUniqueLayerLabel(const Scene::LayerArr& layers, const String& requestedLabel, uint32_t ignoredLayerID = NO_ID)
+{
+	const String baseLabel(requestedLabel.empty() ? _T("Untitled") : requestedLabel);
+	String label(baseLabel);
+	for (unsigned suffix = 2;; ++suffix) {
+		bool duplicate = false;
+		for (const Scene::Layer& layer : layers) {
+			if (layer.id != ignoredLayerID && layer.label == label) {
+				duplicate = true;
+				break;
+			}
+		}
+		if (!duplicate)
+			return label;
+		label = String::FormatString(_T("%s (%u)"), baseLabel.c_str(), suffix);
+	}
+}
+
+unsigned UpdateCameraUncertaintyStatistics(Scene::Layer& layer)
+{
+	FloatArr sigmas;
+	for (const Scene::CameraUncertainty& uncertainty : layer.cameraUncertainty)
+		if (uncertainty.state == Scene::CameraUncertainty::COMPUTED)
+			sigmas.push_back(uncertainty.MaxPosSigma());
+	if (sigmas.empty()) {
+		layer.cameraUncertaintyNorm = 0.f;
+		layer.cameraUncertaintyAutoScale = 1.f;
+		return 0;
+	}
+	sigmas.Sort();
+	layer.cameraUncertaintyNorm = sigmas[(sigmas.size() - 1) * 95 / 100];
+	if (layer.cameraUncertaintyNorm <= 0.f)
+		layer.cameraUncertaintyNorm = MAXF(sigmas.Last(), 1.f);
+	const float sceneExtent = norm(layer.sceneSize);
+	const float medianSigma = sigmas[sigmas.size() / 2];
+	layer.cameraUncertaintyAutoScale = (sceneExtent > 0.f && medianSigma > 0.f) ?
+		MINF(MAXF(0.03f * sceneExtent / medianSigma, 1e-6f), 1e6f) : 1.f;
+	return (unsigned)sigmas.size();
+}
+
+bool HasNonCollinearPoints(const Point3Arr& points)
+{
+	if (points.size() < 3)
+		return false;
+	Eigen::Vector3d mean(Eigen::Vector3d::Zero());
+	for (const Point3& point : points)
+		mean += static_cast<const Point3::CEVecMap>(point);
+	mean /= (double)points.size();
+	Eigen::Matrix3d covariance(Eigen::Matrix3d::Zero());
+	for (const Point3& point : points) {
+		const Eigen::Vector3d centered(static_cast<const Point3::CEVecMap>(point) - mean);
+		covariance += centered * centered.transpose();
+	}
+	const Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> solver(covariance);
+	if (solver.info() != Eigen::Success || !solver.eigenvalues().allFinite())
+		return false;
+	const double largest = solver.eigenvalues()[2];
+	return largest > std::numeric_limits<double>::epsilon() && solver.eigenvalues()[1] > largest * 1e-10;
+}
+
 template <typename Geometry>
 AABB3f ComputeViewerBounds(const Geometry& geometry, size_t elementCount)
 {
@@ -552,7 +612,7 @@ void Scene::RefreshLayerState(Layer& layer, bool rebuildImages)
 		layer.sceneSize = Point3f(bounds.GetSize().cast<float>());
 	layer.sceneDistance = layer.images.empty() ? 1.f : scene.ComputeDistanceCameras2Scene(0.1f, true);
 	if (layer.label.empty()) {
-		layer.label = Util::getFileName(layer.sceneName);
+		layer.label = Util::getFileNameExt(layer.sceneName);
 	}
 }
 
@@ -769,61 +829,111 @@ bool Scene::AlignLayersToActive()
 	const Layer* refLayer = GetActiveLayer();
 	if (refLayer == NULL || layers.size() < 2)
 		return false;
-	// Reference camera centers keyed by image file name and by preserved SFM image ID:
-	// the same capture reconstructed twice keeps its photo names, and scenes exported
-	// from the same SFM keep their image IDs, so either key identifies shared cameras.
-	std::unordered_map<std::string, Point3> nameToCenter;
-	std::unordered_map<uint32_t, Point3> idToCenter;
+	// Reference camera centers keyed by image file name and by preserved SFM image ID.
+	// Duplicate basenames/IDs are marked ambiguous instead of silently overwriting a
+	// correspondence, which could otherwise produce a plausible but incorrect transform.
+	struct CameraMatch {
+		Point3 center;
+		MVS::IIndex imageIdx{NO_ID};
+	};
+	std::unordered_map<std::string, CameraMatch> nameToCamera;
+	std::unordered_map<uint32_t, CameraMatch> idToCamera;
 	for (const Image& image : refLayer->images) {
 		const MVS::Image& imageData = refLayer->scene.images[image.idx];
-		nameToCenter[Util::getFileNameExt(imageData.name).ToLower()] = Point3(imageData.camera.C);
-		if (imageData.ID != NO_ID)
-			idToCenter[imageData.ID] = Point3(imageData.camera.C);
+		const CameraMatch cameraMatch{Point3(imageData.camera.C), image.idx};
+		const std::string imageName(Util::getFileNameExt(imageData.name).ToLower());
+		const auto [nameIt, nameInserted] = nameToCamera.emplace(imageName, cameraMatch);
+		if (!nameInserted)
+			nameIt->second.imageIdx = NO_ID;
+		if (imageData.ID != NO_ID) {
+			const auto [idIt, idInserted] = idToCamera.emplace(imageData.ID, cameraMatch);
+			if (!idInserted)
+				idIt->second.imageIdx = NO_ID;
+		}
 	}
 	unsigned alignedLayers = 0;
 	for (Layer& layer : layers) {
 		if (layer.id == refLayer->id)
 			continue;
 		Point3Arr points, pointsRef;
+		std::unordered_set<MVS::IIndex> matchedRefImages;
+		unsigned nameMatches = 0, idMatches = 0;
 		for (const Image& image : layer.images) {
 			const MVS::Image& imageData = layer.scene.images[image.idx];
-			const auto it = nameToCenter.find(Util::getFileNameExt(imageData.name).ToLower());
-			if (it == nameToCenter.end())
+			const CameraMatch* match = NULL;
+			bool matchedByName = false;
+			const auto nameIt = nameToCamera.find(Util::getFileNameExt(imageData.name).ToLower());
+			if (nameIt != nameToCamera.end() && nameIt->second.imageIdx != NO_ID && !matchedRefImages.count(nameIt->second.imageIdx)) {
+				match = &nameIt->second;
+				matchedByName = true;
+			}
+			if (match == NULL && imageData.ID != NO_ID) {
+				const auto idIt = idToCamera.find(imageData.ID);
+				if (idIt != idToCamera.end() && idIt->second.imageIdx != NO_ID && !matchedRefImages.count(idIt->second.imageIdx))
+					match = &idIt->second;
+			}
+			if (match == NULL)
 				continue;
 			points.emplace_back(imageData.camera.C);
-			pointsRef.emplace_back(it->second);
-		}
-		if (points.size() < 3) {
-			points.Empty();
-			pointsRef.Empty();
-			for (const Image& image : layer.images) {
-				const MVS::Image& imageData = layer.scene.images[image.idx];
-				const auto it = imageData.ID != NO_ID ? idToCenter.find(imageData.ID) : idToCenter.end();
-				if (it == idToCenter.end())
-					continue;
-				points.emplace_back(imageData.camera.C);
-				pointsRef.emplace_back(it->second);
-			}
+			pointsRef.emplace_back(match->center);
+			matchedRefImages.emplace(match->imageIdx);
+			if (matchedByName)
+				++nameMatches;
+			else
+				++idMatches;
 		}
 		if (points.size() < 3) {
 			DEBUG("Layer '%s' not aligned: only %u camera(s) match the active layer", layer.label.c_str(), points.size());
 			continue;
 		}
+		if (!HasNonCollinearPoints(points) || !HasNonCollinearPoints(pointsRef)) {
+			DEBUG("Layer '%s' not aligned: the %u matched camera centers are coincident or collinear", layer.label.c_str(), points.size());
+			continue;
+		}
 		const Matrix4x4 transform = SimilarityTransform(points, pointsRef);
+		if (!static_cast<const Matrix4x4::CEMatMap>(transform).allFinite()) {
+			DEBUG("Layer '%s' not aligned: similarity estimation produced a non-finite transform", layer.label.c_str());
+			continue;
+		}
 		Matrix3x3 rotation; Point3 translation; REAL scale;
 		DecomposeSimilarityTransform(transform, rotation, translation, scale);
+		if (!std::isfinite(scale) || scale <= std::numeric_limits<REAL>::epsilon()) {
+			DEBUG("Layer '%s' not aligned: invalid estimated scale %g", layer.label.c_str(), scale);
+			continue;
+		}
 		layer.scene.Transform(rotation, translation, scale);
 		RefreshLayerState(layer, false);
+		if (!layer.cameraUncertainty.empty()) {
+			const Eigen::Matrix3f R = static_cast<const Matrix3x3::CEMatMap>(rotation).cast<float>();
+			for (CameraUncertainty& uncertainty : layer.cameraUncertainty) {
+				if (uncertainty.state != CameraUncertainty::COMPUTED)
+					continue;
+				Eigen::Matrix3f covariance = static_cast<const Matrix3x3f::CEMatMap>(uncertainty.posCov);
+				covariance = (float)SQUARE(scale) * R * covariance * R.transpose();
+				covariance = (covariance + covariance.transpose()) * 0.5f;
+				uncertainty.posCov = covariance;
+				uncertainty.posSigma = Point3f(
+					SQRT(MAXF(covariance(0, 0), 0.f)),
+					SQRT(MAXF(covariance(1, 1), 0.f)),
+					SQRT(MAXF(covariance(2, 2), 0.f)));
+			}
+			UpdateCameraUncertaintyStatistics(layer);
+		}
 		layer.dirty = true;
 		++alignedLayers;
-		DEBUG("Layer '%s' aligned to '%s' using %u matched cameras (scale %g)",
-			layer.label.c_str(), refLayer->label.c_str(), points.size(), scale);
+		DEBUG("Layer '%s' aligned to '%s' using %u matched cameras (%u by name, %u by ID; scale %g)",
+			layer.label.c_str(), refLayer->label.c_str(), points.size(), nameMatches, idMatches, scale);
 	}
 	if (alignedLayers == 0)
 		return false;
 	UpdateGeometryModifiedFlag();
-	// Keep the current viewpoint: the moved layers now coincide with the active layer,
-	// which the view is already framing.
+	// Refit to the unchanged reference layer. Loading an initially displaced layer
+	// may have framed very large combined bounds, leaving the aligned result tiny or
+	// off-center even though the transform itself succeeded.
+	if (!refLayer->bounds.IsEmpty())
+		window.SetSceneBounds(refLayer->bounds.GetCenter(), refLayer->bounds.GetSize().cast<float>());
+	else
+		UpdateWindowSceneBounds(true);
 	window.GetCamera().SetSceneDistance(ComputeVisibleSceneDistance());
 	window.UploadRenderData();
 	return true;
@@ -835,7 +945,7 @@ bool Scene::LoadLayer(Layer& layer, const String& fileName, String geometryFileN
 	const String sceneFileName(MAKE_PATH_FULL(WORKING_FOLDER_FULL, fileName));
 	layer.sceneName = sceneFileName;
 	layer.workingFolder = Util::getFilePath(sceneFileName);
-	layer.label = Util::getFileName(sceneFileName);
+	layer.label = Util::getFileNameExt(sceneFileName);
 	ActivateWorkingFolder(layer);
 
 	const MVS::Scene::SCENE_TYPE sceneType(layer.scene.Load(sceneFileName, true));
@@ -934,12 +1044,15 @@ bool Scene::AddLayer(const String& fileName, String geometryFileName, bool makeA
 		window.SetVisible(true);
 		return false;
 	}
+	layer.label = MakeUniqueLayerLabel(layers, layer.label);
 	layers.emplace_back(std::move(layer));
-	if (makeActive || activeLayerIndex < 0)
+	const bool activeLayerChanged(makeActive || activeLayerIndex < 0);
+	if (activeLayerChanged)
 		activeLayerIndex = (int)layers.size() - 1;
 	const Layer& activeLayer(*GetActiveLayer());
 	ActivateWorkingFolder(activeLayer);
-	PrecomputeTrackBasedNeighbors();
+	if (activeLayerChanged)
+		PrecomputeTrackBasedNeighbors();
 	window.GetCamera().SetMaxCamID(activeLayer.images.size());
 	window.GetCamera().SetSceneDistance(ComputeVisibleSceneDistance());
 	UpdateWindowSceneBounds(true);
@@ -1023,7 +1136,7 @@ bool Scene::Save(const String& _fileName, bool bRescaleImages) {
 	}
 	layer->sceneName = fileName;
 	layer->workingFolder = saveWorkingFolder;
-	layer->label = Util::getFileName(fileName);
+	layer->label = MakeUniqueLayerLabel(layers, Util::getFileNameExt(fileName), layer->id);
 	layer->dirty = false;
 	UpdateGeometryModifiedFlag();
 	UpdateWindowTitle();
@@ -1350,7 +1463,6 @@ bool Scene::LoadPoseUncertainty(const String& fileName) {
 	// match the entries to the scene images by ID
 	CameraUncertaintyArr loadedUncertainty(images.size());
 	unsigned matched = 0;
-	FloatArr sigmas;
 	FOREACH(i, images) {
 		const MVS::Image& imageData = scene.images[images[i].idx];
 		const auto it = mapUncertainty.find(imageData.ID);
@@ -1358,20 +1470,10 @@ bool Scene::LoadPoseUncertainty(const String& fileName) {
 			continue;
 		loadedUncertainty[i] = it->second;
 		++matched;
-		if (it->second.state == CameraUncertainty::COMPUTED)
-			sigmas.push_back(it->second.MaxPosSigma());
 	}
 	if (matched == 0) {
 		DEBUG("error: no pose uncertainty entries in '%s' match the scene image IDs", fileName.c_str());
 		return false;
-	}
-	// robust colormap normalization: 95th-percentile of the max-axis sigma
-	float uncertaintyNorm = 0.f;
-	if (!sigmas.empty()) {
-		sigmas.Sort();
-		uncertaintyNorm = sigmas[(sigmas.size() - 1) * 95 / 100];
-		if (uncertaintyNorm <= 0.f)
-			uncertaintyNorm = MAXF(sigmas.Last(), 1.f);
 	}
 	// Auto-size the ellipsoids to the scene: raw 1-sigma radii are in world units and can be far
 	// smaller (metric/GPS scenes) or far larger (datum-relative scenes, where the unanchored scale
@@ -1383,22 +1485,16 @@ bool Scene::LoadPoseUncertainty(const String& fileName) {
 	// small enough not to overlap their neighbours at the default x1 slider). This is kept SEPARATE
 	// from the user-facing `Window::uncertaintyEllipsoidScale` (which multiplies it, defaulting to 1)
 	// so the deferred ImGui-ini load of that persisted slider value cannot clobber the auto fit.
-	const float sceneExtent = norm(layer->sceneSize);
-	const float medianSigma = sigmas.empty() ? 0.f : sigmas[sigmas.size() / 2]; // sigmas is sorted above
-	const float uncertaintyAutoScale = (sceneExtent > 0.f && medianSigma > 0.f) ?
-		MINF(MAXF(0.03f * sceneExtent / medianSigma, 1e-6f), 1e6f) : 1.f;
 	layer->cameraUncertainty.Swap(loadedUncertainty);
-	layer->cameraUncertaintyNorm = uncertaintyNorm;
-	layer->cameraUncertaintyAutoScale = uncertaintyAutoScale;
+	const unsigned drawable = UpdateCameraUncertaintyStatistics(*layer);
 	window.showUncertaintyEllipsoids = true;
 	window.GetRenderer().UploadUncertaintyEllipsoids(window);
 	Window::RequestRedraw();
 	// drawable = COMPUTED entries (datum entries have zero covariance and draw nothing)
-	const unsigned drawable = sigmas.size();
 	DEBUG("Pose uncertainty loaded from '%s': %u/%u images matched (%u drawable ellipsoids, %u datum), "
 		"sigma norm %.3g, auto-fit ellipsoid scale %.3g (x%.3g slider)%s",
 		Util::getFileNameExt(fileName).c_str(), matched, images.size(),
-		drawable, matched - drawable, uncertaintyNorm, uncertaintyAutoScale,
+		drawable, matched - drawable, layer->cameraUncertaintyNorm, layer->cameraUncertaintyAutoScale,
 		window.uncertaintyEllipsoidScale,
 		drawable == 0 ? " -- WARNING: nothing to draw (all matched entries are gauge datum)" : "");
 	return true;
@@ -1778,8 +1874,9 @@ void Scene::OnCastRay(const Point2f& screenPos, const Ray3d& ray, int button, in
 		if (window.showCameras) {
 			const TCone<REAL, 3> cone(ray, D2R(REAL(0.5)));
 			const TConeIntersect<REAL, 3> coneIntersect(cone);
+			const bool pickCompareRight = screenPos.x >= (float)window.GetCompareSplitX();
 			for (const Layer& layer : layers) {
-				if (!layer.visible)
+				if (!layer.visible || (window.IsCompareEnabled() && layer.compareRight != pickCompareRight))
 					continue;
 				FOREACH(idx, layer.images) {
 					const Image& image = layer.images[idx];

--- a/apps/Viewer/Scene.h
+++ b/apps/Viewer/Scene.h
@@ -37,6 +37,53 @@ namespace VIEWER {
 
 class Scene {
 public:
+	// Per-image pose uncertainty loaded from a CreateStructure pose-quality CSV report
+	struct CameraUncertainty {
+		enum State : uint8_t {
+			NOT_COMPUTED = 0,
+			COMPUTED,
+			DATUM
+		};
+		Matrix3x3f posCov; // world-frame camera-center covariance (m^2 when geo-referenced)
+		Point3f posSigma; // camera-center 1-sigma along the world axes (sqrt of posCov diagonal)
+		Point3f rotSigma; // rotation 1-sigma about the camera x/y/z axes (deg)
+		State state{NOT_COMPUTED};
+		bool IsComputed() const { return state != NOT_COMPUTED; }
+		float MaxPosSigma() const { return MAXF(MAXF(posSigma.x, posSigma.y), posSigma.z); }
+	};
+	typedef CLISTDEF0IDX(CameraUncertainty, uint32_t) CameraUncertaintyArr;
+
+	struct Layer {
+		uint32_t id{NO_ID};
+		String label;
+		String sceneName;
+		String workingFolder;
+		bool visible{true};
+		bool dirty{false};
+		bool compareRight{false}; // compare split view side: false = left (A), true = right (B)
+		bool usePointSolidColor{false};
+		bool useCameraJetColor{false};
+		Point3f pointColor{1.f, 1.f, 1.f};
+		Point3f cameraColor{1.f, 1.f, 0.f};
+		MVS::Scene scene;
+		ImageArr images; // valid scene photos for this layer
+		CameraUncertaintyArr cameraUncertainty; // per viewer-image (indexed like images), empty when not loaded
+		float cameraUncertaintyNorm{0.f}; // ellipsoid colormap normalization (robust max of MaxPosSigma)
+		float cameraUncertaintyAutoScale{1.f}; // scene-fit radius scale (Window::uncertaintyEllipsoidScale multiplies it)
+		AABB3f bounds{true};
+		Point3f sceneSize{0, 0, 0};
+		float sceneDistance{1.f};
+
+		Layer() = default;
+		Layer(const Layer&) = delete;
+		Layer& operator=(const Layer&) = delete;
+		Layer(Layer&&) noexcept = default;
+		Layer& operator=(Layer&&) noexcept = default;
+
+		bool IsOpen() const { return scene.IsValid() || !scene.IsEmpty(); }
+	};
+	using LayerArr = std::vector<Layer>;
+
 	struct EstimateROIWorkflowOptions {
 		float scaleROI{1.1f};
 		int upAxis{-1}; // -1 = auto, 0=X,1=Y,2=Z
@@ -129,14 +176,13 @@ public:
 	ARCHIVE_TYPE nArchiveType;
 	String name;
 
-	String sceneName;
-	String geometryName;
-	bool geometryMesh;
 	bool estimateSfMNormals;
 	bool estimateSfMPatches;
-	MVS::Scene scene;
+	LayerArr layers;
+	int activeLayerIndex;
+	uint32_t nextLayerID;
+	uint32_t workflowLayerID;
 	Window window;
-	ImageArr images; // scene photos (only valid)
 
 	// Track-based neighbor information with shared point indices
 	struct ViewScoreWithPoints {
@@ -145,21 +191,6 @@ public:
 	};
 	typedef CLISTDEFIDX(ViewScoreWithPoints,uint32_t) ViewScoreWithPointsArr;
 	CLISTDEFIDX(ViewScoreWithPointsArr,uint32_t) trackBasedNeighbors; // per-viewer image neighbors from shared tracks
-
-	// Per-image pose uncertainty loaded from a CreateStructure pose-quality CSV report
-	struct CameraUncertainty {
-		enum State : uint8_t { NOT_COMPUTED = 0, COMPUTED, DATUM };
-		Matrix3x3f posCov; // world-frame camera-center covariance (m^2 when geo-referenced)
-		Point3f posSigma;  // camera-center 1-sigma along the world axes (sqrt of posCov diagonal)
-		Point3f rotSigma;  // rotation 1-sigma about the camera x/y/z axes (deg)
-		State state{NOT_COMPUTED};
-		bool IsComputed() const { return state != NOT_COMPUTED; }
-		float MaxPosSigma() const { return MAXF(MAXF(posSigma.x, posSigma.y), posSigma.z); }
-	};
-	typedef CLISTDEF0IDX(CameraUncertainty,uint32_t) CameraUncertaintyArr;
-	CameraUncertaintyArr cameraUncertainty; // per viewer-image (indexed like images), empty when not loaded
-	float cameraUncertaintyNorm; // ellipsoid colormap normalization (robust max of MaxPosSigma)
-	float cameraUncertaintyAutoScale; // scene-fit ellipsoid radius scale (Window::uncertaintyEllipsoidScale multiplies it)
 
 	EstimateROIWorkflowOptions estimateROIOptions;
 	DensifyWorkflowOptions densifyOptions;
@@ -186,9 +217,15 @@ public:
 		WF_REFINE,
 		WF_TEXTURE
 	};
+	enum ExportGeometry {
+		EXPORT_ALL = 0,
+		EXPORT_POINT_CLOUD,
+		EXPORT_MESH
+	};
 	std::atomic<WorkflowState> workflowState;
 	std::atomic<WorkflowType> currentWorkflowType;
 	std::atomic<bool> geometryModified;
+	std::atomic<unsigned> pendingImageLoads;
 	double workflowStartTime;
 	SEACAVE::CriticalSection workflowMutex;
 
@@ -212,19 +249,24 @@ public:
 	void Release();
 
 	inline bool IsValid() const { return window.IsValid(); }
-	inline bool IsOpen() const { return IsValid() && !scene.IsEmpty(); }
+	inline bool IsOpen() const { return IsValid() && !layers.empty(); }
 
 	bool SetViewFromFile(const String& viewFileName);
 	bool SetViewFromCamera(unsigned camIndex);
 
 	// Scene management
 	bool Open(const String& fileName, String geometryFileName = {});
+	bool OpenFiles(const std::vector<String>& fileNames, bool replaceExisting = true);
+	bool AddLayer(const String& fileName, String geometryFileName = {}, bool makeActive = true);
+	bool RemoveLayer(size_t layerIndex);
 	bool Save(const String& fileName = String(), bool bRescaleImages = false);
-	bool Export(const String& fileName, const String& exportType = String(), bool bViews = true) const;
+	bool SaveModifiedLayers();
+	bool Export(const String& fileName, const String& exportType = String(), bool bViews = true, ExportGeometry geometry = EXPORT_ALL) const;
+	bool ExportVisibleLayers(const String& fileName, const String& exportType = String(), ExportGeometry geometry = EXPORT_ALL) const;
 
 	// Pose uncertainty display (per-image quality report produced by CreateStructure)
 	bool LoadPoseUncertainty(const String& fileName);
-	bool HasCameraUncertainty() const { return !cameraUncertainty.empty(); }
+	bool HasCameraUncertainty() const;
 
 	// Workflows (async execution)
 	bool RunEstimateROIWorkflow(const EstimateROIWorkflowOptions& options);
@@ -232,15 +274,19 @@ public:
 	bool RunReconstructMeshWorkflow(const ReconstructMeshWorkflowOptions& options);
 	bool RunRefineMeshWorkflow(const RefineMeshWorkflowOptions& options);
 	bool RunTextureMeshWorkflow(const TextureMeshWorkflowOptions& options);
+	bool RunBatchWorkflow(const std::vector<WorkflowType>& workflowTypes);
 
 	// Workflow state management
 	bool IsWorkflowRunning() const { return workflowState.load() == WF_STATE_RUNNING; }
+	bool HasPendingImageLoads() const { return pendingImageLoads.load() != 0; }
+	bool HasBackgroundWork() const { return workflowState.load() != WF_STATE_IDLE || HasPendingImageLoads(); }
 	WorkflowState GetWorkflowState() const { return workflowState.load(); }
 	WorkflowType GetCurrentWorkflowType() const { return currentWorkflowType.load(); }
+	static const char* GetWorkflowName(WorkflowType type, bool shortName = false);
 	double GetWorkflowElapsedTime() const;
 	void CheckWorkflowCompletion(); // Called from main loop to check if workflow completed
 	bool IsGeometryModified() const { return geometryModified.load(); }
-	void SetGeometryModified(bool modified = true) { geometryModified.store(modified); }
+	void SetGeometryModified(bool modified = true);
 	const std::vector<WorkflowHistoryEntry>& GetWorkflowHistory() const { return workflowHistory; }
 	void ClearWorkflowHistory() { workflowHistory.clear(); }
 
@@ -265,10 +311,52 @@ public:
 	const RefineMeshWorkflowOptions& GetRefineMeshWorkflowOptions() const { return refineOptions; }
 	TextureMeshWorkflowOptions& GetTextureMeshWorkflowOptions() { return textureOptions; }
 	const TextureMeshWorkflowOptions& GetTextureMeshWorkflowOptions() const { return textureOptions; }
-	const MVS::Scene& GetScene() const { return scene; }
-	MVS::Scene& GetScene() { return scene; }
-	const ImageArr& GetImages() const { return images; }
-	ImageArr& GetImages() { return images; }
+	const LayerArr& GetLayers() const { return layers; }
+	size_t GetLayerCount() const { return layers.size(); }
+	int GetActiveLayerIndex() const { return activeLayerIndex; }
+	bool HasVisibleLayers() const;
+	Layer* GetLayer(size_t idx);
+	const Layer* GetLayer(size_t idx) const;
+	Layer* GetActiveLayer();
+	const Layer* GetActiveLayer() const;
+	Layer* GetLayerByID(uint32_t layerID);
+	const Layer* GetLayerByID(uint32_t layerID) const;
+	bool SetActiveLayer(size_t layerIndex, bool requestRedraw = true);
+	bool SetActiveLayerByID(uint32_t layerID, bool requestRedraw = true);
+	void SetLayerVisible(size_t layerIndex, bool visible);
+	void SetAllLayersVisible(bool visible = true);
+	void SoloLayer(size_t layerIndex);
+	void ActivateNextLayer(int direction);
+	// Compare view (swipe or split): when first enabled, assign the active layer to
+	// side A and every other layer to side B
+	void EnableCompareMode(Window::CompareMode mode);
+	// Align every other layer to the active layer with a similarity transform estimated from
+	// cameras matched by image name (fallback: preserved SFM image ID); returns true if any layer moved
+	bool AlignLayersToActive();
+	const MVS::Scene& GetScene() const
+	{
+		const Layer* layer = GetActiveLayer();
+		ASSERT(layer != NULL);
+		return layer->scene;
+	}
+	MVS::Scene& GetScene()
+	{
+		Layer* layer = GetActiveLayer();
+		ASSERT(layer != NULL);
+		return layer->scene;
+	}
+	const ImageArr& GetImages() const
+	{
+		const Layer* layer = GetActiveLayer();
+		ASSERT(layer != NULL);
+		return layer->images;
+	}
+	ImageArr& GetImages()
+	{
+		Layer* layer = GetActiveLayer();
+		ASSERT(layer != NULL);
+		return layer->images;
+	}
 	Window& GetWindow() { return window; }
 	MVS::IIndex ImageIdxMVS2Viewer(MVS::IIndex idx) const;
 
@@ -279,9 +367,29 @@ public:
 	void OnSelectPointsByCamera(bool highlightCameraVisiblePoints);
 
 private:
+	bool LoadLayer(Layer& layer, const String& fileName, String geometryFileName = {});
+	void RefreshLayerState(Layer& layer, bool rebuildImages = true);
+	void UpdateWindowTitle();
+	void UpdateWindowSceneBounds(bool resetView = true);
+	void RefreshVisibleLayers();
+	float ComputeVisibleSceneDistance() const;
+	void UpdateGeometryModifiedFlag();
+	bool BuildMergedVisiblePointCloud(MVS::PointCloud& pointcloud) const;
+	bool BuildMergedVisibleMesh(MVS::Mesh& mesh) const;
+	void ClearLayers();
+
 	void CropToBounds();
 	void TogleSceneBox();
 	void PrecomputeTrackBasedNeighbors();
+	bool StartWorkflow(WorkflowType type, Layer& layer, SEACAVE::Event* event);
+	bool StartNextBatchWorkflow();
+	bool batchWorkflowActive{false};
+	std::deque<WorkflowType> batchWorkflowQueue;
+	EstimateROIWorkflowOptions batchEstimateROIOptions;
+	DensifyWorkflowOptions batchDensifyOptions;
+	ReconstructMeshWorkflowOptions batchReconstructOptions;
+	RefineMeshWorkflowOptions batchRefineOptions;
+	TextureMeshWorkflowOptions batchTextureOptions;
 
 	// Workflow finalization (called from main thread after workflow completes)
 	void FinalizeWorkflow(bool success);

--- a/apps/Viewer/UI.cpp
+++ b/apps/Viewer/UI.cpp
@@ -1912,8 +1912,11 @@ void UI::ShowExportDialog(Scene& scene) {
 		ImGui::Separator();
 
 		const bool backgroundWork(scene.HasBackgroundWork());
-		bool canExport = !backgroundWork && (((exportFormat == 0 || exportFormat == 1) && hasPointCloud) || ((exportFormat == 2 || exportFormat == 3 || exportFormat == 4) && hasMesh));
-		if (ImGui::Button("Export...", ImVec2(120, 0)) && canExport) {
+		const bool canExport = !backgroundWork && (((exportFormat == 0 || exportFormat == 1) && hasPointCloud) || ((exportFormat == 2 || exportFormat == 3 || exportFormat == 4) && hasMesh));
+		ImGui::BeginDisabled(!canExport);
+		const bool exportRequested(ImGui::Button("Export...", ImVec2(120, 0)));
+		ImGui::EndDisabled();
+		if (exportRequested) {
 			String filename;
 			if (ShowSaveFileDialog(filename)) {
 				// Ensure the filename has the correct extension
@@ -1929,7 +1932,7 @@ void UI::ShowExportDialog(Scene& scene) {
 		}
 		if (!canExport) {
 			ImGui::SameLine();
-			ImGui::TextColored(ImVec4(0.7f, 0.7f, 0.7f, 1.f), "(Export disabled - no compatible data)");
+			ImGui::TextDisabled(backgroundWork ? "(Export disabled while processing)" : "(No compatible data)");
 		}
 
 		ImGui::SameLine();

--- a/apps/Viewer/UI.cpp
+++ b/apps/Viewer/UI.cpp
@@ -52,7 +52,8 @@ constexpr size_t MAX_UI_LOG_LINES = 9000;
 // S T R U C T S ///////////////////////////////////////////////////
 
 UI::UI()
-	: showSceneInfo(false)
+	: initialized(false)
+	, showSceneInfo(false)
 	, showCameraControls(false)
 	, showSelectionControls(false)
 	, showRenderSettings(false)
@@ -62,6 +63,7 @@ UI::UI()
 	, showWorkflowOverlay(true)
 	, showViewportOverlay(true)
 	, showSelectionOverlay(true)
+	, showLayersPanel(true)
 	, showAboutDialog(false)
 	, showHelpDialog(false)
 	, showExportDialog(false)
@@ -152,11 +154,15 @@ bool UI::Initialize(Window& window, const String& glslVersion) {
 
 	// Register log listener to capture log messages for the in-app console
 	GET_LOG().RegisterListener(DELEGATEBINDCLASS(Log::ClbkRecordMsg, &UI::RecordLog, this));
+	initialized = true;
 
 	return true;
 }
 
 void UI::Release() {
+	if (!initialized)
+		return;
+	initialized = false;
 	// Unregister log listener
 	GET_LOG().UnregisterListener(DELEGATEBINDCLASS(Log::ClbkRecordMsg, &UI::RecordLog, this));
 
@@ -187,6 +193,10 @@ void UI::Render(Window& window) {
 	ShowViewportOverlay(window);
 	ShowEmptySceneOverlay(window);
 	ShowSelectionOverlay(window);
+	if (showLayersPanel)
+		ShowLayersPanel(window);
+	if (window.compareMode && window.GetScene().IsOpen())
+		ShowCompareDivider(window);
 
 	ImGui::Render();
 	ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
@@ -231,33 +241,41 @@ void UI::ShowMainMenuBar(Window& window) {
 
 		if (ImGui::BeginMenu("File")) {
 			lastMenuInteraction = glfwGetTime(); // Update interaction time when menu is open
+			const bool backgroundWork(scene.HasBackgroundWork());
 			#ifdef __APPLE__
-			if (ImGui::MenuItem("Open Scene...", "Cmd+O")) {
+			if (ImGui::MenuItem("Open Scene...", "Cmd+O", false, !backgroundWork)) {
 			#else
-			if (ImGui::MenuItem("Open Scene...", "Ctrl+O")) {
+			if (ImGui::MenuItem("Open Scene...", "Ctrl+O", false, !backgroundWork)) {
 			#endif
 				// Open file dialog and load scene if file selected
 				window.SetVisible(false);
-				String filename, geometryFilename;
-				if (ShowOpenFileDialog(filename, geometryFilename))
-					scene.Open(filename, geometryFilename);
+				std::vector<String> filenames;
+				if (ShowOpenFileDialog(filenames) && ConfirmDiscardChanges(scene, "open another scene"))
+					scene.OpenFiles(filenames, true);
+				window.SetVisible(true);
+			}
+			if (ImGui::MenuItem("Add Layer...", nullptr, false, !backgroundWork)) {
+				window.SetVisible(false);
+				std::vector<String> filenames;
+				if (ShowOpenFileDialog(filenames))
+					scene.OpenFiles(filenames, false);
 				window.SetVisible(true);
 			}
 			// Load a pose-quality CSV report onto the current scene (camera uncertainty ellipsoids)
-			if (ImGui::MenuItem("Load Pose Quality...", nullptr, false, scene.IsOpen()))
+			if (ImGui::MenuItem("Load Pose Quality...", nullptr, false, scene.IsOpen() && !backgroundWork))
 				PromptOpenPoseQualityReport(window);
 			#ifdef __APPLE__
-			if (ImGui::MenuItem("Save Scene", "Cmd+S", false, scene.IsOpen())) {
+			if (ImGui::MenuItem("Save Scene", "Cmd+S", false, scene.IsOpen() && !backgroundWork)) {
 			#else
-			if (ImGui::MenuItem("Save Scene", "Ctrl+S", false, scene.IsOpen())) {
+			if (ImGui::MenuItem("Save Scene", "Ctrl+S", false, scene.IsOpen() && !backgroundWork)) {
 			#endif
 				// Save scene to current file
 				scene.Save();
 			}
 			#ifdef __APPLE__
-			if (ImGui::MenuItem("Save Scene As...", "Cmd+Shift+S", false, scene.IsOpen())) {
+			if (ImGui::MenuItem("Save Scene As...", "Cmd+Shift+S", false, scene.IsOpen() && !backgroundWork)) {
 			#else
-			if (ImGui::MenuItem("Save Scene As...", "Ctrl+Shift+S", false, scene.IsOpen())) {
+			if (ImGui::MenuItem("Save Scene As...", "Ctrl+Shift+S", false, scene.IsOpen() && !backgroundWork)) {
 			#endif
 				// Always prompt for save location
 				window.SetVisible(false);
@@ -295,25 +313,24 @@ void UI::ShowMainMenuBar(Window& window) {
 				window.SetVisible(true);
 			}
 			#ifdef __APPLE__
-			if (ImGui::MenuItem("Close", "Cmd+W", false, scene.IsOpen())) {
+			if (ImGui::MenuItem("Close", "Cmd+W", false, scene.IsOpen() && !backgroundWork)) {
 			#else
-			if (ImGui::MenuItem("Close", "Ctrl+W", false, scene.IsOpen())) {
+			if (ImGui::MenuItem("Close", "Ctrl+W", false, scene.IsOpen() && !backgroundWork)) {
 			#endif
-				// Release/reset the currently open scene (keeps the application/window running)
-				scene.Reset();
-				// Make sure renderer/UI reflect the cleared scene
-				window.UploadRenderData();
+				const int activeLayerIndex = scene.GetActiveLayerIndex();
+				if (activeLayerIndex >= 0 && ConfirmDiscardLayer(scene, (size_t)activeLayerIndex))
+					scene.RemoveLayer((size_t)activeLayerIndex);
 			}
 			ImGui::Separator();
-			if (ImGui::MenuItem("Export...", nullptr, false, scene.IsOpen())) {
+			if (ImGui::MenuItem("Export...", nullptr, false, scene.IsOpen() && !backgroundWork)) {
 				// Show export dialog with export format options
 				showExportDialog = true;
 			}
 			ImGui::Separator();
 			#ifdef __APPLE__
-			if (ImGui::MenuItem("Exit", "Cmd+Q")) {
+			if (ImGui::MenuItem("Exit", "Cmd+Q", false, !backgroundWork)) {
 			#else
-			if (ImGui::MenuItem("Exit", "Alt+F4")) {
+			if (ImGui::MenuItem("Exit", "Alt+F4", false, !backgroundWork)) {
 			#endif
 				// Check if geometry was modified and show save prompt
 				if (scene.IsGeometryModified()) {
@@ -333,6 +350,7 @@ void UI::ShowMainMenuBar(Window& window) {
 			ImGui::MenuItem("Selection Dialog", "Shift+S", &showSelectionDialog);
 			ImGui::MenuItem("Render Settings", "Shift+R", &showRenderSettings);
 			ImGui::MenuItem("Bounding Box", "Shift+B", &showBoundingBoxControls);
+			ImGui::MenuItem("Layers", nullptr, &showLayersPanel);
 			ImGui::Separator();
 			ImGui::MenuItem("Console", nullptr, &showConsoleOverlay);
 			ImGui::MenuItem("Performance Overlay", nullptr, &showPerformanceOverlay);
@@ -359,33 +377,33 @@ void UI::ShowMainMenuBar(Window& window) {
 			lastMenuInteraction = glfwGetTime();
 			const Scene& scene = window.GetScene();
 			const bool hasScene = scene.IsOpen();
-			const MVS::Scene& mvsScene = scene.GetScene();
-			const bool hasImages = hasScene && mvsScene.IsValid();
-			const bool hasPoints = hasImages && mvsScene.pointcloud.IsValid();
-			const bool hasMesh = hasImages && !mvsScene.mesh.IsEmpty();
-			const bool workflowRunning = scene.IsWorkflowRunning();
+			const bool backgroundWork = scene.HasBackgroundWork();
+			const MVS::Scene* mvsScene = hasScene && !backgroundWork ? &scene.GetScene() : nullptr;
+			const bool hasImages = mvsScene != nullptr && mvsScene->IsValid();
+			const bool hasPoints = hasImages && mvsScene->pointcloud.IsValid();
+			const bool hasMesh = hasImages && !mvsScene->mesh.IsEmpty();
 			const auto addWorkflowEntry = [&](const char* label, bool enabled, bool& toggleFlag, const char* tooltip) {
 				// Disable if workflow is running or prerequisites not met
-				const bool canRun = enabled && !workflowRunning;
+				const bool canRun = enabled && !backgroundWork;
 				if (ImGui::MenuItem(label, nullptr, false, canRun))
 					toggleFlag = true;
 				else if (!canRun && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
-					if (workflowRunning)
-						ImGui::SetTooltip("A workflow is currently running");
+					if (backgroundWork)
+						ImGui::SetTooltip("Background work is currently running");
 					else
 						ImGui::SetTooltip("%s", tooltip);
 				}
 			};
 			addWorkflowEntry("Estimate ROI", hasPoints, showEstimateROIWorkflow, "Requires calibrated images and point-cloud.");
-			if (ImGui::MenuItem("Recompute Bounding Box", "Ctrl+B", false, hasPoints && !workflowRunning))
+			if (ImGui::MenuItem("Recompute Bounding Box", "Ctrl+B", false, hasPoints && !backgroundWork))
 				window.GetScene().RunEstimateROIWorkflow(window.GetScene().GetEstimateROIWorkflowOptions());
 			else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
 				ImGui::SetTooltip("Run the ROI estimation workflow with the current options (same as Ctrl+B)");
-			if (ImGui::MenuItem("Set Bounding Box from Selection", nullptr, false, hasScene))
+			if (ImGui::MenuItem("Set Bounding Box from Selection", nullptr, false, hasScene && !backgroundWork))
 				window.GetScene().SetROIFromSelection(false);
 			else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
 				ImGui::SetTooltip("Fit an oriented bounding box to the currently selected points/faces");
-			if (ImGui::MenuItem("Clear Bounding Box", nullptr, false, hasScene && mvsScene.IsBounded()))
+			if (ImGui::MenuItem("Clear Bounding Box", nullptr, false, mvsScene != nullptr && mvsScene->IsBounded() && !backgroundWork))
 				window.GetScene().ClearBoundingBox();
 			else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
 				ImGui::SetTooltip("Remove the scene's bounding box");
@@ -415,6 +433,7 @@ void UI::ShowMainMenuBar(Window& window) {
 
 void UI::ShowSceneInfo(const Window& window) {
 	if (!showSceneInfo) return;
+	if (!window.GetScene().IsOpen()) return; // GetScene() requires an active layer
 	const MVS::Scene& scene = window.GetScene().GetScene();
 
 	ImGui::SetNextWindowPos(ImVec2(10, 110), ImGuiCond_FirstUseEver);
@@ -525,23 +544,15 @@ void UI::ShowCameraControls(Window& window) {
 		if (ImGui::SliderFloat("Camera Size", &window.cameraSize, 0.005f, 0.5f, "%.4f")) {
 			window.GetRenderer().UploadCameras(window);
 			window.GetRenderer().UploadSelection(window);
+			window.RequestRedraw();
 		}
 		if (ImGui::IsItemHovered())
 			ImGui::SetTooltip("Adjust camera size");
 
-		// Camera display color mode
-		ImGui::TextUnformatted("Camera Display Color");
-		int displayColor = (int)window.cameraDisplayColor;
-		bool cameraDisplayChanged = false;
-		if (ImGui::RadioButton("Solid##CameraDisplayColor", &displayColor, (int)Window::CAMERA_COLOR_SOLID))
-			cameraDisplayChanged = true;
-		ImGui::SameLine();
-		if (ImGui::RadioButton("Jet##CameraDisplayColor", &displayColor, (int)Window::CAMERA_COLOR_JET))
-			cameraDisplayChanged = true;
-
 		// Camera display type
 		ImGui::TextUnformatted("Camera Display Type");
 		int displayType = (int)window.cameraDisplayType;
+		bool cameraDisplayChanged = false;
 		if (ImGui::RadioButton("Frustum##CameraDisplayType", &displayType, (int)Window::CAMERA_DISPLAY_FRUSTUM))
 			cameraDisplayChanged = true;
 		ImGui::SameLine();
@@ -554,7 +565,6 @@ void UI::ShowCameraControls(Window& window) {
 			ImGui::SetTooltip("Show look-at direction indicator for each camera");
 
 		if (cameraDisplayChanged) {
-			window.cameraDisplayColor = (Window::CameraDisplayColor)displayColor;
 			window.cameraDisplayType = (Window::CameraDisplayType)displayType;
 			window.GetRenderer().UploadCameras(window);
 			window.GetRenderer().UploadSelection(window);
@@ -563,7 +573,7 @@ void UI::ShowCameraControls(Window& window) {
 
 		// Pose-uncertainty ellipsoids (available once a pose quality report is loaded)
 		{
-			ImGui::BeginDisabled(!window.GetScene().IsOpen());
+			ImGui::BeginDisabled(!window.GetScene().IsOpen() || window.GetScene().HasBackgroundWork());
 			if (ImGui::Button("Load Pose Quality..."))
 				PromptOpenPoseQualityReport(window);
 			ImGui::EndDisabled();
@@ -860,14 +870,14 @@ void UI::ShowBoundingBoxControls(Window& window) {
 	if (!showBoundingBoxControls) return;
 
 	Scene& scene = window.GetScene();
-	MVS::Scene& mvsScene = scene.GetScene();
 
 	ImGui::SetNextWindowPos(ImVec2(20, 130), ImGuiCond_FirstUseEver);
 	ImGui::SetNextWindowSize(ImVec2(340, 420), ImGuiCond_FirstUseEver);
 	if (ImGui::Begin("Bounding Box", &showBoundingBoxControls)) {
 		const bool hasScene = scene.IsOpen();
-		const bool hasPoints = mvsScene.pointcloud.IsValid();
-		const bool isBounded = mvsScene.IsBounded();
+		MVS::Scene* mvsScene = hasScene ? &scene.GetScene() : nullptr;
+		const bool hasPoints = mvsScene != nullptr && mvsScene->pointcloud.IsValid();
+		const bool isBounded = mvsScene != nullptr && mvsScene->IsBounded();
 		const bool workflowRunning = scene.IsWorkflowRunning();
 
 		// --- Visibility ---
@@ -906,6 +916,7 @@ void UI::ShowBoundingBoxControls(Window& window) {
 		}
 		ImGui::Spacing();
 		{
+			ImGui::BeginDisabled(workflowRunning);
 			if (ImGui::Button("Select ROI with mouse...")) {
 				// Switch to selection control so the user can draw a region.
 				window.SetControlMode(Window::CONTROL_SELECTION);
@@ -920,10 +931,11 @@ void UI::ShowBoundingBoxControls(Window& window) {
 			if (ImGui::Button("Set from Selection (AABB)"))
 				scene.SetROIFromSelection(true);
 			ImGui::EndDisabled();
+			ImGui::EndDisabled();
 		}
 		ImGui::Spacing();
 		{
-			ImGui::BeginDisabled(!isBounded);
+			ImGui::BeginDisabled(!isBounded || workflowRunning);
 			if (ImGui::Button("Clear Bounding Box"))
 				scene.ClearBoundingBox();
 			ImGui::EndDisabled();
@@ -938,6 +950,7 @@ void UI::ShowBoundingBoxControls(Window& window) {
 		if (!isBounded) {
 			ImGui::TextDisabled("(no bounding box - compute or set one first)");
 		} else {
+			ImGui::BeginDisabled(workflowRunning);
 			// 3D gizmo edit mode toggle
 			const bool inEditMode = window.GetControlMode() == Window::CONTROL_BBOX_EDIT;
 			if (inEditMode) {
@@ -956,7 +969,7 @@ void UI::ShowBoundingBoxControls(Window& window) {
 
 			// Numeric edit - always available. Edit a local copy, then commit
 			// through Scene::SetBoundingBox so invariants stay centralized.
-			OBB3f edited = mvsScene.obb;
+			OBB3f edited = mvsScene->obb;
 			if (BoxRotationWidget::EditOBB("##OBBEdit", edited)) {
 				scene.SetBoundingBox(edited);
 				// If the controller is active, refresh its working copy too.
@@ -972,9 +985,295 @@ void UI::ShowBoundingBoxControls(Window& window) {
 			}
 			if (ImGui::IsItemHovered())
 				ImGui::SetTooltip("Clear the current OBB and re-run Estimate ROI");
+			ImGui::EndDisabled();
 		}
 	}
 	ImGui::End();
+}
+
+void UI::ShowLayersPanel(Window& window)
+{
+	Scene& scene = window.GetScene();
+	ImGui::SetNextWindowPos(ImVec2(10, 470), ImGuiCond_FirstUseEver);
+	ImGui::SetNextWindowSize(ImVec2(320, 320), ImGuiCond_FirstUseEver);
+	if (!ImGui::Begin("Layers", &showLayersPanel)) {
+		ImGui::End();
+		return;
+	}
+	const bool backgroundWork(scene.HasBackgroundWork());
+	ImGui::BeginDisabled(backgroundWork);
+	if (backgroundWork) {
+		ImGui::TextDisabled("Layer controls are locked while background work is running");
+		ImGui::EndDisabled();
+		ImGui::End();
+		return;
+	}
+
+	if (ImGui::Button("Open...", ImVec2(90, 0))) {
+		window.SetVisible(false);
+		std::vector<String> filenames;
+		if (ShowOpenFileDialog(filenames) && ConfirmDiscardChanges(scene, "open another scene"))
+			scene.OpenFiles(filenames, true);
+		window.SetVisible(true);
+	}
+	ImGui::SameLine();
+	if (ImGui::Button("Add...", ImVec2(90, 0))) {
+		window.SetVisible(false);
+		std::vector<String> filenames;
+		if (ShowOpenFileDialog(filenames))
+			scene.OpenFiles(filenames, false);
+		window.SetVisible(true);
+	}
+	ImGui::SameLine();
+	if (ImGui::Button("Show All", ImVec2(90, 0)))
+		scene.SetAllLayersVisible();
+
+	if (!scene.IsOpen()) {
+		ImGui::EndDisabled();
+		ImGui::Separator();
+		ImGui::TextDisabled("No layers loaded");
+		ImGui::End();
+		return;
+	}
+
+	ImGui::Separator();
+	if (ImGui::Button("Prev")) {
+		scene.ActivateNextLayer(-1);
+	}
+	ImGui::SameLine();
+	if (ImGui::Button("Next")) {
+		scene.ActivateNextLayer(1);
+	}
+	ImGui::SameLine();
+	if (ImGui::Button("Solo Active")) {
+		const int activeLayerIndex = scene.GetActiveLayerIndex();
+		if (activeLayerIndex >= 0)
+			scene.SoloLayer((size_t)activeLayerIndex);
+	}
+
+	ImGui::Separator();
+	int compareMode = (int)window.compareMode;
+	bool compareChanged = false;
+	ImGui::AlignTextToFramePadding();
+	ImGui::TextUnformatted("Compare:");
+	ImGui::SameLine();
+	compareChanged |= ImGui::RadioButton("Off", &compareMode, Window::COMPARE_DISABLED);
+	ImGui::SameLine();
+	compareChanged |= ImGui::RadioButton("Swipe", &compareMode, Window::COMPARE_SWIPE);
+	if (ImGui::IsItemHovered())
+		ImGui::SetTooltip("Split the view at a draggable divider: side-A layers render left,\n"
+		                  "side-B layers right, both sharing the same full-window projection,\n"
+		                  "so aligned scenes match pixel-exact across the divider");
+	ImGui::SameLine();
+	compareChanged |= ImGui::RadioButton("Split", &compareMode, Window::COMPARE_SPLIT);
+	if (ImGui::IsItemHovered())
+		ImGui::SetTooltip("Show two equal side-by-side viewports, each scene centered\n"
+		                  "in its own full frustum");
+	if (compareChanged)
+		scene.EnableCompareMode((Window::CompareMode)compareMode);
+	if (window.IsCompareEnabled()) {
+		bool syncCameras = window.compareSyncCameras;
+		if (ImGui::Checkbox("Sync Cameras", &syncCameras))
+			window.SetCompareSyncCameras(syncCameras);
+		if (ImGui::IsItemHovered())
+			ImGui::SetTooltip("Move the cameras of both sides together; uncheck to adjust each\n"
+			                  "side's camera individually with the mouse over its viewport\n"
+			                  "(re-checking snaps the other side back onto the active view)");
+	}
+	if (scene.GetLayerCount() > 1) {
+		ImGui::SameLine();
+		if (ImGui::Button("Align to Active")) {
+			if (!scene.AlignLayersToActive())
+				DEBUG("No layer could be aligned to the active layer");
+		}
+		if (ImGui::IsItemHovered())
+			ImGui::SetTooltip("Move every other layer onto the active layer with a similarity transform\n"
+			                  "estimated from cameras shared between the scenes (matched by photo name,\n"
+			                  "then by preserved SFM image ID); requires at least 3 shared cameras");
+	}
+
+	ImGui::Separator();
+	bool removedLayer = false;
+	const int layerColumns = window.compareMode ? 5 : 4;
+	if (ImGui::BeginTable("##layer-list", layerColumns, ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersInnerH)) {
+		ImGui::TableSetupColumn("Visible", ImGuiTableColumnFlags_WidthFixed, 24.f);
+		ImGui::TableSetupColumn("Layer", ImGuiTableColumnFlags_WidthStretch);
+		if (window.compareMode)
+			ImGui::TableSetupColumn("Side", ImGuiTableColumnFlags_WidthFixed, 24.f);
+		ImGui::TableSetupColumn("Solo", ImGuiTableColumnFlags_WidthFixed, 24.f);
+		ImGui::TableSetupColumn("Remove", ImGuiTableColumnFlags_WidthFixed, 24.f);
+		for (size_t i = 0; i < scene.GetLayerCount(); ++i) {
+			Scene::Layer* layer = scene.GetLayer(i);
+			if (layer == nullptr)
+				continue;
+			ImGui::PushID((int)layer->id);
+			ImGui::TableNextRow();
+
+			ImGui::TableSetColumnIndex(0);
+			bool isVisible = layer->visible;
+			if (ImGui::Checkbox("##visible", &isVisible))
+				scene.SetLayerVisible(i, isVisible);
+			if (ImGui::IsItemHovered())
+				ImGui::SetTooltip("Show or hide this layer");
+
+			ImGui::TableSetColumnIndex(1);
+			String displayLabel(layer->label);
+			if (layer->dirty)
+				displayLabel += _T(" *");
+			const bool isActive(scene.GetActiveLayerIndex() == (int)i);
+			if (ImGui::Selectable(displayLabel.c_str(), isActive))
+				scene.SetActiveLayer(i);
+			if (ImGui::IsItemHovered())
+					ImGui::SetTooltip("%u points\n%u mesh vertices, %u faces\n%u cameras",
+					                  (unsigned)layer->scene.pointcloud.points.size(), (unsigned)layer->scene.mesh.vertices.size(),
+					                  (unsigned)layer->scene.mesh.faces.size(), (unsigned)layer->images.size());
+
+			int column = 2;
+			if (window.compareMode) {
+				ImGui::TableSetColumnIndex(column++);
+				if (ImGui::SmallButton(layer->compareRight ? "B" : "A")) {
+					layer->compareRight = !layer->compareRight;
+					window.RequestRedraw();
+				}
+				if (ImGui::IsItemHovered())
+					ImGui::SetTooltip("Compare side: A renders left of the divider, B right (click to swap)");
+			}
+
+			ImGui::TableSetColumnIndex(column++);
+			if (ImGui::SmallButton("S"))
+				scene.SoloLayer(i);
+			if (ImGui::IsItemHovered())
+				ImGui::SetTooltip("Solo this layer");
+
+			ImGui::TableSetColumnIndex(column);
+			if (ImGui::SmallButton("X") && ConfirmDiscardLayer(scene, i)) {
+				scene.RemoveLayer(i);
+				removedLayer = true;
+				ImGui::PopID();
+				break;
+			}
+			if (ImGui::IsItemHovered())
+				ImGui::SetTooltip("Remove this layer");
+			ImGui::PopID();
+		}
+		ImGui::EndTable();
+	}
+	if (removedLayer) {
+		ImGui::EndDisabled();
+		ImGui::End();
+		return;
+	}
+
+	Scene::Layer* activeLayer = scene.GetActiveLayer();
+	if (activeLayer != nullptr) {
+		ImGui::Separator();
+		ImGui::Text("Active Layer Appearance");
+
+		bool pointAppearanceChanged = false;
+		bool cameraAppearanceChanged = false;
+
+		const bool hasPoints = !activeLayer->scene.pointcloud.IsEmpty();
+		const bool hasCameras = !activeLayer->images.empty();
+
+		if (hasPoints) {
+			bool usePointSolidColor = activeLayer->usePointSolidColor;
+			if (ImGui::Checkbox("Solid Point Color", &usePointSolidColor)) {
+				activeLayer->usePointSolidColor = usePointSolidColor;
+				pointAppearanceChanged = true;
+			}
+
+			float pointColor[3] = {
+			    activeLayer->pointColor.x,
+			    activeLayer->pointColor.y,
+			    activeLayer->pointColor.z};
+			ImGui::BeginDisabled(!activeLayer->usePointSolidColor);
+			if (ImGui::ColorEdit3("Point Color", pointColor)) {
+				activeLayer->pointColor = Point3f(pointColor[0], pointColor[1], pointColor[2]);
+				pointAppearanceChanged = true;
+			}
+			ImGui::EndDisabled();
+		} else {
+			ImGui::TextDisabled("No point cloud in active layer");
+		}
+
+		if (hasCameras) {
+			bool useCameraJetColor = activeLayer->useCameraJetColor;
+			if (ImGui::Checkbox("Jet Camera Colors", &useCameraJetColor)) {
+				activeLayer->useCameraJetColor = useCameraJetColor;
+				cameraAppearanceChanged = true;
+			}
+
+			float cameraColor[3] = {
+			    activeLayer->cameraColor.x,
+			    activeLayer->cameraColor.y,
+			    activeLayer->cameraColor.z};
+			ImGui::BeginDisabled(activeLayer->useCameraJetColor);
+			if (ImGui::ColorEdit3("Camera Color", cameraColor)) {
+				activeLayer->cameraColor = Point3f(cameraColor[0], cameraColor[1], cameraColor[2]);
+				cameraAppearanceChanged = true;
+			}
+			ImGui::EndDisabled();
+			ImGui::TextDisabled("Jet gradient is computed within this layer.");
+		} else {
+			ImGui::TextDisabled("No cameras in active layer");
+		}
+
+		if (pointAppearanceChanged || cameraAppearanceChanged) {
+			if (pointAppearanceChanged)
+				window.GetRenderer().UploadPointClouds(scene, window.pointNormalLength);
+			if (cameraAppearanceChanged)
+				window.GetRenderer().UploadCameras(window);
+			window.RequestRedraw();
+		}
+	}
+	ImGui::EndDisabled();
+
+	ImGui::End();
+}
+
+// A|B compare divider: the split line and side labels drawn on the foreground draw
+// list. In swipe mode a full-height drag handle moves the divider; the position is
+// stored as a window fraction, so the UI-space overlay and the framebuffer-space
+// scissor rects always agree. In split mode the divider is a fixed separator
+// between the two equal viewports.
+void UI::ShowCompareDivider(Window& window)
+{
+	const ImGuiIO& io = ImGui::GetIO();
+	const float displayWidth = io.DisplaySize.x;
+	const float displayHeight = io.DisplaySize.y;
+	if (displayWidth <= 0.f || displayHeight <= 0.f)
+		return;
+
+	float splitX = window.compareSplitPos * displayWidth;
+	bool hovered = false, held = false;
+	if (window.compareMode == Window::COMPARE_SWIPE) {
+		ImGui::SetNextWindowPos(ImVec2(splitX - 6.f, 0.f));
+		ImGui::SetNextWindowSize(ImVec2(12.f, displayHeight));
+		ImGui::SetNextWindowBgAlpha(0.f);
+		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings |
+		                               ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav |
+		                               ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBackground;
+		if (ImGui::Begin("##compare-divider", nullptr, flags)) {
+			ImGui::InvisibleButton("##compare-divider-drag", ImVec2(12.f, displayHeight));
+			hovered = ImGui::IsItemHovered();
+			held = ImGui::IsItemActive();
+			if (hovered || held)
+				ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
+			if (held) {
+				window.compareSplitPos = CLAMP(io.MousePos.x / displayWidth, 0.05f, 0.95f);
+				Window::RequestRedraw();
+			}
+		}
+		ImGui::End();
+	}
+
+	splitX = window.compareSplitPos * displayWidth;
+	ImDrawList* drawList = ImGui::GetForegroundDrawList();
+	const ImU32 lineColor = (hovered || held) ? IM_COL32(255, 210, 80, 255) : IM_COL32(230, 230, 230, 180);
+	drawList->AddLine(ImVec2(splitX, 0.f), ImVec2(splitX, displayHeight), lineColor, (hovered || held) ? 3.f : 2.f);
+	const ImU32 labelColor = IM_COL32(255, 255, 255, 220);
+	drawList->AddText(ImVec2(splitX - 20.f, 40.f), labelColor, "A");
+	drawList->AddText(ImVec2(splitX + 10.f, 40.f), labelColor, "B");
 }
 
 void UI::ShowConsoleOverlay(Window& window)
@@ -1000,8 +1299,8 @@ void UI::ShowConsoleOverlay(Window& window)
 	ImGui::SetNextWindowPos(window_pos, ImGuiCond_Always, window_pos_pivot);
 	ImGui::SetNextWindowBgAlpha(0.35f);
 	ImGui::SetNextWindowSizeConstraints(ImVec2(400, 100), ImVec2(
-		MINF(window.GetCamera().GetSize().width*0.8f, 800*window.userFontScale),
-		MINF(window.GetCamera().GetSize().height*0.4f, 200*window.userFontScale)));
+		MINF(window.GetSize().width*0.8f, 800*window.userFontScale),
+		MINF(window.GetSize().height*0.4f, 200*window.userFontScale)));
 
 	if (ImGui::Begin("Console", &showConsoleOverlay, window_flags)) {
 		// use the last item's rect (the child) in screen coordinates — this anchors the buttons
@@ -1135,12 +1434,7 @@ void UI::ShowWorkflowOverlay(Window& window) {
 		if (workflowRunning) {
 			const Scene::WorkflowType type = scene.GetCurrentWorkflowType();
 			const double elapsed = scene.GetWorkflowElapsedTime();
-			const char* workflowName =
-				type == Scene::WF_ESTIMATE_ROI ? "Estimate ROI" :
-				type == Scene::WF_DENSIFY ? "Densify" :
-				type == Scene::WF_RECONSTRUCT ? "Reconstruct Mesh" :
-				type == Scene::WF_REFINE ? "Refine Mesh" :
-				type == Scene::WF_TEXTURE ? "Texture Mesh" : "Unknown";
+			const char* workflowName = Scene::GetWorkflowName(type);
 
 			ImGui::TextColored(ImVec4(1.0f, 0.7f, 0.2f, 1.0f), "Running: %s", workflowName);
 			ImGui::ProgressBar(-1.0f * static_cast<float>(ImGui::GetTime()), ImVec2(-1, 0));
@@ -1157,12 +1451,7 @@ void UI::ShowWorkflowOverlay(Window& window) {
 			const size_t start = history.size() > maxShow ? history.size() - maxShow : 0;
 			for (size_t i = start; i < history.size(); ++i) {
 				const auto& entry = history[i];
-				const char* name =
-					entry.type == Scene::WF_ESTIMATE_ROI ? "ROI" :
-					entry.type == Scene::WF_DENSIFY ? "Densify" :
-					entry.type == Scene::WF_RECONSTRUCT ? "Reconstruct" :
-					entry.type == Scene::WF_REFINE ? "Refine" :
-					entry.type == Scene::WF_TEXTURE ? "Texture" : "?";
+				const char* name = Scene::GetWorkflowName(entry.type, true);
 
 				if (entry.success) {
 					ImGui::TextColored(ImVec4(0.0f, 1.0f, 0.0f, 1.0f), "%s: %.1f s", name, entry.duration);
@@ -1277,9 +1566,9 @@ void UI::ShowEmptySceneOverlay(const Window& window) {
 		ImGui::Dummy(ImVec2(0,8));
 		ImGui::SetCursorPosX((win_size.x - btn_w) * 0.5f);
 		if (ImGui::Button("Open", ImVec2(btn_w, btn_h))) {
-			String filename, geometryFilename;
-			if (ShowOpenFileDialog(filename, geometryFilename))
-				scene.Open(filename, geometryFilename);
+			std::vector<String> filenames;
+			if (ShowOpenFileDialog(filenames))
+				scene.OpenFiles(filenames, true);
 		}
 	}
 	ImGui::End();
@@ -1337,6 +1626,7 @@ void UI::ShowHelpDialog() {
 			ImGui::Text("  Ctrl+X        Save Screenshot");
 			ImGui::Text("  Alt+F4        Exit");
 		}
+		ImGui::Text("  [ / ]         Previous/next active layer");
 		ImGui::Separator();
 
 		// Camera Navigation
@@ -1442,6 +1732,9 @@ void UI::ShowHelpDialog() {
 		ImGui::Text("  Mouse at top        Show/hide menu bar");
 		ImGui::Text("  Escape              Close dialogs/windows");
 		ImGui::Text("                      Clear focus/hide menu");
+		ImGui::Text("  Layers panel        Toggle visibility, solo, active layer");
+		ImGui::Text("                      Compare A|B (swipe or split view), align layers");
+		ImGui::Text("                      Sync or per-viewport camera adjustment");
 		ImGui::Separator();
 
 		// File Formats
@@ -1476,6 +1769,10 @@ void UI::ShowHelpDialog() {
 
 void UI::ShowExportDialog(Scene& scene) {
 	if (!showExportDialog) return;
+	if (!scene.IsOpen() || scene.HasBackgroundWork()) {
+		showExportDialog = false;
+		return;
+	}
 
 	// Show as a regular window instead of modal popup
 	ImGui::SetNextWindowSize(ImVec2(400, 300), ImGuiCond_FirstUseEver);
@@ -1484,33 +1781,59 @@ void UI::ShowExportDialog(Scene& scene) {
 		ImGui::Separator();
 
 		static int exportFormat = 0;
+		static int exportScope = 0;
 		static bool bExportViews = true;
 		const char* formatOptions[] = { "PLY Point Cloud", "GLTF Point Cloud", "PLY Mesh", "OBJ Mesh", "GLTF Mesh" };
 		const char* formatExt[] = { ".ply", ".glb", ".ply", ".obj", ".glb" };
 		ImGui::Combo("Export Format", &exportFormat, formatOptions, IM_ARRAYSIZE(formatOptions));
+		if (scene.GetLayerCount() > 1) {
+			const char* scopeOptions[] = {"Active Layer", "Visible Layers (Merged)"};
+			ImGui::Combo("Export Scope", &exportScope, scopeOptions, IM_ARRAYSIZE(scopeOptions));
+		} else {
+			exportScope = 0;
+		}
 
 		ImGui::Separator();
 
 		// Show what will be exported based on format and scene content
-		const MVS::Scene& mvs_scene = scene.GetScene();
-		bool hasPointCloud = !mvs_scene.pointcloud.IsEmpty();
-		bool hasMesh = !mvs_scene.mesh.IsEmpty();
+		bool hasPointCloud = false;
+		bool hasMesh = false;
+		if (exportScope == 0) {
+			const MVS::Scene& mvs_scene = scene.GetScene();
+			hasPointCloud = !mvs_scene.pointcloud.IsEmpty();
+			hasMesh = !mvs_scene.mesh.IsEmpty();
+		} else {
+			for (const Scene::Layer& layer : scene.GetLayers()) {
+				if (!layer.visible)
+					continue;
+				hasPointCloud = hasPointCloud || !layer.scene.pointcloud.IsEmpty();
+				hasMesh = hasMesh || !layer.scene.mesh.IsEmpty();
+			}
+		}
 
 		switch (exportFormat) {
 		case 0: // PLY Point Cloud
 		case 1: // GLTF Point Cloud
 			if (hasPointCloud) {
-				ImGui::Text("✓ Point cloud: %zu points", mvs_scene.pointcloud.points.size());
-				if (!mvs_scene.pointcloud.pointViews.empty()) {
+				if (exportScope == 0) {
+					const MVS::Scene& mvs_scene = scene.GetScene();
+					ImGui::Text("✓ Point cloud: %zu points", mvs_scene.pointcloud.points.size());
+				} else {
+					ImGui::Text("✓ Merged visible point clouds");
+				}
+				if (exportScope == 0 && !scene.GetScene().pointcloud.pointViews.empty()) {
 					ImGui::Text("✓ Point views available");
 					ImGui::SameLine();
 					ImGui::Checkbox("Export", &bExportViews);
+				} else if (exportScope != 0) {
+					bExportViews = false;
+					ImGui::TextDisabled("Point-view export is disabled for merged layers");
 				}
-				if (!mvs_scene.pointcloud.pointWeights.empty())
+				if (exportScope == 0 && !scene.GetScene().pointcloud.pointWeights.empty())
 					ImGui::Text("✓ Point weights available");
-				if (!mvs_scene.pointcloud.colors.empty())
+				if (exportScope == 0 && !scene.GetScene().pointcloud.colors.empty())
 					ImGui::Text("✓ Point colors available");
-				if (!mvs_scene.pointcloud.normals.empty())
+				if (exportScope == 0 && !scene.GetScene().pointcloud.normals.empty())
 					ImGui::Text("✓ Point normals available");
 			} else {
 				ImGui::TextColored(ImVec4(1.f, 0.6f, 0.6f, 1.f), "⚠ No point cloud data to export");
@@ -1520,10 +1843,16 @@ void UI::ShowExportDialog(Scene& scene) {
 		case 3: // OBJ Mesh
 		case 4: // GLTF Mesh
 			if (hasMesh) {
-				ImGui::Text("✓ Mesh: %u vertices, %u faces", mvs_scene.mesh.vertices.size(), mvs_scene.mesh.faces.size());
-				if (!mvs_scene.mesh.faceTexcoords.empty() && !mvs_scene.mesh.texturesDiffuse.empty())
+				if (exportScope == 0) {
+					const MVS::Scene& mvs_scene = scene.GetScene();
+					ImGui::Text("✓ Mesh: %u vertices, %u faces", mvs_scene.mesh.vertices.size(), mvs_scene.mesh.faces.size());
+				} else {
+					ImGui::Text("✓ Merged visible meshes");
+					ImGui::TextDisabled("Textures are omitted from merged export");
+				}
+				if (exportScope == 0 && !scene.GetScene().mesh.faceTexcoords.empty() && !scene.GetScene().mesh.texturesDiffuse.empty())
 					ImGui::Text("✓ Texture coordinates and textures available");
-				if (!mvs_scene.mesh.vertexNormals.empty())
+				if (exportScope == 0 && !scene.GetScene().mesh.vertexNormals.empty())
 					ImGui::Text("✓ Vertex normals available");
 			} else {
 				ImGui::TextColored(ImVec4(1.f, 0.6f, 0.6f, 1.f), "⚠ No mesh data to export");
@@ -1533,15 +1862,19 @@ void UI::ShowExportDialog(Scene& scene) {
 
 		ImGui::Separator();
 
-		bool canExport = ((exportFormat == 0 || exportFormat == 1) && hasPointCloud) ||
-			((exportFormat == 2 || exportFormat == 3 || exportFormat == 4) && hasMesh);
+		const bool backgroundWork(scene.HasBackgroundWork());
+		bool canExport = !backgroundWork && (((exportFormat == 0 || exportFormat == 1) && hasPointCloud) || ((exportFormat == 2 || exportFormat == 3 || exportFormat == 4) && hasMesh));
 		if (ImGui::Button("Export...", ImVec2(120, 0)) && canExport) {
 			String filename;
 			if (ShowSaveFileDialog(filename)) {
 				// Ensure the filename has the correct extension
 				String baseFileName = Util::getFileFullName(filename);
 				String finalFileName = baseFileName + formatExt[exportFormat];
-				scene.Export(finalFileName, formatExt[exportFormat], bExportViews);
+				const Scene::ExportGeometry geometry = exportFormat < 2 ? Scene::EXPORT_POINT_CLOUD : Scene::EXPORT_MESH;
+				if (exportScope == 0)
+					scene.Export(finalFileName, formatExt[exportFormat], bExportViews, geometry);
+				else
+					scene.ExportVisibleLayers(finalFileName, formatExt[exportFormat], geometry);
 			}
 			showExportDialog = false;
 		}
@@ -1565,6 +1898,16 @@ void UI::ShowCameraInfoDialog(Window& window) {
 	ImGui::SetNextWindowSize(ImVec2(390, 612), ImGuiCond_FirstUseEver);
 	if (ImGui::Begin("Camera Information", &showCameraInfoDialog)) {
 		const Scene& scene = window.GetScene();
+		if (scene.HasBackgroundWork()) {
+			ImGui::TextDisabled("Camera information is unavailable while background work is running");
+			ImGui::End();
+			return;
+		}
+		if (!scene.IsOpen()) {
+			ImGui::TextDisabled("No active layer");
+			ImGui::End();
+			return;
+		}
 		const ImageArr& images = scene.GetImages();
 		const MVS::Scene& mvs_scene = scene.GetScene();
 
@@ -1805,6 +2148,24 @@ void UI::ShowSelectionDialog(Window& window) {
 	// Set dialog properties
 	ImGui::OpenPopup("Selection Dialog");
 	if (ImGui::BeginPopupModal("Selection Dialog", &showSelectionDialog, ImGuiWindowFlags_AlwaysAutoResize)) {
+		if (window.GetScene().HasBackgroundWork()) {
+			ImGui::TextDisabled("Selection is unavailable while background work is running");
+			if (ImGui::Button("Close", ImVec2(120, 0))) {
+				showSelectionDialog = false;
+				ImGui::CloseCurrentPopup();
+			}
+			ImGui::EndPopup();
+			return;
+		}
+		if (!window.GetScene().IsOpen()) {
+			ImGui::TextDisabled("No active layer");
+			if (ImGui::Button("Close", ImVec2(120, 0))) {
+				showSelectionDialog = false;
+				ImGui::CloseCurrentPopup();
+			}
+			ImGui::EndPopup();
+			return;
+		}
 		ImGui::Text("Select an element by index or name:");
 		ImGui::Separator();
 
@@ -1821,6 +2182,7 @@ void UI::ShowSelectionDialog(Window& window) {
 		// Input fields based on selection type
 		const Scene& scene = window.GetScene();
 		const MVS::Scene& mvs_scene = scene.GetScene();
+		const ImageArr& viewerImages = scene.GetImages();
 		IDXArr selectionIndices;
 		String selectionError;
 
@@ -1848,14 +2210,13 @@ void UI::ShowSelectionDialog(Window& window) {
 				selectionError = Util::parseIndexRanges(selectionInputBuffer, mvs_scene.mesh.faces.size(), selectionIndices, "face");
 				} break;
 			case 2: { // Camera by Index
-				selectionError = Util::parseIndexRanges(selectionInputBuffer, mvs_scene.images.size(), selectionIndices, "camera");
+				selectionError = Util::parseIndexRanges(selectionInputBuffer, viewerImages.size(), selectionIndices, "camera");
 				} break;
 			case 3: { // Camera by Name
 				int cameraIndex = -1;
-				const ImageArr& images = scene.GetImages();
-				FOREACH(i, images) {
-					if (images[i].idx < mvs_scene.images.size()) {
-						const MVS::Image& imageData = mvs_scene.images[images[i].idx];
+				FOREACH(i, viewerImages) {
+					if (viewerImages[i].idx < mvs_scene.images.size()) {
+						const MVS::Image& imageData = mvs_scene.images[viewerImages[i].idx];
 						String fileName = Util::getFileNameExt(imageData.name);
 						if (fileName.find(selectionInputBuffer) != String::npos) {
 							cameraIndex = i;
@@ -1877,7 +2238,9 @@ void UI::ShowSelectionDialog(Window& window) {
 		ImGui::Separator();
 
 		// Buttons
-		if (ImGui::Button("Select", ImVec2(120, 0)) && selectionError.empty()) {
+		const bool canSelect = selectionError.empty() && !selectionIndices.empty();
+		ImGui::BeginDisabled(!canSelect);
+		if (ImGui::Button("Select", ImVec2(120, 0))) {
 			// Perform the selection based on the type
 			const IDX primarySelectionIdx = selectionIndices.front();
 			switch (selectionType) {
@@ -1900,7 +2263,7 @@ void UI::ShowSelectionDialog(Window& window) {
 			case 3: { // Camera by Name
 				window.selectionType = Window::SEL_CAMERA;
 				window.SetSelectionIds(selectionIndices);
-				const MVS::Image& imageData = mvs_scene.images[scene.GetImages()[primarySelectionIdx].idx];
+				const MVS::Image& imageData = mvs_scene.images[viewerImages[primarySelectionIdx].idx];
 				window.selectionPoints[0] = imageData.camera.C;
 			} break;
 			}
@@ -1914,6 +2277,7 @@ void UI::ShowSelectionDialog(Window& window) {
 			showSelectionDialog = false;
 			ImGui::CloseCurrentPopup();
 		}
+		ImGui::EndDisabled();
 
 		ImGui::SameLine();
 		if (ImGui::Button("Cancel", ImVec2(120, 0))) {
@@ -1935,20 +2299,21 @@ void UI::ShowSavePromptDialog(Window& window) {
 	ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
 
 	if (ImGui::BeginPopupModal("Save Changes?", &showSavePromptDialog, ImGuiWindowFlags_AlwaysAutoResize)) {
-		ImGui::Text("The geometry has been modified.");
+		ImGui::Text("One or more layers have been modified.");
 		ImGui::Text("Do you want to save the changes before exiting?");
 		ImGui::Separator();
 
 		if (ImGui::Button("Save", ImVec2(120, 0))) {
-			// Save the scene
-			if (scene.Save()) {
-				DEBUG("Scene saved successfully");
-				scene.SetGeometryModified(false);
+			if (scene.SaveModifiedLayers()) {
+				DEBUG("Modified layers saved successfully");
+				showSavePromptDialog = false;
+				ImGui::CloseCurrentPopup();
+				window.ConfirmClose();
+			} else if (!scene.IsGeometryModified()) {
+				showSavePromptDialog = false;
+				ImGui::CloseCurrentPopup();
+				window.ConfirmClose();
 			}
-			// Close the dialog and exit
-			showSavePromptDialog = false;
-			ImGui::CloseCurrentPopup();
-			glfwSetWindowShouldClose(window.GetGLFWWindow(), GLFW_TRUE);
 		}
 
 		ImGui::SameLine();
@@ -1956,7 +2321,7 @@ void UI::ShowSavePromptDialog(Window& window) {
 			// Exit without saving
 			showSavePromptDialog = false;
 			ImGui::CloseCurrentPopup();
-			glfwSetWindowShouldClose(window.GetGLFWWindow(), GLFW_TRUE);
+			window.ConfirmClose();
 		}
 
 		ImGui::SameLine();
@@ -2073,16 +2438,21 @@ void UI::ShowPointCloudControls(Window& window) {
 		ImGui::Indent();
 		if (ImGui::SliderFloat("Point Size", &window.pointSize, 1.f, 10.f))
 			window.RequestRedraw();
-		// Check if normals are available
-		const MVS::Scene& scene = window.GetScene().GetScene();
-		if (!scene.pointcloud.normals.empty()) {
+		// Check if normals are available in any visible layer
+		bool hasNormals = false;
+		for (const Scene::Layer& layer : window.GetScene().GetLayers()) {
+			if (layer.visible && !layer.scene.pointcloud.normals.empty() && layer.scene.pointcloud.normals.size() == layer.scene.pointcloud.points.size()) {
+				hasNormals = true;
+				break;
+			}
+		}
+		if (hasNormals) {
 			if (ImGui::Checkbox("Show Normals", &window.showPointCloudNormals))
 				window.RequestRedraw();
 			if (window.showPointCloudNormals) {
 				ImGui::Indent();
 				if (ImGui::SliderFloat("Normal Length", &window.pointNormalLength, 0.001f, 0.1f, "%.3f")) {
-					// Re-upload point cloud with new normal length
-					window.GetRenderer().UploadPointCloud(scene.pointcloud, window.pointNormalLength);
+					window.GetRenderer().UploadPointClouds(window.GetScene(), window.pointNormalLength);
 					window.RequestRedraw();
 				}
 				ImGui::Unindent();
@@ -2129,10 +2499,12 @@ void UI::ShowMeshControls(Window& window) {
 			}
 
 			// Individual sub-mesh checkboxes
+			std::unordered_map<uint32_t, unsigned> layerSubmeshCounts;
 			FOREACH(i, window.meshSubMeshVisible) {
-				// Create a meaningful label for each sub-mesh
-				String label = String::FormatString("Sub-mesh %zu", i);
-				// Add texture info if available
+				const uint32_t layerID(window.GetRenderer().GetMeshSubMeshLayerID(i));
+				const Scene::Layer* layer(window.GetScene().GetLayerByID(layerID));
+				const unsigned layerSubmeshIdx(layerSubmeshCounts[layerID]++);
+				const String label(layer == NULL ? String::FormatString("Sub-mesh %u", layerSubmeshIdx + 1) : String::FormatString("%s / mesh %u", layer->label.c_str(), layerSubmeshIdx + 1));
 				bool isVisible = window.meshSubMeshVisible[i];
 				if (ImGui::Checkbox(label, &isVisible)) {
 					window.meshSubMeshVisible[i] = isVisible;
@@ -2146,6 +2518,7 @@ void UI::ShowMeshControls(Window& window) {
 
 void UI::ShowSelectionOverlay(const Window& window) {
 	if (!showSelectionOverlay) return;
+	if (window.GetScene().HasBackgroundWork()) return;
 
 	// Only show if there's a valid selection
 	if (window.selectionType == Window::SEL_NA) return;
@@ -2247,8 +2620,9 @@ void UI::ShowSelectionOverlay(const Window& window) {
 						R2D(eulerAngles.x), R2D(eulerAngles.y), R2D(eulerAngles.z));
 					ImGui::Text("  avg depth: %.2g", imageData.avgDepth);
 					ImGui::Text("  neighbors: %u", (unsigned)imageData.neighbors.size());
-					if (selectionIdx < scene.cameraUncertainty.size()) {
-						const Scene::CameraUncertainty& u = scene.cameraUncertainty[selectionIdx];
+					const Scene::Layer* activeLayer = scene.GetActiveLayer();
+					if (activeLayer != NULL && selectionIdx < activeLayer->cameraUncertainty.size()) {
+						const Scene::CameraUncertainty& u = activeLayer->cameraUncertainty[selectionIdx];
 						if (u.state == Scene::CameraUncertainty::DATUM) {
 							ImGui::Text("  pose sigma: reference (datum)");
 						} else if (u.IsComputed()) {
@@ -2447,8 +2821,9 @@ void UI::ShowEstimateROIWorkflowWindow(Window& window) {
 		return;
 
 	Scene& scene = window.GetScene();
-	const MVS::Scene& mvsScene = scene.GetScene();
-	const bool hasPoints = mvsScene.IsValid() && mvsScene.pointcloud.IsValid();
+	const bool workflowRunning = scene.IsWorkflowRunning();
+	const MVS::Scene* mvsScene = workflowRunning ? nullptr : &scene.GetScene();
+	const bool hasPoints = mvsScene != nullptr && mvsScene->IsValid() && mvsScene->pointcloud.IsValid();
 
 	ImGui::SetNextWindowSize(ImVec2(360.f, 140.f), ImGuiCond_FirstUseEver);
 	if (!ImGui::Begin("Estimate ROI##workflow", &showEstimateROIWorkflow)) {
@@ -2472,7 +2847,7 @@ void UI::ShowEstimateROIWorkflowWindow(Window& window) {
 
 	ImGui::Separator();
 	const bool canRun = scene.IsOpen() && hasPoints;
-	ImGui::BeginDisabled(!canRun || scene.IsWorkflowRunning());
+	ImGui::BeginDisabled(!canRun || workflowRunning);
 	if (ImGui::Button("Run")) {
 		showEstimateROIWorkflow = false;
 		scene.RunEstimateROIWorkflow(opts);
@@ -2493,8 +2868,9 @@ void UI::ShowDensifyWorkflowWindow(Window& window) {
 
 	Scene& scene = window.GetScene();
 	Scene::DensifyWorkflowOptions& opts = scene.GetDensifyWorkflowOptions();
-	const MVS::Scene& mvsScene = scene.GetScene();
-	const bool hasImages = mvsScene.IsValid();
+	const bool workflowRunning = scene.IsWorkflowRunning();
+	const MVS::Scene* mvsScene = workflowRunning ? nullptr : &scene.GetScene();
+	const bool hasImages = mvsScene != nullptr && mvsScene->IsValid();
 	ImGui::SetNextWindowSize(ImVec2(420.f, 0.f), ImGuiCond_FirstUseEver);
 	if (!ImGui::Begin("Densify Point Cloud##workflow", &showDensifyWorkflow)) {
 		ImGui::End();
@@ -2644,8 +3020,9 @@ void UI::ShowReconstructWorkflowWindow(Window& window) {
 
 	Scene& scene = window.GetScene();
 	Scene::ReconstructMeshWorkflowOptions& opts = scene.GetReconstructMeshWorkflowOptions();
-	const MVS::Scene& mvsScene = scene.GetScene();
-	const bool hasPoints = mvsScene.IsValid() && mvsScene.pointcloud.IsValid();
+	const bool workflowRunning = scene.IsWorkflowRunning();
+	const MVS::Scene* mvsScene = workflowRunning ? nullptr : &scene.GetScene();
+	const bool hasPoints = mvsScene != nullptr && mvsScene->IsValid() && mvsScene->pointcloud.IsValid();
 	ImGui::SetNextWindowSize(ImVec2(420.f, 0.f), ImGuiCond_FirstUseEver);
 	if (!ImGui::Begin("Reconstruct Mesh##workflow", &showReconstructWorkflow)) {
 		ImGui::End();
@@ -2808,9 +3185,10 @@ void UI::ShowRefineWorkflowWindow(Window& window) {
 		ImGui::SetTooltip("Memory reduction strategy:\n- 0 = no reduction (fastest, most memory)\n- 3 = maximum reduction (slowest, least memory)\nUse higher values for large scenes or limited RAM.");
 
 	ImGui::Separator();
-	const MVS::Scene& mvsScene = scene.GetScene();
-	const bool canRun = scene.IsOpen() && mvsScene.IsValid() && !mvsScene.mesh.IsEmpty();
-	ImGui::BeginDisabled(!canRun || scene.IsWorkflowRunning());
+	const bool workflowRunning = scene.IsWorkflowRunning();
+	const MVS::Scene* mvsScene = workflowRunning ? nullptr : &scene.GetScene();
+	const bool canRun = mvsScene != nullptr && mvsScene->IsValid() && !mvsScene->mesh.IsEmpty();
+	ImGui::BeginDisabled(!canRun || workflowRunning);
 	if (ImGui::Button("Run")) {
 		showRefineWorkflow = false;
 		scene.RunRefineMeshWorkflow(opts);
@@ -2831,8 +3209,9 @@ void UI::ShowTextureWorkflowWindow(Window& window) {
 
 	Scene& scene = window.GetScene();
 	Scene::TextureMeshWorkflowOptions& opts = scene.GetTextureMeshWorkflowOptions();
-	const MVS::Scene& mvsScene = scene.GetScene();
-	const bool hasMesh = mvsScene.IsValid() && !mvsScene.mesh.IsEmpty();
+	const bool workflowRunning = scene.IsWorkflowRunning();
+	const MVS::Scene* mvsScene = workflowRunning ? nullptr : &scene.GetScene();
+	const bool hasMesh = mvsScene != nullptr && mvsScene->IsValid() && !mvsScene->mesh.IsEmpty();
 	ImGui::SetNextWindowSize(ImVec2(420.f, 0.f), ImGuiCond_FirstUseEver);
 	if (!ImGui::Begin("Texture Mesh##workflow", &showTextureWorkflow)) {
 		ImGui::End();
@@ -2933,15 +3312,11 @@ void UI::ShowBatchWorkflowWindow(Window& window) {
 		return;
 
 	Scene& scene = window.GetScene();
-	Scene::EstimateROIWorkflowOptions& estimateOpts = scene.GetEstimateROIWorkflowOptions();
-	Scene::DensifyWorkflowOptions& densifyOpts = scene.GetDensifyWorkflowOptions();
-	Scene::ReconstructMeshWorkflowOptions& reconstructOpts = scene.GetReconstructMeshWorkflowOptions();
-	Scene::RefineMeshWorkflowOptions& refineOpts = scene.GetRefineMeshWorkflowOptions();
-	Scene::TextureMeshWorkflowOptions& textureOpts = scene.GetTextureMeshWorkflowOptions();
-	const MVS::Scene& mvsScene = scene.GetScene();
-	const bool hasImages = mvsScene.IsValid();
-	const bool hasPoints = hasImages && mvsScene.pointcloud.IsValid();
-	const bool hasMesh = hasImages && !mvsScene.mesh.IsEmpty();
+	const bool workflowRunning = scene.IsWorkflowRunning();
+	const MVS::Scene* mvsScene = workflowRunning ? nullptr : &scene.GetScene();
+	const bool hasImages = mvsScene != nullptr && mvsScene->IsValid();
+	const bool hasPoints = hasImages && mvsScene->pointcloud.IsValid();
+	const bool hasMesh = hasImages && !mvsScene->mesh.IsEmpty();
 	ImGui::SetNextWindowSize(ImVec2(400.f, 184.f), ImGuiCond_FirstUseEver);
 	if (!ImGui::Begin("Batch Process##workflow", &showBatchWorkflow)) {
 		ImGui::End();
@@ -2990,46 +3365,17 @@ void UI::ShowBatchWorkflowWindow(Window& window) {
 
 	ImGui::Separator();
 	// Build runnable list
-	std::vector<int> runnable;
+	std::vector<Scene::WorkflowType> runnable;
 	for (int idx = 0; idx < 5; ++idx)
 		if (selectedModules[idx])
-			runnable.push_back(idx);
+			runnable.push_back(static_cast<Scene::WorkflowType>(idx + 1));
 	const bool canRun = !runnable.empty();
 	if (!canRun)
 		ImGui::TextDisabled("No runnable modules selected or prerequisites missing.");
 
 	if (ImGui::Button("Run") && canRun) {
-		// Close window before running long tasks
-		showBatchWorkflow = false;
-		ImGui::End();
-		// Execute selected modules in order
-		FOREACH(i, runnable) {
-			const int mod = runnable[i];
-			switch (mod) {
-			case 0:
-				DEBUG("Batch: Running Estimate ROI...");
-				scene.RunEstimateROIWorkflow(estimateOpts);
-				break;
-			case 1:
-				DEBUG("Batch: Running Densify Point Cloud...");
-				scene.RunDensifyWorkflow(densifyOpts);
-				break;
-			case 2:
-				DEBUG("Batch: Running Reconstruct Mesh...");
-				scene.RunReconstructMeshWorkflow(reconstructOpts);
-				break;
-			case 3:
-				DEBUG("Batch: Running Refine Mesh...");
-				scene.RunRefineMeshWorkflow(refineOpts);
-				break;
-			case 4:
-				DEBUG("Batch: Running Texture Mesh...");
-				scene.RunTextureMeshWorkflow(textureOpts);
-				break;
-			}
-		}
-		window.RequestRedraw();
-		return; // already ended ImGui for this invocation
+		if (scene.RunBatchWorkflow(runnable))
+			showBatchWorkflow = false;
 	}
 	ImGui::SameLine();
 	if (ImGui::Button("Close"))
@@ -3063,8 +3409,7 @@ void SettingsReadLine(ImGuiContext*, ImGuiSettingsHandler* handler, void* entry,
 		window.uncertaintyEllipsoidScale = x;
 	}
 	else if (sscanf(line, "CameraDisplayColor=%d", &intVal) == 1) {
-		window.cameraDisplayColor =
-			intVal == (int)Window::CAMERA_COLOR_JET ? Window::CAMERA_COLOR_JET : Window::CAMERA_COLOR_SOLID;
+		(void)intVal; // deprecated: camera jet/solid mode is stored per layer
 	}
 	else if (sscanf(line, "CameraDisplayType=%d", &intVal) == 1) {
 		window.cameraDisplayType =
@@ -3130,7 +3475,6 @@ void SettingsWriteAll(ImGuiContext*, ImGuiSettingsHandler* handler, ImGuiTextBuf
 		window.clearColor[2], window.clearColor[3]);
 	buf->appendf("CameraSize=%f\n", window.cameraSize);
 	buf->appendf("EllipsoidScale=%f\n", window.uncertaintyEllipsoidScale);
-	buf->appendf("CameraDisplayColor=%d\n", (int)window.cameraDisplayColor);
 	buf->appendf("CameraDisplayType=%d\n", (int)window.cameraDisplayType);
 	buf->appendf("ShowCameraLookAt=%d\n", window.showCameraLookAt ? 1 : 0);
 	buf->appendf("PointSize=%f\n", window.pointSize);
@@ -3157,38 +3501,62 @@ void SettingsWriteAll(ImGuiContext*, ImGuiSettingsHandler* handler, ImGuiTextBuf
 }
 
 // Custom settings implementation
-bool UI::ShowOpenFileDialog(String& filename, String& geometryFilename) {
+bool UI::ShowOpenFileDialog(std::vector<String>& filenames)
+{
 	// Use portable-file-dialogs for cross-platform file dialog
 	try {
 		auto dialog = pfd::open_file(
-			"Open Scene File",                   // title
-			WORKING_FOLDER_FULL,          // initial path (absolute)
-			{
-				"OpenMVS Scene Files", "*.mvs",
-				"OpenMVS Depth Map Files", "*.dmap",
-				"PLY Mesh / Point Cloud Files", "*.ply",
-				"GLTF Mesh / Point Cloud Files", "*.gltf",
-				"GLB Mesh / Point Cloud Files", "*.glb",
-				"OBJ Mesh Files", "*.obj",
-				"All Files", "*"
-			},                                         // filters
-			pfd::opt::multiselect             // options
+		    "Open Scene File", // title
+		    WORKING_FOLDER_FULL, // initial path (absolute)
+		    {
+		        "OpenMVS Scene Files", "*.mvs",
+		        "OpenMVS Interface Files", "*.sfm",
+		        "OpenMVS Depth Map Files", "*.dmap",
+		        "PLY Mesh / Point Cloud Files", "*.ply",
+		        "GLTF Mesh / Point Cloud Files", "*.gltf",
+		        "GLB Mesh / Point Cloud Files", "*.glb",
+		        "OBJ Mesh Files", "*.obj",
+		        "All Files", "*"}, // filters
+		    pfd::opt::multiselect // options
 		);
 
 		// Get the result
 		auto result = dialog.result();
 		if (!result.empty()) {
-			Util::ensureValidPath(filename = result[0]);
-			if (result.size() > 1)
-				Util::ensureValidPath(geometryFilename = result[1]);
-			else
-				geometryFilename.clear();
+			filenames.clear();
+			filenames.reserve(result.size());
+			for (const std::string& path : result) {
+				String filename(path.c_str());
+				Util::ensureValidPath(filename);
+				filenames.emplace_back(std::move(filename));
+			}
 			return true;
 		}
 	} catch (const std::exception& e) {
 		DEBUG("File dialog error: %s", e.what());
 	}
 	return false;
+}
+
+bool UI::ConfirmDiscardChanges(const Scene& scene, const char* action)
+{
+	if (!scene.IsGeometryModified())
+		return true;
+	const String message(String::FormatString(
+		"One or more layers have unsaved changes.\n\nDiscard them and %s?",
+		action));
+	return pfd::message("Unsaved Changes", message.c_str(), pfd::choice::yes_no, pfd::icon::warning).result() == pfd::button::yes;
+}
+
+bool UI::ConfirmDiscardLayer(const Scene& scene, size_t layerIndex)
+{
+	const Scene::Layer* layer(scene.GetLayer(layerIndex));
+	if (layer == nullptr || !layer->dirty)
+		return true;
+	const String message(String::FormatString(
+		"Layer '%s' has unsaved changes.\n\nDiscard them and remove the layer?",
+		layer->label.c_str()));
+	return pfd::message("Unsaved Layer", message.c_str(), pfd::choice::yes_no, pfd::icon::warning).result() == pfd::button::yes;
 }
 
 bool UI::ShowSaveFileDialog(String& filename) {

--- a/apps/Viewer/UI.cpp
+++ b/apps/Viewer/UI.cpp
@@ -1059,16 +1059,27 @@ void UI::ShowLayersPanel(Window& window)
 	ImGui::SameLine();
 	compareChanged |= ImGui::RadioButton("Off", &compareMode, Window::COMPARE_DISABLED);
 	ImGui::SameLine();
+	const bool canCompare(scene.GetLayerCount() > 1);
+	ImGui::BeginDisabled(!canCompare);
 	compareChanged |= ImGui::RadioButton("Swipe", &compareMode, Window::COMPARE_SWIPE);
-	if (ImGui::IsItemHovered())
-		ImGui::SetTooltip("Split the view at a draggable divider: side-A layers render left,\n"
-		                  "side-B layers right, both sharing the same full-window projection,\n"
-		                  "so aligned scenes match pixel-exact across the divider");
+	if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+		if (!canCompare)
+			ImGui::SetTooltip("Load at least two layers to enable comparison");
+		else
+			ImGui::SetTooltip("Split the view at a draggable divider: side-A layers render left,\n"
+			                  "side-B layers right, both sharing the same full-window projection,\n"
+			                  "so aligned scenes match pixel-exact across the divider");
+	}
 	ImGui::SameLine();
 	compareChanged |= ImGui::RadioButton("Split", &compareMode, Window::COMPARE_SPLIT);
-	if (ImGui::IsItemHovered())
-		ImGui::SetTooltip("Show two equal side-by-side viewports, each scene centered\n"
-		                  "in its own full frustum");
+	if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+		if (!canCompare)
+			ImGui::SetTooltip("Load at least two layers to enable comparison");
+		else
+			ImGui::SetTooltip("Show two equal side-by-side viewports, each scene centered\n"
+			                  "in its own full frustum");
+	}
+	ImGui::EndDisabled();
 	if (compareChanged)
 		scene.EnableCompareMode((Window::CompareMode)compareMode);
 	if (window.IsCompareEnabled()) {
@@ -1077,19 +1088,56 @@ void UI::ShowLayersPanel(Window& window)
 			window.SetCompareSyncCameras(syncCameras);
 		if (ImGui::IsItemHovered())
 			ImGui::SetTooltip("Move the cameras of both sides together; uncheck to adjust each\n"
-			                  "side's camera individually with the mouse over its viewport\n"
+			                  "side's camera individually in Arcball mode with the mouse over its viewport\n"
 			                  "(re-checking snaps the other side back onto the active view)");
+		unsigned visibleSides[2] = {0, 0};
+		for (const Scene::Layer& layer : scene.GetLayers())
+			if (layer.visible)
+				++visibleSides[layer.compareRight ? 1 : 0];
+		ImGui::SameLine();
+		ImGui::TextDisabled("A: %u  B: %u", visibleSides[0], visibleSides[1]);
+		if (visibleSides[0] == 0 || visibleSides[1] == 0)
+			ImGui::TextColored(ImVec4(1.f, 0.7f, 0.3f, 1.f), "Assign at least one visible layer to each side.");
 	}
 	if (scene.GetLayerCount() > 1) {
-		ImGui::SameLine();
-		if (ImGui::Button("Align to Active")) {
-			if (!scene.AlignLayersToActive())
-				DEBUG("No layer could be aligned to the active layer");
+		ImGui::Spacing();
+		const Scene::Layer* activeLayer(scene.GetActiveLayer());
+		bool canAttemptAlignment = activeLayer != NULL && activeLayer->images.size() >= 3;
+		if (canAttemptAlignment) {
+			canAttemptAlignment = false;
+			for (const Scene::Layer& layer : scene.GetLayers()) {
+				if (&layer != activeLayer && layer.images.size() >= 3) {
+					canAttemptAlignment = true;
+					break;
+				}
+			}
 		}
-		if (ImGui::IsItemHovered())
-			ImGui::SetTooltip("Move every other layer onto the active layer with a similarity transform\n"
-			                  "estimated from cameras shared between the scenes (matched by photo name,\n"
-			                  "then by preserved SFM image ID); requires at least 3 shared cameras");
+		ImGui::BeginDisabled(!canAttemptAlignment);
+		if (ImGui::Button("Align Layers to Active..."))
+			ImGui::OpenPopup("Confirm Layer Alignment");
+		ImGui::EndDisabled();
+		if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+			if (!canAttemptAlignment)
+				ImGui::SetTooltip("Alignment requires at least two scene layers with 3 or more cameras each");
+			else
+				ImGui::SetTooltip("Move every other layer onto the active layer with a similarity transform\n"
+				                  "estimated from cameras shared between the scenes (matched by photo name,\n"
+				                  "then by preserved SFM image ID); requires at least 3 shared cameras");
+		}
+		if (ImGui::BeginPopupModal("Confirm Layer Alignment", NULL, ImGuiWindowFlags_AlwaysAutoResize)) {
+			ImGui::TextWrapped("Align all other layers to '%s'?", activeLayer != NULL ? activeLayer->label.c_str() : "the active layer");
+			ImGui::TextWrapped("This changes their scene coordinates and cannot be undone in Viewer. Modified layers will be marked unsaved.");
+			ImGui::Separator();
+			if (ImGui::Button("Align", ImVec2(120, 0))) {
+				if (!scene.AlignLayersToActive())
+					DEBUG("No layer could be aligned to the active layer");
+				ImGui::CloseCurrentPopup();
+			}
+			ImGui::SameLine();
+			if (ImGui::Button("Cancel", ImVec2(120, 0)))
+				ImGui::CloseCurrentPopup();
+			ImGui::EndPopup();
+		}
 	}
 
 	ImGui::Separator();
@@ -1124,7 +1172,8 @@ void UI::ShowLayersPanel(Window& window)
 			if (ImGui::Selectable(displayLabel.c_str(), isActive))
 				scene.SetActiveLayer(i);
 			if (ImGui::IsItemHovered())
-					ImGui::SetTooltip("%u points\n%u mesh vertices, %u faces\n%u cameras",
+					ImGui::SetTooltip("%s\n%u points\n%u mesh vertices, %u faces\n%u cameras",
+					                  layer->sceneName.c_str(),
 					                  (unsigned)layer->scene.pointcloud.points.size(), (unsigned)layer->scene.mesh.vertices.size(),
 					                  (unsigned)layer->scene.mesh.faces.size(), (unsigned)layer->images.size());
 

--- a/apps/Viewer/UI.h
+++ b/apps/Viewer/UI.h
@@ -42,6 +42,7 @@ class Window;
 
 class UI {
 private:
+	bool initialized;
 	String iniPath;
 
 	bool showSceneInfo;
@@ -54,6 +55,7 @@ private:
 	bool showWorkflowOverlay;
 	bool showViewportOverlay;
 	bool showSelectionOverlay;
+	bool showLayersPanel;
 	bool showAboutDialog;
 	bool showHelpDialog;
 	bool showExportDialog;
@@ -104,6 +106,8 @@ public:
 	void ShowSelectionControls(Window& window);
 	void ShowRenderSettings(Window& window);
 	void ShowBoundingBoxControls(Window& window);
+	void ShowLayersPanel(Window& window);
+	void ShowCompareDivider(Window& window); // A|B split view divider (draggable) + side labels
 	void ShowConsoleOverlay(Window& window);
 	void ShowPerformanceOverlay(Window& window);
 	void ShowWorkflowOverlay(Window& window);
@@ -118,6 +122,8 @@ public:
 	void ToggleSelectionDialog() { showSelectionDialog = !showSelectionDialog; }
 	void ToggleRenderSettings() { showRenderSettings = !showRenderSettings; }
 	void ToggleBoundingBoxControls() { showBoundingBoxControls = !showBoundingBoxControls; }
+	void ToggleLayersPanel() { showLayersPanel = !showLayersPanel; }
+	void RequestSavePrompt() { showSavePromptDialog = true; }
 	void SetSelectionControls(bool v) { showSelectionControls = v; }
 	void SetUserFontScale(float scale);
 
@@ -128,11 +134,13 @@ public:
 	void ShowCameraInfoDialog(Window& window);
 	void ShowSelectionDialog(Window& window);
 	void ShowSavePromptDialog(Window& window);
-	void PromptOpenPoseQualityReport(Window& window); // prompt for and load a pose-quality CSV onto the open scene
-	static bool ShowOpenFileDialog(String& filename, String& geometryFilename);
+	void PromptOpenPoseQualityReport(Window& window); // prompt for and load a pose-quality CSV onto the active layer
+	static bool ShowOpenFileDialog(std::vector<String>& filenames);
 	static bool ShowSaveFileDialog(String& filename);
 	static bool ShowSaveImageDialog(String& filename);
 	static bool ShowOpenPoseQualityDialog(String& filename);
+	static bool ConfirmDiscardChanges(const Scene& scene, const char* action);
+	static bool ConfirmDiscardLayer(const Scene& scene, size_t layerIndex);
 
 	// Input handling
 	void RecordLog(const String& msg);

--- a/apps/Viewer/Viewer.cpp
+++ b/apps/Viewer/Viewer.cpp
@@ -53,6 +53,8 @@ String strPoseQualityFileName;
 String strOutputFileName;
 String strScreenshotFileName;
 String strViewFileName;
+String strCompareMode;
+bool bAlignLayers;
 int nViewCamera;
 String strShow;
 unsigned nArchiveType;
@@ -117,6 +119,8 @@ bool Application::Initialize(size_t argc, LPCTSTR* argv)
 		("pose-quality-file", boost::program_options::value<std::string>(&OPT::strPoseQualityFileName), "per-image pose quality CSV report (CreateStructure --export-pose-quality) to display as camera uncertainty ellipsoids")
 		("output-file,o", boost::program_options::value<std::string>(&OPT::strOutputFileName), "output filename for storing the mesh")
 		("screenshot-file,S", boost::program_options::value<std::string>(&OPT::strScreenshotFileName), "render the scene off-screen to this image file and exit (scriptable; extension selects the format, .png if omitted)")
+		("compare-mode", boost::program_options::value<std::string>(&OPT::strCompareMode), "enable multi-layer comparison in swipe or split mode (requires at least two layers)")
+		("align-layers", boost::program_options::bool_switch(&OPT::bAlignLayers)->default_value(false), "align additional layers to the active layer using shared cameras")
 		("view-file", boost::program_options::value<std::string>(&OPT::strViewFileName), "transform file controlling the screenshot viewpoint (12 or 16 whitespace-separated values, row-major camera-to-world); if omitted the default fitted view is used")
 		("view-camera", boost::program_options::value(&OPT::nViewCamera)->default_value(-1), "set the screenshot viewpoint to this scene camera's pose for a natural upright framing (-1 disabled; out-of-range selects a central camera); overridden by --view-file")
 		("screenshot-show", boost::program_options::value<std::string>(&OPT::strShow), "which scene components to render in the screenshot, as a string of flags: p=point-cloud, m=mesh, t=textured, c=cameras, w=wireframe, b=bounding-box, u=UI overlay (e.g. 'p', 'm', 'mt', 'mu'); if omitted the interactive defaults are kept and the UI overlay is disabled")
@@ -188,6 +192,11 @@ bool Application::Initialize(size_t argc, LPCTSTR* argv)
 	resolveOptionPath(OPT::strOutputFileName);
 	resolveOptionPath(OPT::strScreenshotFileName);
 	resolveOptionPath(OPT::strViewFileName);
+	OPT::strCompareMode = OPT::strCompareMode.ToLower();
+	if (!OPT::strCompareMode.empty() && OPT::strCompareMode != _T("swipe") && OPT::strCompareMode != _T("split")) {
+		LOG("invalid compare mode '%s' (expected 'swipe' or 'split')", OPT::strCompareMode.c_str());
+		return false;
+	}
 
 	MVS::Initialize(APPNAME, OPT::nMaxThreads, OPT::nProcessPriority);
 	return true;
@@ -231,6 +240,19 @@ int main(int argc, LPCTSTR* argv)
 			if (!viewer.AddLayer(MAKE_PATH_SAFE(fileName), String(), !viewer.IsOpen()))
 				return EXIT_FAILURE;
 		}
+	}
+	if (OPT::bAlignLayers) {
+		if (viewer.GetLayerCount() < 2 || !viewer.AlignLayersToActive()) {
+			DEBUG("error: --align-layers requires at least two layers with three or more shared non-collinear cameras");
+			return EXIT_FAILURE;
+		}
+	}
+	if (!OPT::strCompareMode.empty()) {
+		if (viewer.GetLayerCount() < 2) {
+			DEBUG("error: --compare-mode requires at least two loaded layers");
+			return EXIT_FAILURE;
+		}
+		viewer.EnableCompareMode(OPT::strCompareMode == _T("swipe") ? Window::COMPARE_SWIPE : Window::COMPARE_SPLIT);
 	}
 	if (viewer.IsOpen() && !OPT::strPoseQualityFileName.empty()) {
 		// load and display the per-image pose uncertainty

--- a/apps/Viewer/Viewer.cpp
+++ b/apps/Viewer/Viewer.cpp
@@ -47,6 +47,7 @@ namespace {
 
 namespace OPT {
 String strInputFileName;
+std::vector<std::string> strLayerFileNames;
 String strGeometryFileName;
 String strPoseQualityFileName;
 String strOutputFileName;
@@ -111,13 +112,14 @@ bool Application::Initialize(size_t argc, LPCTSTR* argv)
 	boost::program_options::options_description config("Viewer options");
 	config.add_options()
 		("input-file,i", boost::program_options::value<std::string>(&OPT::strInputFileName), "input project filename containing camera poses and scene (point-cloud/mesh)")
+		("layer-file,l", boost::program_options::value<std::vector<std::string>>(&OPT::strLayerFileNames)->composing(), "additional scene or geometry file to load as a layer (repeat for multiple layers)")
 		("geometry-file,g", boost::program_options::value<std::string>(&OPT::strGeometryFileName), "mesh or point-cloud with views file name (overwrite existing geometry)")
 		("pose-quality-file", boost::program_options::value<std::string>(&OPT::strPoseQualityFileName), "per-image pose quality CSV report (CreateStructure --export-pose-quality) to display as camera uncertainty ellipsoids")
 		("output-file,o", boost::program_options::value<std::string>(&OPT::strOutputFileName), "output filename for storing the mesh")
 		("screenshot-file,S", boost::program_options::value<std::string>(&OPT::strScreenshotFileName), "render the scene off-screen to this image file and exit (scriptable; extension selects the format, .png if omitted)")
 		("view-file", boost::program_options::value<std::string>(&OPT::strViewFileName), "transform file controlling the screenshot viewpoint (12 or 16 whitespace-separated values, row-major camera-to-world); if omitted the default fitted view is used")
 		("view-camera", boost::program_options::value(&OPT::nViewCamera)->default_value(-1), "set the screenshot viewpoint to this scene camera's pose for a natural upright framing (-1 disabled; out-of-range selects a central camera); overridden by --view-file")
-		("screenshot-show", boost::program_options::value<std::string>(&OPT::strShow), "which layers to render in the screenshot, as a string of flags: p=point-cloud, m=mesh, t=textured, c=cameras, w=wireframe, b=bounding-box, u=UI overlay (e.g. 'p', 'm', 'mt', 'mu'); if omitted the interactive defaults are kept for the layers and the UI overlay is disabled")
+		("screenshot-show", boost::program_options::value<std::string>(&OPT::strShow), "which scene components to render in the screenshot, as a string of flags: p=point-cloud, m=mesh, t=textured, c=cameras, w=wireframe, b=bounding-box, u=UI overlay (e.g. 'p', 'm', 'mt', 'mu'); if omitted the interactive defaults are kept and the UI overlay is disabled")
 		;
 
 	boost::program_options::options_description cmdline_options;
@@ -156,24 +158,36 @@ bool Application::Initialize(size_t argc, LPCTSTR* argv)
 	Util::LogBuild();
 	LOG(_T("Command line: ") APPNAME _T("%s"), Util::CommandLineToString(argc, argv).c_str());
 
-	// validate input
-	Util::ensureValidPath(OPT::strInputFileName);
+	// Resolve every command-line/config path once, before opening a layer can
+	// switch WORKING_FOLDER to that scene's directory.
+	const auto resolveOptionPath = [](String& path) {
+		Util::ensureValidPath(path);
+		if (!path.empty())
+			path = Util::getFullPath(MAKE_PATH_SAFE(path));
+	};
+	resolveOptionPath(OPT::strInputFileName);
+	for (std::string& layerFileName : OPT::strLayerFileNames) {
+		String path(layerFileName.c_str());
+		resolveOptionPath(path);
+		layerFileName.assign(path.c_str());
+	}
 	if (OPT::vm.count("help")) {
 		boost::program_options::options_description visible("Available options");
 		visible.add(generic).add(config);
 		GET_LOG() << _T("\n"
-			"Visualize any know point-cloud/mesh formats or MVS projects. Supply files through command line or Drag&Drop.\n")
+			"Visualize any known point-cloud/mesh formats or MVS projects. Supply files through command line or Drag&Drop.\n"
+			"Multiple scenes can be loaded as layers (-l), aligned, and compared side by side with synchronized cameras.\n")
 			<< visible;
 	}
 	if (!OPT::strExportType.empty())
 		OPT::strExportType = OPT::strExportType.ToLower() == _T("obj") ? _T(".obj") : _T(".ply");
 
 	// initialize optional options
-	Util::ensureValidPath(OPT::strGeometryFileName);
-	Util::ensureValidPath(OPT::strPoseQualityFileName);
-	Util::ensureValidPath(OPT::strOutputFileName);
-	Util::ensureValidPath(OPT::strScreenshotFileName);
-	Util::ensureValidPath(OPT::strViewFileName);
+	resolveOptionPath(OPT::strGeometryFileName);
+	resolveOptionPath(OPT::strPoseQualityFileName);
+	resolveOptionPath(OPT::strOutputFileName);
+	resolveOptionPath(OPT::strScreenshotFileName);
+	resolveOptionPath(OPT::strViewFileName);
 
 	MVS::Initialize(APPNAME, OPT::nMaxThreads, OPT::nProcessPriority);
 	return true;
@@ -209,13 +223,24 @@ int main(int argc, LPCTSTR* argv)
 			OPT::strInputFileName.empty() ? OPT::strInputFileName : MAKE_PATH_SAFE(OPT::strInputFileName),
 			OPT::strGeometryFileName.empty() ? OPT::strGeometryFileName : MAKE_PATH_SAFE(OPT::strGeometryFileName)))
 		return EXIT_FAILURE;
+	if (!OPT::strLayerFileNames.empty()) {
+		// Each repeated option is an independent layer. OpenFiles() deliberately
+		// pairs a scene+geometry selection from the GUI, which is not the CLI
+		// contract advertised by --layer-file.
+		for (const std::string& fileName : OPT::strLayerFileNames) {
+			if (!viewer.AddLayer(MAKE_PATH_SAFE(fileName), String(), !viewer.IsOpen()))
+				return EXIT_FAILURE;
+		}
+	}
 	if (viewer.IsOpen() && !OPT::strPoseQualityFileName.empty()) {
 		// load and display the per-image pose uncertainty
-		viewer.LoadPoseUncertainty(MAKE_PATH_SAFE(OPT::strPoseQualityFileName));
+		if (!viewer.LoadPoseUncertainty(MAKE_PATH_SAFE(OPT::strPoseQualityFileName)))
+			return EXIT_FAILURE;
 	}
 	if (viewer.IsOpen() && !OPT::strOutputFileName.empty()) {
 		// export the scene
-		viewer.Export(MAKE_PATH_SAFE(OPT::strOutputFileName), OPT::strExportType.empty()?LPCTSTR(NULL):OPT::strExportType.c_str());
+		if (!viewer.Export(MAKE_PATH_SAFE(OPT::strOutputFileName), OPT::strExportType))
+			return EXIT_FAILURE;
 	}
 	if (!OPT::strScreenshotFileName.empty()) {
 		// scriptable mode: optionally set the viewpoint, capture one frame off-screen, then exit
@@ -234,10 +259,12 @@ int main(int argc, LPCTSTR* argv)
 			w.showBounds        = OPT::strShow.find('b') != std::string::npos;
 			includeUI           = OPT::strShow.find('u') != std::string::npos;
 		}
-		if (!OPT::strViewFileName.empty())
-			viewer.SetViewFromFile(MAKE_PATH_SAFE(OPT::strViewFileName));
-		else if (OPT::nViewCamera >= 0)
-			viewer.SetViewFromCamera((unsigned)OPT::nViewCamera);
+		if (!OPT::strViewFileName.empty()) {
+			if (!viewer.SetViewFromFile(MAKE_PATH_SAFE(OPT::strViewFileName)))
+				return EXIT_FAILURE;
+		} else if (OPT::nViewCamera >= 0 && !viewer.SetViewFromCamera((unsigned)OPT::nViewCamera)) {
+			return EXIT_FAILURE;
+		}
 		viewer.GetWindow().RequestScreenshot(MAKE_PATH_SAFE(OPT::strScreenshotFileName), includeUI, true);
 	}
 	// enter viewer loop (returns immediately after the screenshot in scriptable mode)

--- a/apps/Viewer/Window.cpp
+++ b/apps/Viewer/Window.cpp
@@ -186,7 +186,6 @@ bool Window::Initialize(const cv::Size& size, const String& windowTitle, Scene& 
 	// Initialize core systems
 	arcballControls = std::make_unique<ArcballControls>(camera);
 	arcballControlsB = std::make_unique<ArcballControls>(cameraB);
-	arcballControlsB->setEnableGizmos(false); // gizmos are rendered for the main camera only
 	firstPersonControls = std::make_unique<FirstPersonControls>(camera);
 	selectionController = std::make_unique<SelectionController>(camera);
 	bboxEditController = std::make_unique<BoundingBoxEditController>(camera);
@@ -409,6 +408,14 @@ void Window::UploadRenderData() {
 
 void Window::Render() {
 	GL_DEBUG_SCOPE("Window::Render");
+	// Both compare-side arcballs use the same user-facing navigation settings.
+	arcballControlsB->setRadiusFactor(arcballControls->getRadiusFactor());
+	arcballControlsB->setSensitivity(arcballControls->getSensitivity());
+	arcballControlsB->setRotationSensitivity(arcballControls->getRotationSensitivity());
+	arcballControlsB->setZoomSensitivity(arcballControls->getZoomSensitivity());
+	arcballControlsB->setPanSensitivity(arcballControls->getPanSensitivity());
+	arcballControlsB->setEnableGizmos(arcballControls->getEnableGizmos());
+	arcballControlsB->setEnableGizmosCenter(arcballControls->getEnableGizmosCenter());
 
 	// Keep the compare cameras consistent with the current mode and active layer
 	UpdateCompareState();
@@ -532,13 +539,37 @@ void Window::Render() {
 	// Show UI
 	ui->ShowMainMenuBar(*this);
 
-	// Render gizmos or coordinate axes
-	if (currentControlMode == CONTROL_ARCBALL && arcballControls && arcballControls->getEnableGizmos()) {
-		// Render arcball gizmos instead of coordinate axes
-		withMainCameraViewport([&] { renderer->RenderArcballGizmos(camera, *arcballControls); });
+	// Render a navigation indicator for each split viewport. Arcball gizmos are
+	// also clipped per side in swipe mode, making independently controlled camera
+	// orientations visible without duplicating the corner-based axes widget.
+	const auto renderNavigationIndicator = [this](int side) {
+		const Camera& sideCamera(GetSideCamera(side));
+		if (currentControlMode == CONTROL_ARCBALL && arcballControls->getEnableGizmos())
+			renderer->RenderArcballGizmos(sideCamera, GetSideArcballControls(side));
+		else
+			renderer->RenderCoordinateAxes(sideCamera);
+	};
+	const bool renderEachCompareSide =
+		IsCompareEnabled() && scene.IsOpen() &&
+		(compareMode == COMPARE_SPLIT ||
+		 (currentControlMode == CONTROL_ARCBALL && arcballControls->getEnableGizmos()));
+	if (renderEachCompareSide) {
+		const int splitX = GetCompareSplitX();
+		GL_CHECK(glEnable(GL_SCISSOR_TEST));
+		for (int side = 0; side < 2; ++side) {
+			if (compareMode == COMPARE_SPLIT) {
+				const cv::Rect viewport = GetCompareViewport(side);
+				GL_CHECK(glViewport(viewport.x, viewport.y, viewport.width, viewport.height));
+			}
+			GL_CHECK(glScissor(side == 0 ? 0 : splitX, 0, side == 0 ? splitX : windowSize.width - splitX, windowSize.height));
+			renderer->UpdateViewProjection(GetSideCamera(side));
+			renderNavigationIndicator(side);
+		}
+		GL_CHECK(glDisable(GL_SCISSOR_TEST));
+		GL_CHECK(glViewport(0, 0, windowSize.width, windowSize.height));
+		renderer->UpdateViewProjection(camera);
 	} else {
-		// Even when no scene is loaded, render coordinate axes as a visual indicator
-		withMainCameraViewport([&] { renderer->RenderCoordinateAxes(camera); });
+		renderNavigationIndicator(GetCompareActiveSide());
 	}
 
 	// Render UI

--- a/apps/Viewer/Window.cpp
+++ b/apps/Viewer/Window.cpp
@@ -502,7 +502,7 @@ void Window::Render() {
 				}
 				GL_CHECK(glScissor(side == 0 ? 0 : splitX, 0, side == 0 ? splitX : windowSize.width - splitX, windowSize.height));
 				renderer->UpdateViewProjection(GetSideCamera(side));
-				renderer->SetLayerPassFilter(sideLayers[side]);
+				renderer->SetLayerPassFilter(std::move(sideLayers[side]));
 				renderScenePass(side == activeSide);
 			}
 			renderer->ClearLayerPassFilter();

--- a/apps/Viewer/Window.cpp
+++ b/apps/Viewer/Window.cpp
@@ -56,7 +56,10 @@ Window::Window()
 	, devicePixelRatio(1.0, 1.0)
 	, currentControlMode(CONTROL_ARCBALL)
 	, lastMousePos(0, 0)
+	, compareDragSide(-1)
+	, compareActiveSide(-1)
 	, lastFrame(0.0)
+	, closeConfirmed(false)
 	, selectionType(SEL_NA)
 	, selectedNeighborCamera(NO_ID)
 	, clearColor(0.3f, 0.4f, 0.5f, 1.f)
@@ -64,7 +67,6 @@ Window::Window()
 	, userFontScale(1.f)
 	, cameraSize(0.1f)
 	, uncertaintyEllipsoidScale(1.f)
-	, cameraDisplayColor(CAMERA_COLOR_SOLID)
 	, cameraDisplayType(CAMERA_DISPLAY_FRUSTUM)
 	, showCameraLookAt(true)
 	, pointSize(3.f)
@@ -79,8 +81,12 @@ Window::Window()
 	, showMeshTextured(true)
 	, showBounds(true)
 	, showUncertaintyEllipsoids(false)
+	, compareMode(COMPARE_DISABLED)
+	, compareSplitPos(0.5f)
+	, compareSyncCameras(true)
 	, pendingScreenshotIncludeUI(false)
 	, pendingScreenshotQuit(false)
+	, pendingScreenshotWarmupFrames(0)
 {
 }
 
@@ -179,13 +185,15 @@ bool Window::Initialize(const cv::Size& size, const String& windowTitle, Scene& 
 
 	// Initialize core systems
 	arcballControls = std::make_unique<ArcballControls>(camera);
+	arcballControlsB = std::make_unique<ArcballControls>(cameraB);
+	arcballControlsB->setEnableGizmos(false); // gizmos are rendered for the main camera only
 	firstPersonControls = std::make_unique<FirstPersonControls>(camera);
 	selectionController = std::make_unique<SelectionController>(camera);
 	bboxEditController = std::make_unique<BoundingBoxEditController>(camera);
 	// Route every controller-driven OBB change through Scene::SetBoundingBox
 	// so GPU buffer refresh and redraw stay centralized in one place.
 	bboxEditController->setChangeCallback([this](const OBB3f& obb) {
-		if (GetScene().IsOpen())
+		if (GetScene().IsOpen() && !GetScene().HasBackgroundWork())
 			GetScene().SetBoundingBox(obb);
 	});
 	renderer = std::make_unique<Renderer>();
@@ -208,7 +216,8 @@ bool Window::Initialize(const cv::Size& size, const String& windowTitle, Scene& 
 
 	// Set up selection callback to automatically classify geometry when selection is completed
 	selectionController->setChangeCallback([&scene, this]() {
-		if (selectionController->hasSelectionPath()) {
+		const Scene::Layer* activeLayer(scene.GetActiveLayer());
+		if (!scene.HasBackgroundWork() && activeLayer != NULL && activeLayer->visible && selectionController->hasSelectionPath()) {
 			// Automatically classify geometry when selection is finished
 			if (!scene.GetScene().pointcloud.IsEmpty() && showPointCloud)
 				selectionController->classifyPointCloud(scene.GetScene().pointcloud, camera);
@@ -220,7 +229,7 @@ bool Window::Initialize(const cv::Size& size, const String& windowTitle, Scene& 
 
 	// Set up delete callback to remove selected geometry
 	selectionController->setDeleteCallback([&scene, this]() {
-		if (scene.IsWorkflowRunning()) {
+		if (scene.HasBackgroundWork()) {
 			DEBUG("Cannot remove geometry while workflow is running");
 			return;
 		}
@@ -229,7 +238,7 @@ bool Window::Initialize(const cv::Size& size, const String& windowTitle, Scene& 
 
 	// Set up ROI callback to set region of interest from selection
 	selectionController->setROICallback([&scene, this](bool aabb) {
-		if (scene.IsWorkflowRunning()) {
+		if (scene.HasBackgroundWork()) {
 			DEBUG("Cannot set ROI while workflow is running");
 			return;
 		}
@@ -248,8 +257,10 @@ void Window::Release() {
 		ui.reset();
 		renderer.reset();
 		arcballControls.reset();
+		arcballControlsB.reset();
 		firstPersonControls.reset();
 		selectionController.reset();
+		bboxEditController.reset();
 
 		// Destroy window and terminate GLFW
 		glfwDestroyWindow(window);
@@ -265,8 +276,13 @@ void Window::Release() {
 
 void Window::ResetView() {
 	camera.Reset();
-	currentControlMode = CONTROL_NONE;
-	SetControlMode(CONTROL_ARCBALL);
+	cameraB.Reset();
+	if (arcballControls) {
+		currentControlMode = CONTROL_NONE;
+		SetControlMode(CONTROL_ARCBALL);
+	} else {
+		currentControlMode = CONTROL_ARCBALL;
+	}
 	selectedNeighborCamera = NO_ID;
 	selectionType = SEL_NA;
 	selectionIdx.Release();
@@ -274,13 +290,34 @@ void Window::ResetView() {
 
 void Window::Reset() {
 	ResetView();
-	renderer->Reset();
+	if (selectionController)
+		selectionController->clearSelection();
+	meshSubMeshVisible.clear();
+	compareMode = COMPARE_DISABLED;
+	compareSyncCameras = true;
+	compareDragSide = -1;
+	compareActiveSide = -1;
+	if (renderer)
+		renderer->Reset();
 	SetTitle(_T("(empty)"));
 }
 
 void Window::Run() {
 	// Main loop
-	while (!ShouldClose()) {
+	while (true) {
+		if (ShouldClose()) {
+			if (GetScene().HasBackgroundWork()) {
+				glfwSetWindowShouldClose(window, GLFW_FALSE);
+				DEBUG("Cannot close Viewer while background work is running");
+				RequestAttention();
+			} else if (!closeConfirmed && GetScene().IsGeometryModified()) {
+				glfwSetWindowShouldClose(window, GLFW_FALSE);
+				ui->RequestSavePrompt();
+				RequestRedraw();
+			} else {
+				break;
+			}
+		}
 		// Update timing
 		const double deltaTime = UpdateTiming();
 
@@ -291,6 +328,8 @@ void Window::Run() {
 		switch (currentControlMode) {
 		case CONTROL_ARCBALL:
 			arcballControls->update(deltaTime);
+			if (IsCompareEnabled() && !compareSyncCameras)
+				arcballControlsB->update(deltaTime);
 			break;
 		case CONTROL_FIRST_PERSON:
 			firstPersonControls->update(deltaTime);
@@ -304,14 +343,19 @@ void Window::Run() {
 		}
 
 		#ifdef __APPLE__
-		// Check for files requested to open by Finder and open first
+		// Check for files requested to open by Finder
 		{
 			std::vector<std::string> pending;
 			OpenMVS_ConsumePendingOpenFiles(pending);
 			if (!pending.empty()) {
-				String filename(pending.front());
-				Util::ensureValidPath(filename);
-				GetScene().Open(filename);
+				std::vector<String> filenames;
+				filenames.reserve(pending.size());
+				for (const std::string& path : pending) {
+					String filename(path.c_str());
+					Util::ensureValidPath(filename);
+					filenames.emplace_back(std::move(filename));
+				}
+				GetScene().OpenFiles(filenames, false);
 			}
 		}
 		#endif
@@ -348,32 +392,16 @@ void Window::UploadRenderData() {
 	selectionType = SEL_NA;
 	selectionIdx.Release();
 
-	// Upload point cloud data if needed
-	if (!scene.GetScene().pointcloud.IsEmpty()) {
-		renderer->UploadPointCloud(scene.GetScene().pointcloud, pointNormalLength);
-		showPointCloud = true;
-	}
-
-	// Upload mesh data if needed
 	meshSubMeshVisible.clear();
-	if (!scene.GetScene().mesh.IsEmpty()) {
-		showMesh = true;
-		if (scene.GetScene().mesh.HasTexture())
-			showMeshTextured = true;
-		renderer->UploadMesh(scene.GetScene().mesh);
-		meshSubMeshVisible.assign(renderer->GetMeshSubMeshCount(), true);
-	}
-
-	// Upload cameras if visible, and
-	// upload image overlays for cameras with valid textures
-	if (!scene.GetScene().images.empty())
-		renderer->UploadCameras(*this);
+	renderer->UploadLayers(scene, *this);
+	meshSubMeshVisible.assign(renderer->GetMeshSubMeshCount(), true);
 
 	// Upload pose-uncertainty ellipsoids if loaded
 	renderer->UploadUncertaintyEllipsoids(*this);
 
 	// Upload bounds if available
-	renderer->UploadBounds(scene.GetScene());
+	if (scene.GetActiveLayer() != NULL)
+		renderer->UploadBounds(scene.GetActiveLayer()->scene);
 
 	// Request a redraw
 	RequestRedraw();
@@ -381,6 +409,9 @@ void Window::UploadRenderData() {
 
 void Window::Render() {
 	GL_DEBUG_SCOPE("Window::Render");
+
+	// Keep the compare cameras consistent with the current mode and active layer
+	UpdateCompareState();
 
 	// Enable depth testing
 	GL_CHECK(glEnable(GL_DEPTH_TEST));
@@ -392,46 +423,91 @@ void Window::Render() {
 	// Start UI frame
 	ui->NewFrame(*this);
 
+	// In split mode the main camera projects into the active-side viewport; scope
+	// main-camera overlays (selection rectangle, arcball gizmos) to it
+	const auto withMainCameraViewport = [this](auto&& draw) {
+		if (compareMode == COMPARE_SPLIT && GetScene().IsOpen() && GetScene().GetActiveLayer() != NULL) {
+			const cv::Rect viewport = GetCompareViewport(GetCompareActiveSide());
+			GL_CHECK(glViewport(viewport.x, viewport.y, viewport.width, viewport.height));
+			draw();
+			GL_CHECK(glViewport(0, 0, windowSize.width, windowSize.height));
+		} else
+			draw();
+	};
+
 	Scene& scene = GetScene();
 	if (scene.IsOpen()) {
-		// Render the scene contents
-		if (showPointCloud) {
-			renderer->RenderPointCloud(*this);
-			if (showPointCloudNormals)
-				renderer->RenderPointCloudNormals(*this);
-		}
-		if (showMesh)
-			renderer->RenderMesh(*this);
-
-		// Render cameras and selection highlights
-		if (showCameras)
-			renderer->RenderCameras(*this);
-		if (showUncertaintyEllipsoids)
-			renderer->RenderUncertaintyEllipsoids(*this);
-		renderer->RenderSelection(*this);
-		renderer->RenderSelectedGeometry(*this);
-
-		// Render bounds if visible and available
-		if (showBounds)
-			renderer->RenderBounds();
-
-		// Render the interactive bounding-box edit gizmos while edit mode is active
-		if (currentControlMode == CONTROL_BBOX_EDIT && GetScene().IsOpen()) {
-			const OBB3f& editOBB = bboxEditController->getOBB();
-			if (editOBB.IsValid()) {
-				renderer->RenderBoundingBoxGizmos(
-					editOBB,
-					bboxEditController->getHoverCornerIdx(),
-					bboxEditController->getHoverFaceIdx(),
-					bboxEditController->getHoverAxisIdx());
+		// One 3D scene pass; active-layer extras (selection, bounds, gizmos, image overlay)
+		// are drawn only in the pass that shows the active layer.
+		const auto renderScenePass = [this](bool renderActiveLayerExtras) {
+			if (showPointCloud) {
+				renderer->RenderPointCloud(*this);
+				if (showPointCloudNormals)
+					renderer->RenderPointCloudNormals(*this);
 			}
+			if (showMesh)
+				renderer->RenderMesh(*this);
+			if (showCameras)
+				renderer->RenderCameras(*this);
+			if (showUncertaintyEllipsoids)
+				renderer->RenderUncertaintyEllipsoids(*this);
+			if (!renderActiveLayerExtras)
+				return;
+			renderer->RenderSelection(*this);
+			renderer->RenderSelectedGeometry(*this);
+			if (showBounds)
+				renderer->RenderBounds();
+			// Render the interactive bounding-box edit gizmos while edit mode is active
+			if (currentControlMode == CONTROL_BBOX_EDIT) {
+				const OBB3f& editOBB = bboxEditController->getOBB();
+				if (editOBB.IsValid()) {
+					renderer->RenderBoundingBoxGizmos(
+						editOBB,
+						bboxEditController->getHoverCornerIdx(),
+						bboxEditController->getHoverFaceIdx(),
+						bboxEditController->getHoverAxisIdx());
+				}
+			}
+			// Render image overlay when in camera view mode
+			renderer->RenderImageOverlays(*this);
+		};
+		const Scene::Layer* activeLayer = scene.GetActiveLayer();
+		if (IsCompareEnabled() && activeLayer != NULL) {
+			// A|B compare: each pass draws only one side's layers. In swipe mode both
+			// passes share the full-window projection and differ only by the scissor
+			// rectangle, so aligned scenes match pixel-exact across the divider; in
+			// split mode each side renders into its own half-window viewport with its
+			// own projection. The side cameras are the same object while camera
+			// synchronization is on, so the views cannot drift apart.
+			const int splitX = GetCompareSplitX();
+			const int activeSide = GetCompareActiveSide();
+			std::vector<uint32_t> sideLayers[2];
+			for (const Scene::Layer& layer : scene.GetLayers())
+				if (layer.visible)
+					sideLayers[layer.compareRight ? 1 : 0].push_back(layer.id);
+			GL_CHECK(glEnable(GL_SCISSOR_TEST));
+			for (int side = 0; side < 2; ++side) {
+				if (sideLayers[side].empty())
+					continue; // an empty filter would mean "draw all layers"
+				if (compareMode == COMPARE_SPLIT) {
+					const cv::Rect viewport = GetCompareViewport(side);
+					GL_CHECK(glViewport(viewport.x, viewport.y, viewport.width, viewport.height));
+				}
+				GL_CHECK(glScissor(side == 0 ? 0 : splitX, 0, side == 0 ? splitX : windowSize.width - splitX, windowSize.height));
+				renderer->UpdateViewProjection(GetSideCamera(side));
+				renderer->SetLayerPassFilter(sideLayers[side]);
+				renderScenePass(side == activeSide);
+			}
+			renderer->ClearLayerPassFilter();
+			GL_CHECK(glDisable(GL_SCISSOR_TEST));
+			GL_CHECK(glViewport(0, 0, windowSize.width, windowSize.height));
+			renderer->UpdateViewProjection(camera); // restore the main camera for the overlays
+		} else {
+			renderScenePass(true);
 		}
-
-		// Render image overlay when in camera view mode
-		renderer->RenderImageOverlays(*this);
 
 		// Render 2D selection overlay (after all 3D rendering, before UI)
-		renderer->RenderSelectionOverlay(*this);
+		withMainCameraViewport([&] { renderer->RenderSelectionOverlay(*this); });
 
 		// Flush pending screenshot if requested (without UI): capture after every
 		// 3D layer so the screenshot-show flags (cameras, bounds, ...) take effect
@@ -439,24 +515,18 @@ void Window::Render() {
 			CaptureScreenshot(pendingScreenshotPath);
 			pendingScreenshotPath.clear();
 			if (pendingScreenshotQuit)
-				glfwSetWindowShouldClose(window, GLFW_TRUE);
+				ConfirmClose();
 		}
 
-		// Show scene information
-		ui->ShowSceneInfo(*this);
-
-		// Show camera controls
-		ui->ShowCameraControls(*this);
-
-		// Show selection controls
-		ui->ShowSelectionControls(*this);
-
-		// Show render settings
-		ui->ShowRenderSettings(*this);
-
-		// Show bounding-box editor
-		ui->ShowBoundingBoxControls(*this);
-		ui->ShowWorkflowWindows(*this);
+		if (!scene.HasBackgroundWork()) {
+			// Scene-dependent panels must not inspect or re-upload geometry while a worker mutates it.
+			ui->ShowSceneInfo(*this);
+			ui->ShowCameraControls(*this);
+			ui->ShowSelectionControls(*this);
+			ui->ShowRenderSettings(*this);
+			ui->ShowBoundingBoxControls(*this);
+			ui->ShowWorkflowWindows(*this);
+		}
 	}
 
 	// Show UI
@@ -465,10 +535,10 @@ void Window::Render() {
 	// Render gizmos or coordinate axes
 	if (currentControlMode == CONTROL_ARCBALL && arcballControls && arcballControls->getEnableGizmos()) {
 		// Render arcball gizmos instead of coordinate axes
-		renderer->RenderArcballGizmos(camera, *arcballControls);
+		withMainCameraViewport([&] { renderer->RenderArcballGizmos(camera, *arcballControls); });
 	} else {
 		// Even when no scene is loaded, render coordinate axes as a visual indicator
-		renderer->RenderCoordinateAxes(camera);
+		withMainCameraViewport([&] { renderer->RenderCoordinateAxes(camera); });
 	}
 
 	// Render UI
@@ -476,10 +546,15 @@ void Window::Render() {
 
 	// Flush pending screenshot if requested (with UI)
 	if (!pendingScreenshotPath.empty()) {
-		CaptureScreenshot(pendingScreenshotPath);
-		pendingScreenshotPath.clear();
-		if (pendingScreenshotQuit)
-			glfwSetWindowShouldClose(window, GLFW_TRUE);
+		if (pendingScreenshotWarmupFrames > 0) {
+			--pendingScreenshotWarmupFrames;
+			RequestRedraw();
+		} else {
+			CaptureScreenshot(pendingScreenshotPath);
+			pendingScreenshotPath.clear();
+			if (pendingScreenshotQuit)
+				ConfirmClose();
+		}
 	}
 
 	// End frame
@@ -508,6 +583,13 @@ void Window::SetVisible(bool visible) {
 	}
 }
 
+void Window::ConfirmClose()
+{
+	closeConfirmed = true;
+	if (window)
+		glfwSetWindowShouldClose(window, GLFW_TRUE);
+}
+
 void Window::RequestAttention() {
 	if (window)
 		glfwRequestWindowAttention(window);
@@ -520,8 +602,93 @@ void Window::Focus() {
 
 void Window::SetSceneBounds(const Point3f& center, const Point3f& size) {
 	camera.SetSceneBounds(center, size);
+	cameraB.SetSceneBounds(center, size);
 	arcballControls->setSensitivity(norm(size) * 0.1);
+	arcballControlsB->setSensitivity(norm(size) * 0.1);
 	firstPersonControls->setMovementSpeed(norm(size) * 0.1);
+}
+
+// Divider position in framebuffer pixels (fixed at the middle in split mode,
+// draggable in swipe mode)
+int Window::GetCompareSplitX() const {
+	return CLAMP(ROUND2INT(compareSplitPos * (float)windowSize.width), 1, windowSize.width - 1);
+}
+
+// Viewport rectangle of a compare side in framebuffer pixels; outside split mode
+// both sides cover the full window (the swipe divider only scissors the draw)
+cv::Rect Window::GetCompareViewport(int side) const {
+	if (compareMode != COMPARE_SPLIT)
+		return cv::Rect(0, 0, windowSize.width, windowSize.height);
+	const int splitX = GetCompareSplitX();
+	return side == 0 ?
+		cv::Rect(0, 0, splitX, windowSize.height) :
+		cv::Rect(splitX, 0, windowSize.width - splitX, windowSize.height);
+}
+
+int Window::GetCompareActiveSide() const {
+	const Scene::Layer* activeLayer = GetScene().GetActiveLayer();
+	return activeLayer != NULL && activeLayer->compareRight ? 1 : 0;
+}
+
+int Window::GetCompareSideAt(double xpos) const {
+	if (!IsCompareEnabled())
+		return 0;
+	return xpos * devicePixelRatio.x() >= (double)GetCompareSplitX() ? 1 : 0;
+}
+
+Camera& Window::GetSideCamera(int side) {
+	if (!IsCompareEnabled() || compareSyncCameras || side == GetCompareActiveSide())
+		return camera;
+	return cameraB;
+}
+
+const Camera& Window::GetSideCamera(int side) const {
+	return const_cast<Window*>(this)->GetSideCamera(side);
+}
+
+ArcballControls& Window::GetSideArcballControls(int side) {
+	return &GetSideCamera(side) == &cameraB ? *arcballControlsB : *arcballControls;
+}
+
+// Toggle synchronized camera movement; unsynchronizing hands the current view to
+// the other side's camera so both sides start from the same view
+void Window::SetCompareSyncCameras(bool sync) {
+	if (compareSyncCameras == sync)
+		return;
+	compareSyncCameras = sync;
+	if (!sync) {
+		cameraB.CopyViewFrom(camera);
+		arcballControlsB->reset();
+	}
+	compareDragSide = -1;
+	RequestRedraw();
+}
+
+void Window::UpdateCompareState() {
+	if (!IsCompareEnabled() || !GetScene().IsOpen() || GetScene().GetActiveLayer() == NULL) {
+		if (camera.GetSize() != windowSize)
+			camera.SetSize(windowSize);
+		compareActiveSide = -1;
+		return;
+	}
+	const int activeSide = GetCompareActiveSide();
+	if (!compareSyncCameras && compareActiveSide != -1 && compareActiveSide != activeSide) {
+		// The main camera always renders the active side; when the active layer
+		// switches sides, swap the poses so both views stay visually in place.
+		Camera prevCamera;
+		prevCamera.CopyViewFrom(camera);
+		camera.CopyViewFrom(cameraB);
+		cameraB.CopyViewFrom(prevCamera);
+	}
+	compareActiveSide = activeSide;
+	if (compareMode == COMPARE_SPLIT) {
+		compareSplitPos = 0.5f; // equal-size viewports
+		camera.SetSize(GetCompareViewport(activeSide).size());
+		cameraB.SetSize(GetCompareViewport(1 - activeSide).size());
+	} else {
+		camera.SetSize(windowSize);
+		cameraB.SetSize(windowSize);
+	}
 }
 
 // Request an off-screen screenshot to be saved by the renderer on the next
@@ -532,6 +699,7 @@ void Window::RequestScreenshot(const String& filename, bool includeUI, bool quit
 	pendingScreenshotPath = filename;
 	pendingScreenshotIncludeUI = includeUI;
 	pendingScreenshotQuit = quitAfter;
+	pendingScreenshotWarmupFrames = includeUI ? 1u : 0u;
 	RequestRedraw();
 }
 
@@ -612,13 +780,20 @@ void Window::HandleMouseMove(double xpos, double ypos) {
 	if (ui->WantCaptureMouse())
 		return;
 
-	// Normalize mouse position to [-1, 1] range
-	Eigen::Vector2d normalizedPos = NormalizeMousePos(xpos, ypos);
+	// While a drag is in progress the side latched at button-press keeps receiving
+	// the input, so crossing the divider does not switch cameras mid-drag; only
+	// arcball navigation is routed per side, the other modes always operate on the
+	// active layer through the main camera
+	const int side = compareDragSide != -1 ? compareDragSide : GetCompareSideAt(xpos);
+	const int controlSide = currentControlMode == CONTROL_ARCBALL ? side : GetCompareActiveSide();
+
+	// Normalize mouse position to [-1, 1] range inside the side's viewport
+	Eigen::Vector2d normalizedPos = NormalizeMousePos(xpos, ypos, controlSide);
 
 	// Pass to active control system
 	switch (currentControlMode) {
 	case CONTROL_ARCBALL:
-		arcballControls->handleMouseMove(normalizedPos);
+		GetSideArcballControls(side).handleMouseMove(normalizedPos);
 		break;
 	case CONTROL_FIRST_PERSON:
 		firstPersonControls->handleMouseMove(normalizedPos);
@@ -643,12 +818,28 @@ void Window::HandleMouseButton(int button, int action, int mods) {
 	// Normalize current mouse position
 	double xpos, ypos;
 	glfwGetCursorPos(window, &xpos, &ypos);
-	Eigen::Vector2d normalizedPos = NormalizeMousePos(xpos, ypos);
+
+	// Latch the compare side receiving this drag at button-press and release the
+	// latch once no mouse button remains held
+	const int cursorSide = GetCompareSideAt(xpos);
+	if (action == GLFW_PRESS && compareDragSide == -1)
+		compareDragSide = cursorSide;
+	const int side = compareDragSide != -1 ? compareDragSide : cursorSide;
+	if (action == GLFW_RELEASE &&
+		glfwGetMouseButton(window, GLFW_MOUSE_BUTTON_LEFT) == GLFW_RELEASE &&
+		glfwGetMouseButton(window, GLFW_MOUSE_BUTTON_RIGHT) == GLFW_RELEASE &&
+		glfwGetMouseButton(window, GLFW_MOUSE_BUTTON_MIDDLE) == GLFW_RELEASE)
+		compareDragSide = -1;
+
+	// Only arcball navigation is routed per side, the other modes always operate
+	// on the active layer through the main camera
+	const int controlSide = currentControlMode == CONTROL_ARCBALL ? side : GetCompareActiveSide();
+	Eigen::Vector2d normalizedPos = NormalizeMousePos(xpos, ypos, controlSide);
 
 	// Pass to active control system
 	switch (currentControlMode) {
 	case CONTROL_ARCBALL:
-		arcballControls->handleMouseButton(button, action, normalizedPos);
+		GetSideArcballControls(side).handleMouseButton(button, action, normalizedPos);
 		break;
 	case CONTROL_FIRST_PERSON:
 		firstPersonControls->handleMouseButton(button, action, normalizedPos);
@@ -662,8 +853,8 @@ void Window::HandleMouseButton(int button, int action, int mods) {
 		break;
 	}
 
-	// Handle raycast on click
-	Ray3d ray = camera.GetPickingRay(normalizedPos);
+	// Handle raycast on click: cast through the camera of the viewport under the cursor
+	Ray3d ray = GetSideCamera(cursorSide).GetPickingRay(NormalizeMousePos(xpos, ypos, cursorSide));
 	// Convert logical window cursor coords to framebuffer pixel coords using devicePixelRatio
 	Point2f screenPos(
 		static_cast<float>(xpos * devicePixelRatio.x()),
@@ -676,10 +867,15 @@ void Window::HandleScroll(double yoffset) {
 	if (ui->WantCaptureMouse())
 		return;
 
+	// Zoom the camera of the viewport under the cursor
+	double xpos, ypos;
+	glfwGetCursorPos(window, &xpos, &ypos);
+	const int side = compareDragSide != -1 ? compareDragSide : GetCompareSideAt(xpos);
+
 	// Pass to active control system
 	switch (currentControlMode) {
 	case CONTROL_ARCBALL:
-		arcballControls->handleScroll(yoffset);
+		GetSideArcballControls(side).handleScroll(yoffset);
 		break;
 	case CONTROL_FIRST_PERSON:
 		firstPersonControls->handleScroll(yoffset);
@@ -777,12 +973,14 @@ void Window::HandleKeyboard(int key, int action, int mods) {
 				if (mods & GLFW_MOD_SUPER) {
 				#else
 				if (mods & GLFW_MOD_CONTROL) {
-				#endif
+					#endif
+					if (GetScene().HasBackgroundWork())
+						break;
 					// Ctrl+O - Open file
 					SetVisible(false);
-					String filename, geometryFilename;
-					if (ui->ShowOpenFileDialog(filename, geometryFilename))
-						GetScene().Open(filename, geometryFilename);
+					std::vector<String> filenames;
+					if (ui->ShowOpenFileDialog(filenames) && ui->ConfirmDiscardChanges(GetScene(), "open another scene"))
+						GetScene().OpenFiles(filenames, true);
 					SetVisible(true);
 				}
 				break;
@@ -792,7 +990,9 @@ void Window::HandleKeyboard(int key, int action, int mods) {
 				if (mods & GLFW_MOD_SUPER) {
 				#else
 				if (mods & GLFW_MOD_CONTROL) {
-				#endif
+					#endif
+					if (GetScene().HasBackgroundWork())
+						break;
 					if (mods & GLFW_MOD_SHIFT) {
 						// Ctrl+Shift+S - Save As
 						SetVisible(false);
@@ -829,6 +1029,12 @@ void Window::HandleKeyboard(int key, int action, int mods) {
 			case GLFW_KEY_RIGHT:
 				camera.NextCamera();
 				break;
+			case GLFW_KEY_LEFT_BRACKET:
+				GetScene().ActivateNextLayer(-1);
+				return;
+			case GLFW_KEY_RIGHT_BRACKET:
+				GetScene().ActivateNextLayer(1);
+				return;
 
 			// Help dialog
 			case GLFW_KEY_F1:
@@ -910,31 +1116,19 @@ void Window::HandleKeyboard(int key, int action, int mods) {
 
 void Window::HandleFileDrop(int count, const char** paths) {
 	if (count > 0) {
-		// Handle first dropped file
-		String filename(paths[0]);
-		Util::ensureValidPath(filename);
-		// Check file extension to determine if it's a scene or geometry file
-		String ext = Util::getFileExt(filename).ToLower();
-		if (ext == ".mvs" || ext == ".sfm" || ext == ".dmap") {
-			// Scene file
-			String geometryFilename;
-			if (count > 1) {
-				// Use second dropped file as geometry file if available
-				geometryFilename = String(paths[1]);
-				Util::ensureValidPath(geometryFilename);
-			}
-			GetScene().Open(filename, geometryFilename);
-		} else if (ext == ".ply" || ext == ".obj" || ext == ".off" || ext == ".gltf" || ext == ".glb") {
-			// Geometry file
-			GetScene().Open(filename, "");
-		} else {
-			DEBUG("Unsupported file format: %s", ext.c_str());
+		std::vector<String> filenames;
+		filenames.reserve(count);
+		for (int i = 0; i < count; ++i) {
+			String filename(paths[i]);
+			Util::ensureValidPath(filename);
+			filenames.emplace_back(std::move(filename));
 		}
+		GetScene().OpenFiles(filenames, false);
 	}
 }
 
 bool Window::CaptureScreenshot(const String& filename) {
-	const cv::Size& size = camera.GetSize();
+	const cv::Size& size = windowSize;
 	if (size.empty()) {
 		DEBUG("error: invalid framebuffer size for screenshot");
 		return false;
@@ -970,32 +1164,34 @@ void Window::UpdateDevicePixelRatio() {
 	}
 
 	// Get logical window size and framebuffer size
-	cv::Size windowSize, size;
-	glfwGetWindowSize(window, &windowSize.width, &windowSize.height);
-	glfwGetFramebufferSize(window, &size.width, &size.height);
+	cv::Size logicalSize;
+	glfwGetWindowSize(window, &logicalSize.width, &logicalSize.height);
+	glfwGetFramebufferSize(window, &windowSize.width, &windowSize.height);
 
 	// Calculate device pixel ratio (scale factor)
-	devicePixelRatio.x() = (windowSize.width > 0 ? static_cast<double>(size.width) / static_cast<double>(windowSize.width) : 1.0);
-	devicePixelRatio.y() = (windowSize.height > 0 ? static_cast<double>(size.height) / static_cast<double>(windowSize.height) : 1.0);
+	devicePixelRatio.x() = (logicalSize.width > 0 ? static_cast<double>(windowSize.width) / static_cast<double>(logicalSize.width) : 1.0);
+	devicePixelRatio.y() = (logicalSize.height > 0 ? static_cast<double>(windowSize.height) / static_cast<double>(logicalSize.height) : 1.0);
 
 	// Set initial viewport to match framebuffer size
-	GL_CHECK(glViewport(0, 0, size.width, size.height));
+	GL_CHECK(glViewport(0, 0, windowSize.width, windowSize.height));
 
-	// Set initial camera size
-	camera.SetSize(size);
+	// Set initial camera sizes (UpdateCompareState re-applies the per-mode
+	// viewport sizes before the next frame is rendered)
+	camera.SetSize(windowSize);
+	cameraB.SetSize(windowSize);
 
 	DEBUG("Framebuffer size changed: %dx%d (window size: %dx%d)",
-		size.width, size.height, windowSize.width, windowSize.height);
+		windowSize.width, windowSize.height, logicalSize.width, logicalSize.height);
 }
 
-Eigen::Vector2d Window::NormalizeMousePos(double x, double y) const {
-	// Convert mouse coordinates from logical window coordinates to framebuffer coordinates
-	double framebufferX = x * devicePixelRatio.x();
-	double framebufferY = y * devicePixelRatio.y();
-
-	// Convert from framebuffer coordinates to normalized coordinates [-1, 1]
-	double normalizedX = (2.0 * framebufferX) / GetSize().width - 1.0;
-	double normalizedY = 1.0 - (2.0 * framebufferY) / GetSize().height;
+// Normalize a mouse position to [-1, 1] inside the given compare side's viewport
+// (the full window unless the split view is active)
+Eigen::Vector2d Window::NormalizeMousePos(double x, double y, int side) const {
+	const cv::Rect viewport = GetCompareViewport(side);
+	const double framebufferX = x * devicePixelRatio.x();
+	const double framebufferY = y * devicePixelRatio.y();
+	const double normalizedX = (2.0 * (framebufferX - viewport.x)) / viewport.width - 1.0;
+	const double normalizedY = 1.0 - (2.0 * framebufferY) / viewport.height;
 	return Eigen::Vector2d(normalizedX, normalizedY);
 }
 

--- a/apps/Viewer/Window.h
+++ b/apps/Viewer/Window.h
@@ -53,10 +53,6 @@ public:
 		CONTROL_BBOX_EDIT,
 		CONTROL_NONE
 	};
-	enum CameraDisplayColor {
-		CAMERA_COLOR_SOLID = 0,
-		CAMERA_COLOR_JET
-	};
 	enum CameraDisplayType {
 		CAMERA_DISPLAY_FRUSTUM = 0,
 		CAMERA_DISPLAY_DOT
@@ -75,9 +71,15 @@ private:
 	// Device pixel ratio for Retina/high-DPI displays
 	Eigen::Vector2d devicePixelRatio;
 
+	// Window framebuffer size (decoupled from the camera viewport size, which can be
+	// half the window while the compare split view is active)
+	cv::Size windowSize;
+
 	// Core systems
-	Camera camera;
+	Camera camera; // camera of the active layer's compare side (the only camera outside compare mode)
+	Camera cameraB; // camera of the other compare side (used only when cameras are not synchronized)
 	std::unique_ptr<ArcballControls> arcballControls;
+	std::unique_ptr<ArcballControls> arcballControlsB; // drives cameraB
 	std::unique_ptr<FirstPersonControls> firstPersonControls;
 	std::unique_ptr<SelectionController> selectionController;
 	std::unique_ptr<BoundingBoxEditController> bboxEditController;
@@ -89,9 +91,12 @@ private:
 
 	// Input state
 	Eigen::Vector2d lastMousePos;
+	int compareDragSide; // compare side owning the current mouse drag (-1 = none)
+	int compareActiveSide; // cached active-layer side, to detect side changes (-1 = untracked)
 
 	// Timing
 	double lastFrame;
+	bool closeConfirmed;
 
 public:
 	// Selection state
@@ -113,7 +118,6 @@ public:
 	float userFontScale; // UI font scale
 	float cameraSize;
 	float uncertaintyEllipsoidScale; // multiplies the 1-sigma pose-uncertainty ellipsoid radii
-	CameraDisplayColor cameraDisplayColor;
 	CameraDisplayType cameraDisplayType;
 	bool showCameraLookAt;
 	float pointSize;
@@ -128,10 +132,28 @@ public:
 	bool showMeshTextured;
 	bool showBounds; // draw the scene oriented bounding-box wireframe
 	bool showUncertaintyEllipsoids; // draw the per-camera pose-uncertainty ellipsoids (when loaded)
+	// Compare view (A|B): each layer renders only on its assigned side. Two flavors:
+	//  - swipe: both sides share the full-window projection and are separated by a
+	//    draggable divider (scissor), so aligned scenes match pixel-exact across it;
+	//  - split: two equal side-by-side viewports, each scene centered in its own
+	//    full frustum.
+	// Cameras are synchronized by default (both sides render the same view); when
+	// unsynchronized each side keeps its own camera, driven by the viewport under
+	// the cursor. The main camera always follows the active layer's side, so every
+	// active-layer interaction (selection, bbox edit, camera view) stays correct.
+	enum CompareMode {
+		COMPARE_DISABLED = 0,
+		COMPARE_SWIPE,
+		COMPARE_SPLIT
+	};
+	CompareMode compareMode;
+	float compareSplitPos; // divider position as a fraction of the window width (fixed at 0.5 in split mode)
+	bool compareSyncCameras; // move the cameras of both sides together
 	std::vector<bool> meshSubMeshVisible; // control visibility of individual sub-meshes (using unsigned char instead of bool for ImGui compatibility)
 	String pendingScreenshotPath;
 	bool pendingScreenshotIncludeUI;
 	bool pendingScreenshotQuit; // close the window once the pending screenshot has been saved
+	unsigned pendingScreenshotWarmupFrames;
 
 public:
 	Window();
@@ -154,6 +176,16 @@ public:
 	// Camera access
 	Camera& GetCamera() { return camera; }
 	const Camera& GetCamera() const { return camera; }
+
+	// Compare view helpers
+	bool IsCompareEnabled() const { return compareMode != COMPARE_DISABLED; }
+	int GetCompareSplitX() const; // divider position in framebuffer pixels
+	cv::Rect GetCompareViewport(int side) const; // viewport rect of a side in split mode (framebuffer pixels)
+	int GetCompareActiveSide() const; // side of the active layer (0 = A/left, 1 = B/right)
+	int GetCompareSideAt(double xpos) const; // side under a cursor position (logical window coordinates)
+	Camera& GetSideCamera(int side); // camera rendering the given side
+	const Camera& GetSideCamera(int side) const;
+	void SetCompareSyncCameras(bool sync);
 
 	// Control access
 	void SetControlMode(ControlMode mode);
@@ -188,10 +220,11 @@ public:
 	// Utility
 	void SetTitle(const String& title);
 	void SetVisible(bool visible);
+	void ConfirmClose(); // close without another unsaved-changes prompt
 	void RequestAttention(); // request window attention (flash in taskbar)
 	void Focus(); // bring window to front and give it focus
 	const Eigen::Vector2d& GetDevicePixelRatio() const { return devicePixelRatio; }
-	const cv::Size& GetSize() const { return camera.GetSize(); }
+	const cv::Size& GetSize() const { return windowSize; }
 	void SetSceneBounds(const Point3f& center, const Point3f& size);
 	void RequestScreenshot(const String& filename, bool includeUI = false, bool quitAfter = false);
 	GLFWwindow* GetGLFWWindow() const { return window; }
@@ -223,7 +256,12 @@ private:
 
 	double UpdateTiming();
 	void UpdateDevicePixelRatio();
-	Eigen::Vector2d NormalizeMousePos(double x, double y) const;
+	Eigen::Vector2d NormalizeMousePos(double x, double y, int side) const; // normalize inside a compare-side viewport (full window unless split)
+	// Keep the compare cameras consistent with the current mode, window size and
+	// active layer (viewport sizes, fixed split position, camera hand-over when the
+	// active layer changes sides); called once per frame before rendering
+	void UpdateCompareState();
+	ArcballControls& GetSideArcballControls(int side); // controls driving the given side's camera
 };
 /*----------------------------------------------------------------*/
 

--- a/docs/features_catalog.md
+++ b/docs/features_catalog.md
@@ -756,18 +756,18 @@ OpenMVS is a comprehensive photogrammetry library implementing a complete pipeli
 ### Viewer Scene
 
 - **Files:** `apps/Viewer/Scene.h`, `apps/Viewer/Scene.cpp` (VIEWER namespace)
-- **Algorithms:** Top-level container wrapping `MVS::Scene`; `Open()`/`Save()`/`Export()`; async workflow state machine (IDLE→RUNNING→COMPLETED/FAILED); `CheckWorkflowCompletion()` / `FinalizeWorkflow()`; track-based neighbor precomputation; drag-and-drop handling
+- **Algorithms:** Top-level container wrapping `MVS::Scene`; multi-scene layer management (each layer owns its scene, images and appearance, addressed by stable layer IDs; per-layer visibility/solo/active); `AlignLayersToActive()` similarity alignment from camera centers matched by photo name then preserved SfM image ID; `Open()`/`Save()`/`Export()`; async workflow state machine (IDLE→RUNNING→COMPLETED/FAILED) operating on the active layer; `CheckWorkflowCompletion()` / `FinalizeWorkflow()`; track-based neighbor precomputation; drag-and-drop handling
 - **Dependencies:** MVS library
 
 ### Window and Event Loop
 
 - **Files:** `apps/Viewer/Window.h`, `apps/Viewer/Window.cpp`
-- **Algorithms:** GLFW window management; render-on-change via `glfwWaitEventsTimeout()`; `RequestRedraw()` event posting; delta time calculation; control mode switching (arcball/first-person/selection)
+- **Algorithms:** GLFW window management; render-on-change via `glfwWaitEventsTimeout()`; `RequestRedraw()` event posting; delta time calculation; control mode switching (arcball/first-person/selection); A|B compare view in swipe (shared full-window projection, scissor split) and split (two equal viewports, per-side projection) modes with synchronized or per-viewport cameras (input routed to the viewport under the cursor, side latched per drag)
 
 ### Renderer
 
 - **Files:** `apps/Viewer/Renderer.h`, `apps/Viewer/Renderer.cpp`
-- **Algorithms:** OpenGL 4.x rendering; point cloud, mesh (solid/wireframe/textured), camera frustums, image overlays, selection highlight; picker FBO with `R32UI` texture for primitive ID readback; sub-mesh partitioning by texture; 29 GLSL shaders
+- **Algorithms:** OpenGL 4.x rendering; point cloud, mesh (solid/wireframe/textured), camera frustums, image overlays, selection highlight; per-layer GPU buffer sub-ranges with a layer pass filter for compare-view draw subsets (no re-upload on side changes); picker FBO with `R32UI` texture for primitive ID readback, rasterized with the cursor side's camera in compare view; sub-mesh partitioning by texture; 29 GLSL shaders
 - **GPU Support:** Yes (OpenGL)
 
 ### Control Systems
@@ -778,7 +778,7 @@ OpenMVS is a comprehensive photogrammetry library implementing a complete pipeli
 ### UI
 
 - **Files:** `apps/Viewer/UI.h`, `apps/Viewer/UI.cpp`
-- **Algorithms:** ImGui with docking; workflow windows (Densify, ReconstructMesh, RefineMesh, TextureMesh, Batch); scene info, render settings, console overlay, performance overlay; auto-hiding menu bar
+- **Algorithms:** ImGui with docking; Layers panel (visibility/solo/active, compare off/swipe/split with A|B side assignment and camera sync, align-to-active); compare divider overlay (draggable in swipe mode); workflow windows (Densify, ReconstructMesh, RefineMesh, TextureMesh, Batch); scene info, render settings, console overlay, performance overlay; auto-hiding menu bar
 
 ---
 

--- a/docs/wiki/Usage.md
+++ b/docs/wiki/Usage.md
@@ -31,6 +31,7 @@ CreateStructure -s scene_keyframes.sfm -o scene.sfm --export-mvs scene.mvs --ext
 
 </details>
 
+
 <details>
 <summary><strong>Sparse Reconstruction with Native SfM</strong></summary>
 
@@ -347,6 +348,8 @@ The input file (or any of the supported formats listed below) can be passed on t
 - `--export-type` — export format override (`ply` or `obj`).
 - `--max-memory` — hard memory cap in MB (`0` = unlimited).
 - `--screenshot-file, -S` — render the scene off-screen to this image file and exit, without opening the interactive window.
+- `--compare-mode` — enable `swipe` or `split` comparison for interactive use or scripted screenshots (requires at least two loaded layers).
+- `--align-layers` — align additional layers to the active layer from shared cameras before entering interactive or screenshot mode.
 - `--view-file` — optional viewpoint for the screenshot: a transform file of 12 or 16 whitespace-separated values, row-major, interpreted as a camera-to-world pose (columns are the camera X, Y, Z axes in world space, the last column is the camera center).
 - `--view-camera` — alternative viewpoint for the screenshot: index of a scene camera view point to use (`-1` disables it). Ignored when `--view-file` is given.
 - `--screenshot-show` — which layers to render in the screenshot, as a string of flags: `p` point-cloud, `m` mesh, `t` textured, `c` cameras, `w` wireframe, `b` bounding-box, `u` UI (e.g. `p`, `m`, `mt`). When omitted the interactive defaults are kept.
@@ -401,4 +404,3 @@ Tools
 </details>
 
 </details>
-

--- a/docs/wiki/Usage.md
+++ b/docs/wiki/Usage.md
@@ -342,6 +342,7 @@ The input file (or any of the supported formats listed below) can be passed on t
 
 - `--input-file, -i` — project file containing cameras and geometry.
 - `--geometry-file, -g` — external mesh or point-cloud that overlays / replaces the scene geometry.
+- `--layer-file, -l` — additional scene or geometry file loaded as a separate layer, for inspecting or comparing multiple reconstructions side by side (repeat for multiple layers).
 - `--output-file, -o` — output filename for programmatic mesh export.
 - `--export-type` — export format override (`ply` or `obj`).
 - `--max-memory` — hard memory cap in MB (`0` = unlimited).
@@ -355,7 +356,7 @@ The input file (or any of the supported formats listed below) can be passed on t
 The user interface is built on Dear ImGui and organized into menus, dockable panels and overlays:
 
 - **File menu** — Open / Save / Save As / Close / Export, plus screenshot capture (with or without UI visible).
-- **View menu** — toggles Scene Info, Camera Info, Camera Controls, Selection, Render Settings, Bounding Box, Console and the Performance / Workflow / Viewport / Selection overlays.
+- **View menu** — toggles the Layers panel, Scene Info, Camera Info, Camera Controls, Selection, Render Settings, Bounding Box, Console and the Performance / Workflow / Viewport / Selection overlays.
 - **Render toggles** — one-key switches for Point-cloud, Mesh, Cameras, Wireframe, Textured, and Bounding-box visibility.
 - **Workflow menu** — launches the OpenMVS pipeline steps on the loaded scene: *Estimate ROI*, *Densify*, *Reconstruct Mesh*, *Refine*, *Texture*. Each opens a parameter panel with the corresponding module's options.
 - **Help / About dialogs** — `F1` shows the complete in-app keybinding reference.
@@ -375,7 +376,7 @@ File & app
 - `Ctrl+O` open · `Ctrl+S` save · `Ctrl+Shift+S` save as · `Ctrl+X` screenshot · `F11` fullscreen · `ESC` close window · `F1` help
 
 Navigation
-- `Tab` switch arcball ↔ first-person · `R` reset view · `←` / `→` step to previous / next camera pose
+- `Tab` switch arcball ↔ first-person · `R` reset view · `←` / `→` step to previous / next camera pose · `[` / `]` previous / next active layer
 
 Display toggles
 - `P` point cloud · `M` mesh · `C` cameras · `W` wireframe · `T` textured · `B` bounding box
@@ -388,6 +389,8 @@ Tools
 
 #### Headline features
 
+- **Multi-scene layers.** Several scenes or geometry files can be loaded at the same time as independent layers (`-l` on the command line, `Ctrl+O` or drag-and-drop) with per-layer visibility, solo, active selection and appearance controls in the *View ▸ Layers* panel; `[` / `]` cycle the active layer, on which the in-GUI pipeline and all editing tools operate.
+- **Side-by-side compare.** The Layers panel places each layer on side A or B of a vertical divider, in one of two modes: *Swipe* renders both sides with the same full-window camera separated by a draggable divider, so aligned scenes match pixel-exact across it, while *Split* shows two equal viewports with each scene centered in its own frustum. Camera movement is synchronized between the two sides by default; uncheck *Sync Cameras* to adjust each viewport's camera individually with the mouse over it. *Align to Active* moves every other layer onto the active one with a similarity transform estimated from cameras shared between the scenes (matched by photo file name, then by preserved SfM image ID; at least 3 shared cameras are required).
 - **ROI editing.** Press `Shift+B` to overlay an interactive oriented bounding box on the scene; drag the corner, face or rotation handles to define the region that subsequent pipeline stages will focus on. ROI can also be auto-estimated from the scene (`Ctrl+B`) or loaded from a file.
 - **Camera trajectory colouring.** Camera frustums are coloured along a Jet colormap according to their index in the capture sequence — blue at the start, red at the end — making it easy to spot loop closures, gaps or ordering issues. Cameras can be rendered as full frustums or as simple dots; the currently selected camera and its neighbours are highlighted distinctly.
 - **Camera-pose navigation.** The left / right arrow keys step through the scene's registered views; `Shift+Q` pins a panel showing the selected camera's intrinsics and extrinsics.

--- a/libs/Common/Config.h
+++ b/libs/Common/Config.h
@@ -281,6 +281,15 @@ __inline__ static void trap_instruction() { __asm__ volatile("brk #0"); }
 #define _ASSERT_BREAK() DEBUG_BREAK()
 #endif
 
+// Make every assertion visible to MSVC Code Analysis. _Analysis_assume_ is a
+// no-op outside analysis and does not pass assumptions to the optimizer.
+#ifdef _MSC_VER
+#include <sal.h>
+#define ASSERT_ANALYSIS_ASSUME(exp) _Analysis_assume_(exp)
+#else
+#define ASSERT_ANALYSIS_ASSUME(exp)
+#endif
+
 #ifdef _DEBUG
 
 #ifdef _MSC_VER
@@ -290,15 +299,15 @@ __inline__ static void trap_instruction() { __asm__ volatile("brk #0"); }
 #include <crtdbg.h>
 #ifdef _INC_CRTDBG
 #ifdef _HEADLESS_DEBUG
-#define SIMPLE_ASSERT(exp) {if (!(exp)) PRINT_ASSERT_MSG(exp);}
-#define ASSERT(exp, ...) {if (!(exp)) PRINT_ASSERT_MSG(exp, ##__VA_ARGS__);}
+#define SIMPLE_ASSERT(exp) {if (!(exp)) PRINT_ASSERT_MSG(exp); ASSERT_ANALYSIS_ASSUME(exp);}
+#define ASSERT(exp, ...) {if (!(exp)) PRINT_ASSERT_MSG(exp, ##__VA_ARGS__); ASSERT_ANALYSIS_ASSUME(exp);}
 #else
-#define SIMPLE_ASSERT(exp) {if (!(exp) && 1 == _CrtDbgReport(_CRT_ASSERT, __FILE__, __LINE__, NULL, #exp)) _CrtDbgBreak();}
-#define ASSERT(exp, ...) {static bool bIgnore(false); if (!bIgnore && !(exp)) {PRINT_ASSERT_MSG(exp, ##__VA_ARGS__); if (!(bIgnore = !(1 == _CrtDbgReport(_CRT_ASSERT, __FILE__, __LINE__, NULL, #exp)))) _CrtDbgBreak();}}
+#define SIMPLE_ASSERT(exp) {if (!(exp) && 1 == _CrtDbgReport(_CRT_ASSERT, __FILE__, __LINE__, NULL, #exp)) _CrtDbgBreak(); ASSERT_ANALYSIS_ASSUME(exp);}
+#define ASSERT(exp, ...) {static bool bIgnore(false); if (!bIgnore && !(exp)) {PRINT_ASSERT_MSG(exp, ##__VA_ARGS__); if (!(bIgnore = !(1 == _CrtDbgReport(_CRT_ASSERT, __FILE__, __LINE__, NULL, #exp)))) _CrtDbgBreak();} ASSERT_ANALYSIS_ASSUME(exp);}
 #endif
 #else
-#define SIMPLE_ASSERT(exp) {if (!(exp)) _ASSERT_BREAK();}
-#define ASSERT(exp, ...) {if (!(exp)) {PRINT_ASSERT_MSG(exp, ##__VA_ARGS__); _ASSERT_BREAK();}}
+#define SIMPLE_ASSERT(exp) {if (!(exp)) _ASSERT_BREAK(); ASSERT_ANALYSIS_ASSUME(exp);}
+#define ASSERT(exp, ...) {if (!(exp)) {PRINT_ASSERT_MSG(exp, ##__VA_ARGS__); _ASSERT_BREAK();} ASSERT_ANALYSIS_ASSUME(exp);}
 #endif // _INC_CRTDBG
 #define TRACE(...) {TCHAR buffer[2048]; _sntprintf(buffer, 2048, __VA_ARGS__); OutputDebugString(buffer);}
 #elif defined(__CUDA_ARCH__)
@@ -322,12 +331,12 @@ __inline__ static void trap_instruction() { __asm__ volatile("brk #0"); }
 #else
 
 #ifdef _RELEASE
-#define SIMPLE_ASSERT(exp)
-#define ASSERT(exp, ...)
+#define SIMPLE_ASSERT(exp) ASSERT_ANALYSIS_ASSUME(exp)
+#define ASSERT(exp, ...) ASSERT_ANALYSIS_ASSUME(exp)
 #else
 #ifdef _MSC_VER
-#define SIMPLE_ASSERT(exp) {if (!(exp)) __debugbreak();}
-#define ASSERT(exp, ...) {if (!(exp)) {PRINT_ASSERT_MSG(exp, ##__VA_ARGS__); __debugbreak();}}
+#define SIMPLE_ASSERT(exp) {if (!(exp)) __debugbreak(); ASSERT_ANALYSIS_ASSUME(exp);}
+#define ASSERT(exp, ...) {if (!(exp)) {PRINT_ASSERT_MSG(exp, ##__VA_ARGS__); __debugbreak();} ASSERT_ANALYSIS_ASSUME(exp);}
 #else // _MSC_VER
 #define SIMPLE_ASSERT(exp) {if (!(exp)) __builtin_trap();}
 #define ASSERT(exp, ...) {if (!(exp)) {PRINT_ASSERT_MSG(exp, ##__VA_ARGS__); __builtin_trap();}}

--- a/libs/Common/Util.cpp
+++ b/libs/Common/Util.cpp
@@ -19,6 +19,7 @@
 #else
 #include <sys/utsname.h>
 #ifdef __APPLE__
+#include <mach/mach.h>
 #include <sys/sysctl.h>
 #else
 #include <sys/sysinfo.h>
@@ -770,7 +771,6 @@ void Util::LogMemoryInfo()
 	LOG(_T("} ENDINFO"));
 }
 #elif defined(__APPLE__) // _MSC_VER
-#include <mach/mach.h>
 void Util::LogMemoryInfo()
 {
 	// macOS (Intel and Apple Silicon) has no procfs; ask the Mach kernel for
@@ -829,19 +829,31 @@ Util::MemoryInfo Util::GetMemoryInfo()
 
 	#elif defined(__APPLE__)                // mac
 
-	int mib[2] ={CTL_HW, HW_MEMSIZE};
-	size_t len = sizeof(size_t);
-	size_t totalMemory;
-	if (sysctl(mib, 2, &totalMemory, &len, NULL, 0) < 0) {
-		ASSERT(false);
-		return MemoryInfo();
+	size_t totalMemory = 0;
+	size_t len = sizeof(totalMemory);
+	int mib[2] = {CTL_HW, HW_MEMSIZE};
+	if (sysctl(mib, 2, &totalMemory, &len, NULL, 0) < 0)
+		totalMemory = 0;
+	const mach_port_t host(mach_host_self());
+	if (totalMemory == 0) {
+		host_basic_info_data_t hostInfo;
+		mach_msg_type_number_t hostInfoCount(HOST_BASIC_INFO_COUNT);
+		if (host_info(host, HOST_BASIC_INFO, reinterpret_cast<host_info_t>(&hostInfo), &hostInfoCount) == KERN_SUCCESS)
+			totalMemory = (size_t)hostInfo.max_mem;
 	}
-	mib[1] = HW_USERMEM;
-    size_t freeMemory;
-    if (sysctl(mib, 2, &freeMemory, &len, NULL, 0) == -1) {
-		ASSERT(false);
-        return MemoryInfo();
-    }
+
+	size_t freeMemory = 0;
+	vm_size_t pageSize = 0;
+	vm_statistics64_data_t vmStats;
+	mach_msg_type_number_t vmStatsCount(HOST_VM_INFO64_COUNT);
+	if (host_page_size(host, &pageSize) == KERN_SUCCESS &&
+		host_statistics64(host, HOST_VM_INFO64, reinterpret_cast<host_info64_t>(&vmStats), &vmStatsCount) == KERN_SUCCESS) {
+		const uint64_t availablePages =
+			(uint64_t)vmStats.free_count + vmStats.inactive_count + vmStats.speculative_count;
+		const uint64_t availableMemory = availablePages * (uint64_t)pageSize;
+		freeMemory = (size_t)(totalMemory > 0 ? MINF(availableMemory, (uint64_t)totalMemory) : availableMemory);
+	}
+	mach_port_deallocate(mach_task_self(), host);
 	return MemoryInfo(totalMemory, freeMemory);
 
 	#else // __GNUC__                       // linux

--- a/libs/MVS/CMakeLists.txt
+++ b/libs/MVS/CMakeLists.txt
@@ -65,11 +65,12 @@ if(_USE_METAL)
 endif()
 
 # MSVC scalpel: Camera.cpp and Scene.cpp drag in a template graph (CGAL/Eigen/OpenCV)
-# that lands MSVC's optimizer in a pathological codegen path. Camera.cpp takes ~3 min
-# and Scene.cpp ~10 min under /O2 at this template depth.
+# that can land MSVC's optimizer in a pathological codegen path and take hours on
+# constrained builders.
 #
 # Policy:
-#   * Release       — full /O2 (no override). Long compile accepted; see warning below.
+#   * Release       — full /O2 by default. OpenMVS_MSVC_FAST_RELEASE opts these two
+#                     files into /Od for constrained builders such as hosted CI.
 #   * RelWithDebInfo/Debug — /Od for just these two files, keeping dev builds under 30 min.
 #
 # Implementation notes:
@@ -84,19 +85,21 @@ if(MSVC)
 		"${CMAKE_CURRENT_SOURCE_DIR}/Camera.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Scene.cpp"
 		PROPERTIES
-			COMPILE_OPTIONS "$<$<NOT:$<CONFIG:Release>>:/Od>"
+			COMPILE_OPTIONS "$<$<OR:$<BOOL:${OpenMVS_MSVC_FAST_RELEASE}>,$<NOT:$<CONFIG:Release>>>:/Od>"
 			SKIP_PRECOMPILE_HEADERS ON
 	)
-	message(WARNING "MVS build speed notice:\n"
-	        "  * Release builds compile Camera.cpp and Scene.cpp at full /O2. These two\n"
-	        "    files alone can add 10-20 min to Release wall time due to heavy\n"
-	        "    CGAL/Eigen/OpenCV template instantiation.\n"
-	        "  * RelWithDebInfo (and Debug) use /Od for just these two files to keep\n"
-	        "    dev-iteration builds under ~30 min; the rest of the project stays at /O2.\n"
-	        "  * To speed up Release at the cost of slightly-less-optimized Camera/Scene,\n"
-	        "    edit libs/MVS/CMakeLists.txt and change the COMPILE_OPTIONS line to:\n"
-	        "        COMPILE_OPTIONS \"/Od\"\n"
-	        "    (remove the $<NOT:$<CONFIG:Release>> generator expression).")
+	if(OpenMVS_MSVC_FAST_RELEASE)
+		message(STATUS "OpenMVS_MSVC_FAST_RELEASE: compiling MVS Camera.cpp and Scene.cpp with /Od")
+	else()
+		message(WARNING "MVS build speed notice:\n"
+		        "  * Release builds compile Camera.cpp and Scene.cpp at full /O2. These two\n"
+		        "    files can dominate Release wall time due to heavy CGAL/Eigen/OpenCV\n"
+		        "    template instantiation.\n"
+		        "  * RelWithDebInfo (and Debug) use /Od for just these two files to keep\n"
+		        "    dev iteration fast; the rest of the project stays at /O2.\n"
+		        "  * To speed up Release at the cost of less-optimized Camera.cpp/Scene.cpp,\n"
+		        "    configure with -DOpenMVS_MSVC_FAST_RELEASE=ON.")
+	endif()
 endif()
 
 # Manually set Common.h as the precompiled header


### PR DESCRIPTION
- Added support for multi-scene layers, allowing multiple scenes or geometry files to be loaded as independent layers.
- Introduced compare view functionality with two modes: swipe (shared full-window projection with draggable divider) and split (two equal viewports).
- Implemented camera synchronization options for compare view, enabling independent camera control for each side.
- Enhanced user interface with a Layers panel for managing layer visibility, active selection, and appearance controls.
- Updated input handling to support layer navigation and compare view interactions.
- Improved rendering logic to accommodate new compare view features, ensuring consistent camera behavior and layer rendering.
- Updated documentation to reflect new features and usage instructions for multi-scene layers and compare view.