### PR TITLE
RefineMesh: one measurement for face size, decimation on by default, and the campaign's instrumentation removed

### DIFF
--- a/apps/RefineMesh/RefineMesh.cpp
+++ b/apps/RefineMesh/RefineMesh.cpp
@@ -229,8 +229,8 @@ bool Application::Initialize(size_t argc, LPCTSTR* argv)
 	}
 	if (bValidRefineConfig) {
 		// SML keeps every key it reads, registered or not, and update() only ever reads the
-		// registered ones -- so a misspelled knob would run the default and measure it as the
-		// arm; a key nobody registered has no declared values
+		// registered ones, so a misspelled knob would silently run the default; a key nobody
+		// registered has no declared values
 		String unknown;
 		for (const auto& item: OPTREFINE::oConfig.GetConfig())
 			if (((const CFGITEM*)item.second.data)->vals.IsEmpty())

--- a/apps/RefineMesh/RefineMesh.cpp
+++ b/apps/RefineMesh/RefineMesh.cpp
@@ -205,11 +205,11 @@ bool Application::Initialize(size_t argc, LPCTSTR* argv)
 	const bool bRefineConfigPresent(!OPT::strRefineConfigFileName.empty() && File::isFile(OPT::strRefineConfigFileName));
 	const bool bValidRefineConfig(OPTREFINE::oConfig.Load(OPT::strRefineConfigFileName));
 	OPTREFINE::update();
-	// the CLI (this app's own .cfg file included) always wins over the refine-config-file, same as
-	// DensifyPointCloud's --ignore-mask-label over its --dense-config-file
-	OPTREFINE::nIgnoreMaskLabel = nIgnoreMaskLabel;
-	// an option with a CLI default of its own overrides the refine-config-file only when it was
-	// actually given, or the default silently undoes what the file set
+	// an option with a CLI default of its own (this app's own .cfg file included) overrides the
+	// refine-config-file only when it was actually given, or the default silently undoes what the
+	// file set
+	if (!OPT::vm["ignore-mask-label"].defaulted())
+		OPTREFINE::nIgnoreMaskLabel = nIgnoreMaskLabel;
 	if (!OPT::vm["simplify-tolerance"].defaulted())
 		OPTREFINE::fSimplifyTolerance = OPT::fSimplifyTolerance;
 	if (!OPT::vm["adaptive-face-size"].defaulted())

--- a/apps/Tests/TestsMVS.cpp
+++ b/apps/Tests/TestsMVS.cpp
@@ -1344,8 +1344,8 @@ static bool RefineStepAlternatingTest()
 // BeginSecondPhase(): a caller starting the second phase of a scale gets a fresh stall count,
 // not one the first phase's tail already primed to STOP after a single evaluation -- but the
 // consecutive-reject streak carries over, so a phase that starts right where the first one gave
-// up on its rejections keeps giving up immediately (resetting the streak too measured -0.0048
-// mean F1 on the T&T set); the budget it returns is 3/7 of the accepted count, never below 3
+// up on its rejections keeps giving up immediately; the budget it returns is 3/7 of the accepted
+// count, never below 3
 static bool RefineStepSecondPhaseTest()
 {
 	typedef MeshRefineStep::GradArr GradArr;

--- a/docs/design/MeshRefinement.md
+++ b/docs/design/MeshRefinement.md
@@ -244,11 +244,12 @@ does, per pixel of A:
    to 0 for a vertex none saw (`footprint[v] > 0` iff `photoGradNorm[v] > 0` on both backends). On
    CPU this merge happens per-pair under a lock at the end of `ThProcessPair`, so summation order —
    and the float result — is not reproducible run to run unless `--max-threads 1`. On CUDA it is
-   **deterministic**: `kernelAccumulateFacePhoto` is face-parallel — one thread per mesh face walks
-   its clipped bounding box in fixed scan order, folding the per-pixel terms the window-statistics
-   kernel left behind (weighted by the barycentrics), the pixel count and the footprint minimum
-   into the face's private slots, which accumulate across the evaluation's pair-directions, no
-   atomics; `kernelCountSeenVertices` absorbs the `photoGradNorm += 1` per direction; and once per
+   **deterministic**: `kernelAccumulateFacePhoto` is face-parallel — one thread per face the
+   reference view owns walks its clipped bounding box in fixed scan order, folding the per-pixel
+   terms the window-statistics kernel left behind (weighted by the barycentrics), the pixel count
+   and the footprint minimum into the face's private slots, which accumulate across the
+   evaluation's pair-directions, no atomics, and counts the direction once per vertex through a
+   per-vertex direction stamp (the `photoGradNorm += 1` per direction); and once per
    evaluation `kernelGatherVertexPhoto` is vertex-parallel, walking each vertex's flattened
    incident-face list (`Mesh::ListIncidentFaces` order) to sum the contribution and resolve the
    sentinel exactly like the CPU's post-loop pass. `photoGrad[v]/photoGradNorm[v]` — the pair-count
@@ -326,177 +327,113 @@ at a boundary neighbour, back-face winding) and was removed from the tree once t
 
 #### 1.6.1 What one CUDA evaluation does, and where its time goes
 
-`MeshRefineCUDA::ScoreMesh` issues everything on the default stream and makes one host round trip,
-at the end: the vertex upload and the rasterization of the whole mesh into every view
-(`kernelProjectMesh` x2 per view, no host frustum cull — see the table above); the face normals and
-both smoothness terms (`kernelComputeFaceNormal`, `kernelComputeSmoothnessGradient` x2, which need
-only the vertices and so run while the host is still issuing the pairs); per pair-direction the
-warp (`kernelImageMeshWarp`), the window statistics with the pixel's photometric term
-(`kernelComputeWindowStats`), the per-face accumulation into slots that persist across the
-directions (`kernelAccumulateFacePhoto`) and the per-vertex direction count
-(`kernelCountSeenVertices`); then one reduction of every direction's block partials into `S`
-(`kernelReduceBlockSums`), one per-vertex gather (`kernelGatherVertexPhoto`) and ONE download of
-all per-vertex terms into a pinned host buffer the stepper reads in place. The stepper and the next
-vertex upload are the only host work between two evaluations.
+`MeshRefineCUDA::ScoreMesh` makes two host round trips, one after the rasterization and one at the
+end:
 
-Measured with Nsight Systems on Herz-Jesu-P8 (RTX 4070, level 1, 8 views, 27 pairs = 54
-pair-directions per evaluation, 81k/157k faces at the two scales), before and after the rework:
+1. The vertex upload and the rasterization of the whole mesh into every view (`kernelProjectMesh`
+   x2 per view, no host frustum cull — see the table above); the second pass also leaves, per view,
+   one *owner bit* per face (a warp ballot), set iff the face wrote a pixel there.
+2. The owner bits packed into dense per-view *owner lists* (`kernelCountOwners`,
+   `kernelScanViewCounts`, `kernelCompactOwners`), each view's slice then counting-sorted by the
+   64x8-pixel image tile the face's clipped box starts in (`kernelSortOwnersTile`). The views'
+   offsets come down here — the one synchronization before the terms — and the list is kept at
+   the largest total so far.
+3. The face normals and both smoothness terms (`kernelComputeFaceNormal`,
+   `kernelComputeSmoothnessGradient` x2), which need only the vertices.
+4. Per pair-direction: the warp (`kernelImageMeshWarp`); the window statistics with the pixel's
+   photometric term (`kernelComputeWindowStats`, one thread per pixel, the block's 22x22 tile
+   staged in shared memory, a tile without a masked sample leaving at once); and the accumulation
+   (`kernelAccumulateFacePhoto`): one thread per face the reference view owns walks the face's
+   clipped box in row chunks, folds its pixels' terms weighted by the barycentrics — recomputed
+   with the rasterizer's own `pixelBary`, bit for bit — into the face's private slots, which
+   persist across the directions, and counts the direction once per vertex through a per-vertex
+   direction stamp (`atomicExch`; an integer count, so reproducible).
+5. One reduction of every direction's block partials into `S` (`kernelReduceBlockSums`), one
+   per-vertex gather over the fixed incident-face order (`kernelGatherVertexPhoto`), and ONE
+   download of all per-vertex terms into a pinned host buffer the stepper reads in place.
 
-| per evaluation | before | after |
+Steps 4 and 5 are thousands of launches whose every argument is a constant of the scale (the
+accumulation reads its view's slice offsets on the device and strides over a grid sized at the
+recording), so they are recorded once per scale — per parity when the pairs alternate — into a CUDA
+graph by stream capture and replayed by one `cudaGraphLaunch` per evaluation (Ignatius: 533
+launches and one graph per evaluation against 11,974 issued one by one, at ~10 us each under
+WDDM, as much as the coarse scale's GPU time). The graphs are dropped when a buffer they
+reference moves (a new scale, a grown list); if a recording fails the directions are issued one
+by one. The rasterization, compaction and memsets stay eager ahead of the graph, the terms
+download behind it. Between two evaluations the host does only the stepper and the next vertex
+upload; the next scale's images are prepared on a thread while the current scale runs
+(`PrefetchImages`, its OpenMP team capped at half the cores so it does not starve the thread
+feeding the GPU), so a scale switch pays only the upload.
+
+Why it is shaped this way:
+
+- **No atomics, fixed orders.** Float addition is not associative, and an `atomicAdd` scatter
+  gives a different per-vertex gradient on every run. Every float sum has one writer and a fixed
+  order: a face reduces its own pixels in raster order, the slots accumulate in launch order, the
+  gather walks `Mesh::ListIncidentFaces`' order, `S` is folded from per-block partials in slot
+  order. The list order and the tile sort never touch the result.
+- **Owner bits and lists.** In a scene of hundreds of views any one view sees a fraction of the
+  mesh, so a face-parallel kernel over the whole mesh per direction is O(faces x views) of early
+  exits that leave the warps nearly empty (Nsight Compute on the accumulation: 4.4 active lanes
+  per warp-instruction, two thirds of the cycles waiting on scattered loads). One thread per owner
+  face, in tile order so that a warp's 32 boxes share cache lines (L1 hit rate 52 -> 78 %), and
+  the box rows loaded in chunks so that a chunk's loads are in flight together, took the
+  accumulation from 139 to 35 us per direction at scale 1 on Ignatius.
+- **No barycentric map.** Barycentrics and depth are recomputed from the face's projection where
+  they are needed, in float like the CPU's `BaryMap`, instead of a half-precision map per pixel of
+  every view: 21 bytes per pixel per view (float image 4, its two gradient textures 8, depth 4,
+  face 4, a keep-mask byte when masks are used) instead of 29.
+- **Projected face areas on the GPU.** The preparation's `ListFaceAreas` counts pixels per face
+  per view (`kernelFaceHistogram`, integer atomics, exact) and folds each pair's min into the max
+  over the pairs (`kernelReduceFaceAreasPair`), the pairs walked grouped by their first view; only
+  the reduced `uint16_t` areas come down, truncated exactly like the host's counters, and a Debug
+  build recomputes the host path and asserts equality on every face. A Debug build also checks
+  the rasterizer's payloads against the keys, and the owner lists against the bits, on every
+  evaluation.
+
+Measured with Nsight Systems on Ignatius at level 1 (263 views of 960x540, 1,430 pairs = 2,860
+pair-directions per evaluation, 125k/281k faces at the two scales), the first CUDA build of this
+branch against the shipped one:
+
+| per evaluation, Ignatius level 1 | first build | shipped |
 |---|---|---|
-| scale 0: GPU span / host gap to the next evaluation | 13.5 ms / 6 ms | 8 ms / 1.2 ms |
-| scale 1: GPU span / host gap to the next evaluation | 39 ms / 11 ms | 23 ms / 2.3 ms |
-| GPU idle inside the span | 5-12 % | 1.5-4.5 % |
-| `kernelAccumulateFacePhoto`, scale 1 | 409 us | 191 us |
-| `kernelComputeWindowStats`, scale 1 (now also the photometric term) | 105 us | 127 us |
-| per-vertex gather | 54 x 46 us | 1 x 61 us |
-| kernel launches / D2H copies / `cuMemFree` per run | 14,870 / 397 / 549 | 11,930 / 90 / 89 |
-| refinement loop, both scales | 1.95 s (51 evaluations) | 1.10 s (50) |
-| `RefineMesh` wall | 8.1 s | 6.9 s |
+| GPU kernels, scale 0 / scale 1 | 276 / 638 ms | 102 / 246 ms |
+| host gap to the next evaluation, scale 0 / scale 1 | 70 / 135 ms | 2-6 / 3-7 ms |
+| `kernelAccumulateFacePhoto`, scale 0 / scale 1 | 55 / 139 us | 15 / 35 us |
+| `kernelComputeWindowStats`, scale 0 / scale 1 | 10 / 24 us | 11 / 25 us |
+| D2H copies per run | 1,351 / 1.68 GB | 41 / 188 MB |
+| scale switch (host image preparation + upload) | 1.17 s + 0.47 s | 0.01 s + 0.44 s |
+| device memory per view | 29 B/px | 21 B/px |
 
-The host gap used to be an octree over the mesh rebuilt for every evaluation to frustum-cull a face
-list per view, plus that list's allocation, upload and free (a `cuMemFree` is an implicit device
-sync), plus five pageable downloads; what is left is the stepper. The largest kernel used to
-compute the photometric term itself, one thread walking every pixel of its face, so a warp waited
-for its largest face; the term now comes from the per-pixel window-statistics kernel and the face
-kernel only weights it by the barycentrics. A cooperating-lanes variant of that kernel (8 lanes per
-face, shuffle-tree reduction, a fixed pixel-to-lane mapping) measured 201 us against the 191 us
-above: the kernel is bound by its scattered face-map/mask/barycentric reads, not by divergence, so
-the simpler one stays. What remains of the 6.9 s is the host-side mesh preparation (§2.10),
-identical on both backends, which is why the end-to-end CPU/CUDA ratio on these small scenes stays
-near 3.5x while the refinement loop alone runs about 15x faster than the CPU's 0.33 s per
-evaluation.
+Walls back to back in one machine state: Ignatius 72.5 s -> 34.5 s, Truck, Barn and Meetingroom
+2.1-2.7x (§2.2); the owner lists and the graph then took another 8-15 % off the four (Ignatius
+35.3 -> 32.3 s), and the host-side mesh preparation shared with the CPU path is now most of what
+is left (Barn: 38 s of 81 s). On Herz-Jesu-P8 (8 views, 54 pair-directions), where none of the
+many-view machinery matters, the refinement loop takes 1.1 s for 50 evaluations and the wall
+6.9 s, 5.4 s of it that preparation: the end-to-end CPU/CUDA ratio on small scenes stays near 3x
+while the loop alone runs about 15x faster than the CPU's 0.33 s per evaluation. What is left of
+a scale-1 evaluation on Ignatius is 246 ms of kernels (accumulation 42 %, window statistics
+29 %, rasterization 19 %, warp 8 %), ~24 ms of host stepper and ~10 ms of transfers, memsets and
+graph launch.
 
-**The many-view regime.** Herz-Jesu-P8 has 8 views and 54 pair-directions per evaluation. A
-Tanks and Temples scene at level 1 has hundreds of small views — Ignatius: 263 views of 960x540,
-1,430 pairs = 2,860 pair-directions per evaluation, 125k/281k faces at the two scales — and there
-every face-parallel kernel is O(faces x views) while any one view sees a fraction of the mesh, and
-everything that touches every view once per scale (image loading, the preparation's projected
-areas) is hundreds of times larger. Measured the same way on Ignatius, per evaluation:
+Measured and rejected, all on Ignatius at level 1: a host-side frustum cull shortlisting the faces
+per view (an octree over the mesh rebuilt for every evaluation cost more host time than the
+rasterizer's early exits cost on the GPU, and the per-view face lists were uploads, allocations
+and frees the GPU waited on); eight lanes sharing a face in the accumulation, each taking every
+eighth pixel of the box with a fixed shuffle tree over the partials (49 / 88 us against 26 / 64
+us at the time: on the small boxes most lanes idle, and the extra threads cost more than the
+divergence they remove); a launch bound forcing the accumulation to 64 registers from 71 (spills,
+2 ms slower per evaluation); 128x16 tiles for the owner sort (1.4-2.6 % slower than 64x8); a
+per-reference-view barycentric scratch (unnecessary once the lists were dense); and a per-pair
+octree or BVH preselection of faces, which would only duplicate what the rasterizer's owner bits
+already give exactly, occlusion included, at 1-2 ms per evaluation.
 
-| per evaluation, Ignatius level 1 | before the rework | after the rework above | many-view rework |
-|---|---|---|---|
-| scale 0: GPU kernels / host gap to the next evaluation | 276 ms / 70 ms | 157 ms / 2-6 ms | 138 ms / 2-6 ms |
-| scale 1: GPU kernels / host gap to the next evaluation | 638 ms / 135 ms | 326 ms / 3-7 ms | 327 ms / 3-7 ms |
-| `kernelAccumulateFacePhoto`, scale 0 / scale 1 | 55 / 139 us | 32 / 61 us | 26 / 64 us |
-| `kernelComputeWindowStats`, scale 0 / scale 1 | 10 / 24 us | 11 / 28 us | 11 / 25 us |
-| D2H copies per run | — | 1,351 / 1.68 GB | 41 / 188 MB |
-| scale switch (host image preparation + upload) | — | 1.17 s + 0.47 s | 0.01 s + 0.44 s |
-| device memory per view | 29 B/px | 29 B/px | 21 B/px |
-| `RefineMesh` wall, 36 evaluations, back to back | 72.5 s | — | 34.5 s |
-
-The many-view rework, all of it in `SceneRefineCUDA.{cpp,cu,inl}`:
-
-- **Owner bits.** The rasterizer's second pass leaves, per view, one bit per face set iff the face
-  wrote a pixel (a warp ballot, no atomics, every word written so nothing is cleared), and the
-  accumulation exits on the bit before reading the face — behind the camera, off the image,
-  back-facing or occluded, most of the mesh for any one view. That is the scale-0 gain; at scale 1
-  it is spent again by the next item.
-- **No barycentric map.** The per-pixel `ushort4` of half barycentrics (8 of the 29 bytes every
-  view held per pixel) is gone: the accumulation recomputes barycentrics and depth from the face's
-  projection with the same `pixelBary` call the rasterizer keyed the pixel with, so they are the
-  rasterizer's bit for bit — in float, as the CPU's `BaryMap` keeps them, where the half map was a
-  deviation from the CPU (Herz-Jesu-P8 CUDA F1 moved from 0.45216 to 0.45110 against the CPU's
-  0.45111, §2.2). The recomputation is ~70 instructions per kept pixel, issued once per
-  bounding-box step for however few lanes of a warp keep a pixel there, which is what keeps the
-  scale-1 kernel at 64 us. Eight lanes sharing a face (each taking every eighth pixel of the box,
-  a fixed shuffle tree over the partials) measured 49 / 88 us against 26 / 64 us and was rejected:
-  on the small boxes most lanes idle and the extra threads cost more than the divergence they
-  remove. If that kernel has to go faster, the way is a per-reference-view `float4` (bary, depth)
-  scratch written once per view from the owner faces, with the pair-directions walked grouped by
-  reference view — one view's map resident instead of every view's.
-- **Projected face areas on the GPU.** The preparation's `ListFaceAreas` used to download every
-  view's face map (263 x 2.1 MB pageable per projection, 1.68 GB per run) and count pixels per
-  face on the host, then min over the pair and max over the pairs on the host too (1,430 pairs x
-  every face). Now `kernelFaceHistogram` counts per view (integer atomics, exact) and
-  `kernelReduceFaceAreasPair` folds each pair, the pairs walked grouped by their first view so its
-  histogram is built once; only the reduced `uint16_t` areas come down, truncated exactly like the
-  host's counters, and a Debug build recomputes the host path and asserts equality on every face.
-  The input mesh's projection went from 3.1 s to 1.9 s of which the remaining part is the host's
-  sampled analytic area (`SampleSeenFaceArea`), shared with the CPU.
-- **The next scale's images on a thread.** `PrefetchImages` starts `PrepareImages` for the next
-  scale (load, gray, blur, resize, gradient stencil, keep-mask, on a copy of each `Image`, since
-  `PrepareRefineImage` sets the working size and camera on the `Image` it is given) as soon as
-  the current scale's are uploaded; the switch joins it and pays only the upload. The thread's
-  OpenMP team is capped at half the cores: a full team alongside the refinement of the current
-  scale starved the thread feeding the GPU of its time slices (100-800 ms host gaps between
-  evaluations on 24 logical CPUs).
-- **Empty tiles.** A window-statistics block whose 22x22 tile holds no masked sample writes its
-  zeros and leaves before the window loops (`__syncthreads_or`): most tiles, in a scene where each
-  image sees a small part of the surface.
-
-What is left per evaluation is the kernels themselves (85 % GPU-busy across the refinement window,
-host gaps of 2-7 ms), and per run the host-side mesh preparation. The end-to-end walls against
-the previous CUDA build, same machine state, are in §2.2.
-
-**The accumulation over owner lists, and the evaluation as a graph (round 3).** Nsight Compute
-on `kernelAccumulateFacePhoto` after the many-view rework (Ignatius level 1, 24 launches per
-scale, `--set full`) said what the timelines could not: 4.4 active lanes per warp-instruction, 13
-of 20 warp cycles per instruction waiting on the scattered face-map/mask/term loads, compute at
-27 % and memory at 37 % of peak. The early exit on the owner bit left the warps that reached the
-pixel loop nearly empty, and every lane's box was somewhere else in the image. The
-per-reference-view scratch the previous paragraph proposed was not needed:
-
-- **Owner lists.** The bits are packed once per evaluation into dense per-view lists —
-  `kernelCountOwners` popcounts each view's words, `kernelScanViewCounts` turns the counts into
-  the views' offsets into one packed list (the offsets come down in the evaluation's one
-  synchronization before the terms, on the rasterization every direction needs anyway), and
-  `kernelCompactOwners` writes the face ids. The accumulation runs one thread per owner face of
-  its reference view: 9.4 / 7.7 lanes, 2.3x fewer instructions issued, 26 / 64 us -> 20 / 48 us
-  at scale 0 / 1. The list order is irrelevant to the result: a face still folds its own pixels in
-  raster order into its own slot, and the fold order across directions is the launch order.
-- **Row chunks.** The box is walked in chunks of four pixels whose face ids, mask bytes and terms
-  are loaded together, so a chunk's loads are in flight at once (the SASS confirms twelve
-  back-to-back predicated loads); 20 / 48 -> 19 / 44 us. The pixels are still folded in raster
-  order.
-- **Tile order.** `kernelSortOwnersTile` reorders each view's slice by the 64x8-pixel image tile
-  the face's clipped box starts in (a counting sort in shared memory; the projection is the
-  accumulation's own; the order within a tile is the atomics' and does not matter), so a warp's
-  32 boxes share cache lines: L1 hit rate 52 -> 78 %, 11-13 lanes; 19 / 44 -> 15 / 35 us for
-  1.1 / 2.1 ms of sorting per evaluation. 128x16 tiles measured 1.4-2.6 % slower per evaluation.
-- **One launch in four gone.** `kernelCountSeenVertices` is folded into the accumulation: a
-  per-vertex direction stamp, `atomicExch` handing exactly one of the vertex's contributing faces
-  the previous stamp, counts the direction once — an integer count, so still reproducible.
-- **The evaluation as a CUDA graph.** With the kernels shrunk, the host was the ceiling at the
-  coarse scale: 9,115 launches at ~10 us each under WDDM, 98 ms of launch API per evaluation for
-  103 ms of kernels. Every argument of the direction loop is a constant of the scale — the
-  accumulation reads its view's slice offsets on the device and strides over a grid sized at the
-  recording — so the loop, the reduction and the gather are recorded once per scale (per parity
-  when the pairs alternate) with stream capture and replayed by one `cudaGraphLaunch` per
-  evaluation: 40 ms to instantiate, ~11 ms of host time per launch. The rasterization,
-  compaction and memsets stay eager on the legacy stream ahead of it, the terms download behind
-  it. If the recording fails the directions are issued one by one as before.
-
-Measured the same way (Ignatius level 1, per evaluation, nsys; the graph's kernels are read from a
-node-level trace, the spans from an untraced one):
-
-| per evaluation, Ignatius level 1 | many-view rework | round 3 |
-|---|---|---|
-| `kernelAccumulateFacePhoto`, scale 0 / scale 1 | 26 / 64 us | 15 / 35 us |
-| GPU kernels, scale 0 / scale 1 | 138 / 327 ms | 102 / 246 ms |
-| kernel launches per evaluation (host) | 11,974 | 533 + 1 graph |
-| evaluation to evaluation (rasterization to rasterization), scale 0 / scale 1 | 160 / 420 ms | 109 / 295 ms |
-| host launch API per run | 9.5 s | 1.1 s |
-| `RefineMesh` wall, back to back, same machine state: Ignatius / Truck / Barn / Meetingroom | 35.3 / 41.5 / 90.1 / 80.4 s | 32.3 / 38.5 / 81.5 / 67.9 s |
-
-The output is byte-identical to the many-view build on Ignatius (36 evaluations), Truck, Barn and
-Meetingroom; the Debug synthetic test is unchanged (CUDA/CPU ratio 1.00027) and the Debug build
-checks the compaction against the bits and the sort against the compaction on every evaluation.
-What is left of a scale-1 evaluation is 246 ms of kernels (accumulation 42 %, window statistics
-29 %, rasterization 19 %, warp 8 %), ~24 ms of host stepper between evaluations (shared with the
-CPU path), and ~10 ms of transfers, memsets and graph launch. A launch bound forcing the
-accumulation to 64 registers (from 71) spilled and measured 2 ms slower per evaluation; a
-per-pair octree or BVH preselection of faces would only duplicate what the rasterizer's owner
-bits already give exactly, occlusion included, at 1-2 ms per evaluation.
-
-**Device memory is the next large-scene limit.** With the per-view footprint at 21 bytes per pixel
-(float image 4, its two gradient textures 8, depth 4, face 4, plus a keep-mask byte when masks
-are used), Ignatius at level 0 (263 views of 1920x1080 at the finest scale) needs about 11 GB and
-did not fit a 12 GB RTX 4070 before this rework either (15.8 GB at 29 B/px): the driver paged and
-a scale-1 evaluation went from 0.4 s to minutes. Courthouse (1,106 images) needs the same at level
-1. Beyond that point the design has to stream views — a resident working set of views, pinned host
-copies, the pair-directions ordered by view, a view re-rasterized when it comes back — which is
-a change of memory architecture, not of kernels.
+**Device memory is the next large-scene limit.** At 21 bytes per pixel per view, Ignatius at
+level 0 (263 views of 1920x1080 at the finest scale) needs about 11 GB and does not fit a 12 GB
+RTX 4070: the driver pages and a scale-1 evaluation goes from 0.3 s to minutes. Courthouse (1,106
+images) needs the same at level 1. Beyond that point the design has to stream views — a resident
+working set of views, pinned host copies, the pair-directions ordered by view, a view
+re-rasterized when it comes back — which is a change of memory architecture, not of kernels.
 
 ### 1.7 Optimization schedule
 
@@ -745,17 +682,16 @@ The evaluation counts no longer match exactly, so the surfaces are compared at s
 stopping points rather than at the same one; F1 tracks the iteration count closely enough (§2.4)
 that this accounts for the gap on its own. Before the GPU rework of §1.6.1 the CUDA build
 reproduced §2.10's shipped combination — the sizing field plus the tightest-pair decimation,
-measured there as an arm — to the fifth decimal (0.45312 / 0.34618); the two reworks moved it
-inside the band through the rasterizer's tie-break, the summation order and the float
-barycentrics the CPU also uses (0.45216 / 0.34638 after the first, the values above after the
-many-view one), so the gap is the CPU's own trajectory and not a regression. Walls are only
+measured there as an arm — to the fifth decimal (0.45312 / 0.34618); the rework moved it inside
+the band through the rasterizer's tie-break, the summation order and the float barycentrics the
+CPU also uses, so the gap is the CPU's own trajectory and not a regression. Walls are only
 comparable within one machine state (the CPU column was measured in a different session); the
 end-to-end speedup on these small scenes is capped by the host-side mesh preparation both
 backends share (5.3 s of the 8.4 s on Herz-Jesu-P8), while the refinement loop itself runs about
 15x faster on the GPU (§1.6.1).
 
-On the many-view scenes, against the previous CUDA build (the round before §1.6.1's rework, the
-same source otherwise), each pair run in the same machine state:
+On the many-view scenes, against the CUDA build before §1.6.1's rework (the same source
+otherwise), each pair run in the same machine state:
 
 | scene | previous CUDA build: F1 / evaluations / wall | this build: F1 / evaluations / wall | wall |
 |---|---|---|---|

--- a/docs/design/MeshRefinement.md
+++ b/docs/design/MeshRefinement.md
@@ -209,7 +209,8 @@ does, per pixel of A:
    contrast, resolution and pair count. `MinWindowCount` and the two gates are the only
    pixel-rejection machinery.
 3. **Per-pixel photometric gradient.** `MeshRefine::ComputePhotometricGradient` (CPU) and
-   `kernelAccumulateFacePhoto` (CUDA) compute the face normal `N`, the camera-A ray `dA`, and
+   `kernelComputeWindowStats` (CUDA, one thread per pixel, right after the pixel's own ZNCC)
+   compute the face normal `N`, the camera-A ray `dA`, and
    `Nd = N.dA`; skip the pixel if `Nd > -0.1` (a one-sided grazing/back-face gate). They
    back-project to the 3D point, project into B with a Jacobian `J` (`MeshRefine::ProjectVertex`),
    sample B's precomputed image gradient there, and form
@@ -244,11 +245,14 @@ does, per pixel of A:
    CPU this merge happens per-pair under a lock at the end of `ThProcessPair`, so summation order —
    and the float result — is not reproducible run to run unless `--max-threads 1`. On CUDA it is
    **deterministic**: `kernelAccumulateFacePhoto` is face-parallel — one thread per mesh face walks
-   its clipped bounding box in fixed scan order, reducing the corner sums, pixel count and footprint
-   minimum in registers, no atomics — and `kernelGatherVertexPhoto` is vertex-parallel, walking each
-   vertex's flattened incident-face list (`Mesh::ListIncidentFaces` order) to sum the contribution
-   and absorb the `photoGradNorm += 1`; `kernelFinalizePhotoGrad` resolves the sentinel exactly like
-   the CPU's post-loop pass. `photoGrad[v]/photoGradNorm[v]` — the pair-count average — is what the
+   its clipped bounding box in fixed scan order, folding the per-pixel terms the window-statistics
+   kernel left behind (weighted by the barycentrics), the pixel count and the footprint minimum
+   into the face's private slots, which accumulate across the evaluation's pair-directions, no
+   atomics; `kernelCountSeenVertices` absorbs the `photoGradNorm += 1` per direction; and once per
+   evaluation `kernelGatherVertexPhoto` is vertex-parallel, walking each vertex's flattened
+   incident-face list (`Mesh::ListIncidentFaces` order) to sum the contribution and resolve the
+   sentinel exactly like the CPU's post-loop pass. `photoGrad[v]/photoGradNorm[v]` — the pair-count
+   average — is what the
    stepper and the Ceres energy mode (§1.9) both read as `g_v`; there is no other normalizer.
 6. **Boundary vertices get the photometric term but zero smoothing.** Nothing in `ScoreMesh`/
    `ComputeWindowStats`/`ComputePhotometricGradient` special-cases a boundary vertex — the
@@ -303,13 +307,13 @@ Identical **by construction**, not by measurement: the shared scalar header (`Sc
 `ZnccReliability`, `WindowStatsFromSums`, `ZnccAndDerivative`), the 7x7 window, the visibility test,
 the image-gradient stencil (built once, host-side, shared by both), the rasterizer (both keep only
 front faces where `EdgeFunction(p0,p1,p2) > 0` and use perspective-correct barycentric coordinates —
-CUDA's two-pass `kernelProjectMesh` resolves depth ties the same way the CPU's face-list traversal
-order does, and is itself deterministic run to run), and the stepper (`MeshRefineStep`, one
-implementation). What legitimately differs:
+CUDA's two-pass `kernelProjectMesh` is itself deterministic run to run), and the stepper
+(`MeshRefineStep`, one implementation). What legitimately differs:
 
 | Aspect | CPU | CUDA |
 |---|---|---|
 | Camera projection precision | double (`Camera::TransformPointW2C`) | float (`MVS::CUDA::Camera`, built once per call by `MakeCUDACamera`) — measured bit-identical face maps on the `Tiny` fixture despite the precision drop |
+| Rasterizer input | the faces an octree frustum cull lists per camera, rebuilt every evaluation; the first face rasterised wins an exact depth tie | the whole mesh into every view, the kernel rejecting what a view does not see (the cull cost more host time than it saved on the GPU, §1.6.1); the lower face id wins the tie — the only pixels the two face maps can differ on sit exactly on a shared edge |
 | Photometric accumulation order | per-pair, under a lock, in whatever order threads complete — not bit-reproducible run to run unless `--max-threads 1` | face-parallel accumulate + vertex-parallel gather over a fixed order, no atomics — **bit-reproducible** |
 | Planar-vertex removal | implemented (§1.7) | refused at the entry (a loud error, not a silent no-op) — caller falls back to CPU |
 | Ceres arm (`--use-ceres`) | implemented, gated on `_USE_CERES` | refused at the entry, same fallback |
@@ -319,6 +323,49 @@ The two backends were brought to this state by dumping one image pair's per-vert
 per-pixel maps from each and comparing them side by side; that diagnostic found the six CUDA-only
 defects (window size, `dZNCC` form, image-gradient sampling, border margins, bi-Laplacian valence
 at a boundary neighbour, back-face winding) and was removed from the tree once they were closed.
+
+#### 1.6.1 What one CUDA evaluation does, and where its time goes
+
+`MeshRefineCUDA::ScoreMesh` issues everything on the default stream and makes one host round trip,
+at the end: the vertex upload and the rasterization of the whole mesh into every view
+(`kernelProjectMesh` x2 per view, no host frustum cull — see the table above); the face normals and
+both smoothness terms (`kernelComputeFaceNormal`, `kernelComputeSmoothnessGradient` x2, which need
+only the vertices and so run while the host is still issuing the pairs); per pair-direction the
+warp (`kernelImageMeshWarp`), the window statistics with the pixel's photometric term
+(`kernelComputeWindowStats`), the per-face accumulation into slots that persist across the
+directions (`kernelAccumulateFacePhoto`) and the per-vertex direction count
+(`kernelCountSeenVertices`); then one reduction of every direction's block partials into `S`
+(`kernelReduceBlockSums`), one per-vertex gather (`kernelGatherVertexPhoto`) and ONE download of
+all per-vertex terms into a pinned host buffer the stepper reads in place. The stepper and the next
+vertex upload are the only host work between two evaluations.
+
+Measured with Nsight Systems on Herz-Jesu-P8 (RTX 4070, level 1, 8 views, 27 pairs = 54
+pair-directions per evaluation, 81k/157k faces at the two scales), before and after the rework:
+
+| per evaluation | before | after |
+|---|---|---|
+| scale 0: GPU span / host gap to the next evaluation | 13.5 ms / 6 ms | 8 ms / 1.2 ms |
+| scale 1: GPU span / host gap to the next evaluation | 39 ms / 11 ms | 23 ms / 2.3 ms |
+| GPU idle inside the span | 5-12 % | 1.5-4.5 % |
+| `kernelAccumulateFacePhoto`, scale 1 | 409 us | 191 us |
+| `kernelComputeWindowStats`, scale 1 (now also the photometric term) | 105 us | 127 us |
+| per-vertex gather | 54 x 46 us | 1 x 61 us |
+| kernel launches / D2H copies / `cuMemFree` per run | 14,870 / 397 / 549 | 11,930 / 90 / 89 |
+| refinement loop, both scales | 1.95 s (51 evaluations) | 1.10 s (50) |
+| `RefineMesh` wall | 8.1 s | 6.9 s |
+
+The host gap used to be an octree over the mesh rebuilt for every evaluation to frustum-cull a face
+list per view, plus that list's allocation, upload and free (a `cuMemFree` is an implicit device
+sync), plus five pageable downloads; what is left is the stepper. The largest kernel used to
+compute the photometric term itself, one thread walking every pixel of its face, so a warp waited
+for its largest face; the term now comes from the per-pixel window-statistics kernel and the face
+kernel only weights it by the barycentrics. A cooperating-lanes variant of that kernel (8 lanes per
+face, shuffle-tree reduction, a fixed pixel-to-lane mapping) measured 201 us against the 191 us
+above: the kernel is bound by its scattered face-map/mask/barycentric reads, not by divergence, so
+the simpler one stays. What remains of the 6.9 s is the host-side mesh preparation (§2.10),
+identical on both backends, which is why the end-to-end CPU/CUDA ratio on these small scenes stays
+near 3.5x while the refinement loop alone runs about 15x faster than the CPU's 0.33 s per
+evaluation.
 
 ### 1.7 Optimization schedule
 
@@ -558,16 +605,20 @@ defaults, at an operating point that stopped much earlier (16 evaluations on Her
 on the shipped defaults the agreement is a little wider, because the run is longer and the two
 backends get more chances to split a marginal accept/reject:
 
-| scene | CPU | CUDA | CPU − CUDA | evaluations CPU/CUDA | speedup |
-|---|---|---|---|---|---|
-| Herz-Jesu-P8 | 0.45111 | 0.45312 | −0.0020 | 57 / 51 | 3.1x |
-| fountain-P11 | 0.34520 | 0.34618 | −0.0010 | 54 / 50 | 2.8x |
+| scene | CPU | CUDA | CPU − CUDA | evaluations CPU/CUDA | wall CPU / CUDA | speedup |
+|---|---|---|---|---|---|---|
+| Herz-Jesu-P8 | 0.45111 | 0.45216 | −0.0011 | 57 / 50 | 25.5 s / 7.1 s | 3.6x |
+| fountain-P11 | 0.34520 | 0.34638 | −0.0012 | 54 / 56 | 35.9 s / 11.8 s | 3.0x |
 
 The evaluation counts no longer match exactly, so the surfaces are compared at slightly different
 stopping points rather than at the same one; F1 tracks the iteration count closely enough (§2.4)
-that this accounts for the gap on its own. The CUDA numbers reproduce §2.10's shipped combination
-— the sizing field plus the tightest-pair decimation, measured there as an arm — to the fifth
-decimal, so the gap is the CPU's own trajectory and not a regression.
+that this accounts for the gap on its own. Before the GPU rework of §1.6.1 the CUDA build
+reproduced §2.10's shipped combination — the sizing field plus the tightest-pair decimation,
+measured there as an arm — to the fifth decimal (0.45312 / 0.34618); the rework moved it by
+−0.0010 / +0.0002, inside the band, through the rasterizer's tie-break and the summation order,
+so the gap is the CPU's own trajectory and not a regression. The end-to-end speedup is capped by
+the host-side mesh preparation both backends share (5.4 s of the 7.1 s on Herz-Jesu-P8); the
+refinement loop itself runs about 15x faster on the GPU (§1.6.1).
 
 **CUDA is bit-reproducible.** Three identical runs on Ignatius produce F1 0.7730 / 0.7730 / 0.7730,
 413,865 faces and 23 evaluations each — a run-to-run spread of exactly 0. The CPU is not

--- a/docs/design/MeshRefinement.md
+++ b/docs/design/MeshRefinement.md
@@ -367,6 +367,77 @@ identical on both backends, which is why the end-to-end CPU/CUDA ratio on these 
 near 3.5x while the refinement loop alone runs about 15x faster than the CPU's 0.33 s per
 evaluation.
 
+**The many-view regime.** Herz-Jesu-P8 has 8 views and 54 pair-directions per evaluation. A
+Tanks and Temples scene at level 1 has hundreds of small views — Ignatius: 263 views of 960x540,
+1,430 pairs = 2,860 pair-directions per evaluation, 125k/281k faces at the two scales — and there
+every face-parallel kernel is O(faces x views) while any one view sees a fraction of the mesh, and
+everything that touches every view once per scale (image loading, the preparation's projected
+areas) is hundreds of times larger. Measured the same way on Ignatius, per evaluation:
+
+| per evaluation, Ignatius level 1 | before the rework | after the rework above | many-view rework |
+|---|---|---|---|
+| scale 0: GPU kernels / host gap to the next evaluation | 276 ms / 70 ms | 157 ms / 2-6 ms | 138 ms / 2-6 ms |
+| scale 1: GPU kernels / host gap to the next evaluation | 638 ms / 135 ms | 326 ms / 3-7 ms | 327 ms / 3-7 ms |
+| `kernelAccumulateFacePhoto`, scale 0 / scale 1 | 55 / 139 us | 32 / 61 us | 26 / 64 us |
+| `kernelComputeWindowStats`, scale 0 / scale 1 | 10 / 24 us | 11 / 28 us | 11 / 25 us |
+| D2H copies per run | — | 1,351 / 1.68 GB | 41 / 188 MB |
+| scale switch (host image preparation + upload) | — | 1.17 s + 0.47 s | 0.01 s + 0.44 s |
+| device memory per view | 29 B/px | 29 B/px | 21 B/px |
+| `RefineMesh` wall, 36 evaluations, back to back | 72.5 s | — | 34.5 s |
+
+The many-view rework, all of it in `SceneRefineCUDA.{cpp,cu,inl}`:
+
+- **Owner bits.** The rasterizer's second pass leaves, per view, one bit per face set iff the face
+  wrote a pixel (a warp ballot, no atomics, every word written so nothing is cleared), and the
+  accumulation exits on the bit before reading the face — behind the camera, off the image,
+  back-facing or occluded, most of the mesh for any one view. That is the scale-0 gain; at scale 1
+  it is spent again by the next item.
+- **No barycentric map.** The per-pixel `ushort4` of half barycentrics (8 of the 29 bytes every
+  view held per pixel) is gone: the accumulation recomputes barycentrics and depth from the face's
+  projection with the same `pixelBary` call the rasterizer keyed the pixel with, so they are the
+  rasterizer's bit for bit — in float, as the CPU's `BaryMap` keeps them, where the half map was a
+  deviation from the CPU (Herz-Jesu-P8 CUDA F1 moved from 0.45216 to 0.45110 against the CPU's
+  0.45111, §2.2). The recomputation is ~70 instructions per kept pixel, issued once per
+  bounding-box step for however few lanes of a warp keep a pixel there, which is what keeps the
+  scale-1 kernel at 64 us. Eight lanes sharing a face (each taking every eighth pixel of the box,
+  a fixed shuffle tree over the partials) measured 49 / 88 us against 26 / 64 us and was rejected:
+  on the small boxes most lanes idle and the extra threads cost more than the divergence they
+  remove. If that kernel has to go faster, the way is a per-reference-view `float4` (bary, depth)
+  scratch written once per view from the owner faces, with the pair-directions walked grouped by
+  reference view — one view's map resident instead of every view's.
+- **Projected face areas on the GPU.** The preparation's `ListFaceAreas` used to download every
+  view's face map (263 x 2.1 MB pageable per projection, 1.68 GB per run) and count pixels per
+  face on the host, then min over the pair and max over the pairs on the host too (1,430 pairs x
+  every face). Now `kernelFaceHistogram` counts per view (integer atomics, exact) and
+  `kernelReduceFaceAreasPair` folds each pair, the pairs walked grouped by their first view so its
+  histogram is built once; only the reduced `uint16_t` areas come down, truncated exactly like the
+  host's counters, and a Debug build recomputes the host path and asserts equality on every face.
+  The input mesh's projection went from 3.1 s to 1.9 s of which the remaining part is the host's
+  sampled analytic area (`SampleSeenFaceArea`), shared with the CPU.
+- **The next scale's images on a thread.** `PrefetchImages` starts `PrepareImages` for the next
+  scale (load, gray, blur, resize, gradient stencil, keep-mask, on a copy of each `Image`, since
+  `PrepareRefineImage` sets the working size and camera on the `Image` it is given) as soon as
+  the current scale's are uploaded; the switch joins it and pays only the upload. The thread's
+  OpenMP team is capped at half the cores: a full team alongside the refinement of the current
+  scale starved the thread feeding the GPU of its time slices (100-800 ms host gaps between
+  evaluations on 24 logical CPUs).
+- **Empty tiles.** A window-statistics block whose 22x22 tile holds no masked sample writes its
+  zeros and leaves before the window loops (`__syncthreads_or`): most tiles, in a scene where each
+  image sees a small part of the surface.
+
+What is left per evaluation is the kernels themselves (85 % GPU-busy across the refinement window,
+host gaps of 2-7 ms), and per run the host-side mesh preparation. The end-to-end walls against
+the previous CUDA build, same machine state, are in §2.2.
+
+**Device memory is the next large-scene limit.** With the per-view footprint at 21 bytes per pixel
+(float image 4, its two gradient textures 8, depth 4, face 4, plus a keep-mask byte when masks
+are used), Ignatius at level 0 (263 views of 1920x1080 at the finest scale) needs about 11 GB and
+did not fit a 12 GB RTX 4070 before this rework either (15.8 GB at 29 B/px): the driver paged and
+a scale-1 evaluation went from 0.4 s to minutes. Courthouse (1,106 images) needs the same at level
+1. Beyond that point the design has to stream views — a resident working set of views, pinned host
+copies, the pair-directions ordered by view, a view re-rasterized when it comes back — which is
+a change of memory architecture, not of kernels.
+
 ### 1.7 Optimization schedule
 
 Both backends drive the same shared stepper, `MeshRefineStep` (`SceneRefineCommon.h/.cpp`). The
@@ -607,18 +678,37 @@ backends get more chances to split a marginal accept/reject:
 
 | scene | CPU | CUDA | CPU − CUDA | evaluations CPU/CUDA | wall CPU / CUDA | speedup |
 |---|---|---|---|---|---|---|
-| Herz-Jesu-P8 | 0.45111 | 0.45216 | −0.0011 | 57 / 50 | 25.5 s / 7.1 s | 3.6x |
-| fountain-P11 | 0.34520 | 0.34638 | −0.0012 | 54 / 56 | 35.9 s / 11.8 s | 3.0x |
+| Herz-Jesu-P8 | 0.45111 | 0.45110 | +0.0000 | 57 / 51 | 25.5 s / 9.0 s | 2.8x |
+| fountain-P11 | 0.34520 | 0.34655 | −0.0014 | 54 / 59 | 35.9 s / 11.4 s | 3.2x |
 
 The evaluation counts no longer match exactly, so the surfaces are compared at slightly different
 stopping points rather than at the same one; F1 tracks the iteration count closely enough (§2.4)
 that this accounts for the gap on its own. Before the GPU rework of §1.6.1 the CUDA build
 reproduced §2.10's shipped combination — the sizing field plus the tightest-pair decimation,
-measured there as an arm — to the fifth decimal (0.45312 / 0.34618); the rework moved it by
-−0.0010 / +0.0002, inside the band, through the rasterizer's tie-break and the summation order,
-so the gap is the CPU's own trajectory and not a regression. The end-to-end speedup is capped by
-the host-side mesh preparation both backends share (5.4 s of the 7.1 s on Herz-Jesu-P8); the
-refinement loop itself runs about 15x faster on the GPU (§1.6.1).
+measured there as an arm — to the fifth decimal (0.45312 / 0.34618); the two reworks moved it
+inside the band through the rasterizer's tie-break, the summation order and the float
+barycentrics the CPU also uses (0.45216 / 0.34638 after the first, the values above after the
+many-view one), so the gap is the CPU's own trajectory and not a regression. Walls are only
+comparable within one machine state (the CPU column was measured in a different session); the
+end-to-end speedup on these small scenes is capped by the host-side mesh preparation both
+backends share (5.3 s of the 8.4 s on Herz-Jesu-P8), while the refinement loop itself runs about
+15x faster on the GPU (§1.6.1).
+
+On the many-view scenes, against the previous CUDA build (the round before §1.6.1's rework, the
+same source otherwise), each pair run in the same machine state:
+
+| scene | previous CUDA build: F1 / evaluations / wall | this build: F1 / evaluations / wall | wall |
+|---|---|---|---|
+| Ignatius | 0.7793 / 36 / 75.3 s | 0.7801 / 36 / 34.9 s | 2.2x |
+| Truck | 0.6660 / 16 / 85.2 s | 0.6660 / 16 / 39.9 s | 2.1x |
+| Barn | 0.6768 / 34 / 241.6 s | 0.6757 / 33 / 89.2 s | 2.7x |
+| Meetingroom | 0.4135 / 26 / 110.7 s | 0.4134 / 35 / 79.9 s | 1.4x (2.4x per scale-1 evaluation: 3.6 s to 1.5 s) |
+| Herz-Jesu-P8, back to back, no evaluator | 51 / 10.0 s | 51 / 8.4 s | 1.2x |
+| fountain-P11, back to back, no evaluator | 50 / 16.8 s | 59 / 14.4 s | 1.2x |
+
+F1 moves within the run-to-run band of a changed trajectory (the float barycentrics and the
+summation order change the bits, not the surface); the walls fall where the views are many and
+stay where the host-side preparation dominates (the EPFL pairs).
 
 **CUDA is bit-reproducible.** Three identical runs on Ignatius produce F1 0.7730 / 0.7730 / 0.7730,
 413,865 faces and 23 evaluations each — a run-to-run spread of exactly 0. The CPU is not

--- a/docs/design/MeshRefinement.md
+++ b/docs/design/MeshRefinement.md
@@ -429,6 +429,66 @@ What is left per evaluation is the kernels themselves (85 % GPU-busy across the 
 host gaps of 2-7 ms), and per run the host-side mesh preparation. The end-to-end walls against
 the previous CUDA build, same machine state, are in §2.2.
 
+**The accumulation over owner lists, and the evaluation as a graph (round 3).** Nsight Compute
+on `kernelAccumulateFacePhoto` after the many-view rework (Ignatius level 1, 24 launches per
+scale, `--set full`) said what the timelines could not: 4.4 active lanes per warp-instruction, 13
+of 20 warp cycles per instruction waiting on the scattered face-map/mask/term loads, compute at
+27 % and memory at 37 % of peak. The early exit on the owner bit left the warps that reached the
+pixel loop nearly empty, and every lane's box was somewhere else in the image. The
+per-reference-view scratch the previous paragraph proposed was not needed:
+
+- **Owner lists.** The bits are packed once per evaluation into dense per-view lists —
+  `kernelCountOwners` popcounts each view's words, `kernelScanViewCounts` turns the counts into
+  the views' offsets into one packed list (the offsets come down in the evaluation's one
+  synchronization before the terms, on the rasterization every direction needs anyway), and
+  `kernelCompactOwners` writes the face ids. The accumulation runs one thread per owner face of
+  its reference view: 9.4 / 7.7 lanes, 2.3x fewer instructions issued, 26 / 64 us -> 20 / 48 us
+  at scale 0 / 1. The list order is irrelevant to the result: a face still folds its own pixels in
+  raster order into its own slot, and the fold order across directions is the launch order.
+- **Row chunks.** The box is walked in chunks of four pixels whose face ids, mask bytes and terms
+  are loaded together, so a chunk's loads are in flight at once (the SASS confirms twelve
+  back-to-back predicated loads); 20 / 48 -> 19 / 44 us. The pixels are still folded in raster
+  order.
+- **Tile order.** `kernelSortOwnersTile` reorders each view's slice by the 64x8-pixel image tile
+  the face's clipped box starts in (a counting sort in shared memory; the projection is the
+  accumulation's own; the order within a tile is the atomics' and does not matter), so a warp's
+  32 boxes share cache lines: L1 hit rate 52 -> 78 %, 11-13 lanes; 19 / 44 -> 15 / 35 us for
+  1.1 / 2.1 ms of sorting per evaluation. 128x16 tiles measured 1.4-2.6 % slower per evaluation.
+- **One launch in four gone.** `kernelCountSeenVertices` is folded into the accumulation: a
+  per-vertex direction stamp, `atomicExch` handing exactly one of the vertex's contributing faces
+  the previous stamp, counts the direction once — an integer count, so still reproducible.
+- **The evaluation as a CUDA graph.** With the kernels shrunk, the host was the ceiling at the
+  coarse scale: 9,115 launches at ~10 us each under WDDM, 98 ms of launch API per evaluation for
+  103 ms of kernels. Every argument of the direction loop is a constant of the scale — the
+  accumulation reads its view's slice offsets on the device and strides over a grid sized at the
+  recording — so the loop, the reduction and the gather are recorded once per scale (per parity
+  when the pairs alternate) with stream capture and replayed by one `cudaGraphLaunch` per
+  evaluation: 40 ms to instantiate, ~11 ms of host time per launch. The rasterization,
+  compaction and memsets stay eager on the legacy stream ahead of it, the terms download behind
+  it. If the recording fails the directions are issued one by one as before.
+
+Measured the same way (Ignatius level 1, per evaluation, nsys; the graph's kernels are read from a
+node-level trace, the spans from an untraced one):
+
+| per evaluation, Ignatius level 1 | many-view rework | round 3 |
+|---|---|---|
+| `kernelAccumulateFacePhoto`, scale 0 / scale 1 | 26 / 64 us | 15 / 35 us |
+| GPU kernels, scale 0 / scale 1 | 138 / 327 ms | 102 / 246 ms |
+| kernel launches per evaluation (host) | 11,974 | 533 + 1 graph |
+| evaluation to evaluation (rasterization to rasterization), scale 0 / scale 1 | 160 / 420 ms | 109 / 295 ms |
+| host launch API per run | 9.5 s | 1.1 s |
+| `RefineMesh` wall, back to back, same machine state: Ignatius / Truck / Barn / Meetingroom | 35.3 / 41.5 / 90.1 / 80.4 s | 32.3 / 38.5 / 81.5 / 67.9 s |
+
+The output is byte-identical to the many-view build on Ignatius (36 evaluations), Truck, Barn and
+Meetingroom; the Debug synthetic test is unchanged (CUDA/CPU ratio 1.00027) and the Debug build
+checks the compaction against the bits and the sort against the compaction on every evaluation.
+What is left of a scale-1 evaluation is 246 ms of kernels (accumulation 42 %, window statistics
+29 %, rasterization 19 %, warp 8 %), ~24 ms of host stepper between evaluations (shared with the
+CPU path), and ~10 ms of transfers, memsets and graph launch. A launch bound forcing the
+accumulation to 64 registers (from 71) spilled and measured 2 ms slower per evaluation; a
+per-pair octree or BVH preselection of faces would only duplicate what the rasterizer's owner
+bits already give exactly, occlusion included, at 1-2 ms per evaluation.
+
 **Device memory is the next large-scene limit.** With the per-view footprint at 21 bytes per pixel
 (float image 4, its two gradient textures 8, depth 4, face 4, plus a keep-mask byte when masks
 are used), Ignatius at level 0 (263 views of 1920x1080 at the finest scale) needs about 11 GB and

--- a/libs/MVS/MeshHalfMesh.cpp
+++ b/libs/MVS/MeshHalfMesh.cpp
@@ -33,6 +33,7 @@
 
 #include "Common.h"
 #include "Mesh.h"
+#include <span>
 #include <halfmesh/InteropOpenMVS.h>
 #include <halfmesh/TextureBake.h>
 

--- a/libs/MVS/SceneRefine.cpp
+++ b/libs/MVS/SceneRefine.cpp
@@ -269,7 +269,7 @@ public:
 	const Real weightRegularity; // a scalar regularity weight to balance between photo-consistency and regularization terms
 	Real ratioRigidityElasticity; // a scalar ratio used to compute the regularity gradient as a combination of rigidity and elasticity
 	const unsigned nResolutionLevel; // how many times to scale down the images before mesh optimization
-	const unsigned nMinResolution; // how many times to scale down the images before mesh optimization
+	const unsigned nMinResolution; // do not scale the images below this resolution (longest side, px)
 	unsigned nAlternatePair; // using an image pair alternatively as reference image (0 - both, 1 - alternate, 2 - only left, 3 - only right)
 	unsigned iteration; // current refinement iteration
 
@@ -1603,14 +1603,12 @@ bool Scene::RefineMesh(unsigned nResolutionLevel, unsigned nMinResolution, unsig
 			options.minimizer_progress_to_stdout = false;
 			// the Ceres 2.2 defaults: L-BFGS (rank 20, no Oren-Luenberger scaling, which Ceres
 			// documents as harmful where the parameter sensitivities vary as widely as they do
-			// here) with the Wolfe line search. A sweep of every direction and line search the
-			// solver offers, the L-BFGS rank, the scaling and the function tolerance found no
-			// configuration that wins on more than one of three ground-truth scenes (design
-			// document, the Ceres section)
+			// here) with the Wolfe line search; no other direction, line search, rank, scaling or
+			// tolerance wins on more than one ground-truth scene (see the design document)
 			options.line_search_direction_type = ceres::LBFGS;
 			options.line_search_type = ceres::WOLFE;
 			// the stopping rule is the relative function tolerance below; the cap is a safety net,
-			// never reached on any measured scene (the longest scale ran 88 iterations), and an
+			// never reached in practice, and an
 			// L-BFGS iteration costs one energy evaluation whenever the unit step satisfies the
 			// Wolfe conditions, which it does on most of them
 			options.max_num_iterations = 100;

--- a/libs/MVS/SceneRefineCUDA.cpp
+++ b/libs/MVS/SceneRefineCUDA.cpp
@@ -49,7 +49,7 @@ using namespace MVS;
 
 // S T R U C T S ///////////////////////////////////////////////////
 
-// Convert MVS::Camera (double precision, OpenCV types) to MVS::CUDA::Camera (float precision, Eigen types)
+// MVS::Camera (double precision, OpenCV types) to MVS::CUDA::Camera (float precision, Eigen types)
 static MVS::CUDA::Camera MakeCUDACamera(const Camera& camera, const Image8U::Size& size) {
 	return MVS::CUDA::Camera(
 		Eigen::Map<const SEACAVE::Matrix3x3::EMat>(camera.K.val).cast<float>(),
@@ -57,9 +57,6 @@ static MVS::CUDA::Camera MakeCUDACamera(const Camera& camera, const Image8U::Siz
 		Eigen::Map<const SEACAVE::Point3::EVec>(camera.C.ptr()).cast<float>(),
 		size.width, size.height);
 }
-
-
-// S T R U C T S ///////////////////////////////////////////////////
 
 typedef Mesh::Vertex Vertex;
 typedef Mesh::VIndex VIndex;
@@ -71,18 +68,18 @@ public:
 	// store necessary data about a view
 	struct View {
 		Image8U::Size size;
-		SEACAVE::CUDA::ArrayRT32F image; // float like the CPU's View::image (was half-float; see readSurfFloat in the .cu)
-		SEACAVE::CUDA::ArrayRT32F imageGrad[2]; // x/y derivatives (ComputeRefineImageGradient), sampled by the photometric kernel; kept in float like the CPU's View::imageGrad (half-float cannot hold the sub-6e-5 values a derivative stencil produces on flat regions)
+		SEACAVE::CUDA::ArrayRT32F image; // float like the CPU's View::image (see readSurfFloat in the .cu)
+		SEACAVE::CUDA::ArrayRT32F imageGrad[2]; // x/y derivatives (ComputeRefineImageGradient), float like the CPU's View::imageGrad: a derivative stencil produces values a half cannot hold
 		SEACAVE::CUDA::MemDevice depthMap;
-		SEACAVE::CUDA::MemDevice faceMap; // the barycentrics are not kept per pixel: kernelAccumulateFacePhoto recomputes them from the face's projection (was a ushort4 per pixel of every view)
+		SEACAVE::CUDA::MemDevice faceMap; // no barycentrics per pixel: kernelAccumulateFacePhoto recomputes them from the face's projection
 		SEACAVE::CUDA::MemDevice keepMask; // one byte per pixel (non-zero = keep), uploaded from HostView::keepMask only when non-empty; invalid (unallocated) == keep everything
 	};
 	typedef CLISTDEF2(View) ViewsArr;
 	// one view's images at a scale as the host prepares them (PrepareImages) for UploadImages:
-	// the gray image, its gradient stencil, the keep-mask, and the working size and camera that
-	// PrepareRefineImage derives on a COPY of the scene's Image -- applied to the scene's at the
-	// upload, so that a scale can be prepared on a thread while the previous one is still
-	// being refined (PrefetchImages)
+	// the gray image, its gradient stencil, the keep-mask, and the working size and camera
+	// PrepareRefineImage derives on a COPY of the scene's Image, applied to the scene's at the
+	// upload, so that a scale can be prepared on a thread while the previous one is being
+	// refined (PrefetchImages)
 	struct HostView {
 		Image32F image;
 		Image32F imageGrad[2];
@@ -124,8 +121,7 @@ public:
 	void ListVertexFacesPre();
 	void ListVertexFacesPost();
 	// upload the current vertices and rasterize the mesh into every view; with bOwnerBits, the
-	// per-view owner bits ScoreMesh() packs into the owner lists its accumulations run over are
-	// left too
+	// per-view owner bits ScoreMesh() packs into the owner lists are left too
 	void ListCameraFaces(bool bOwnerBits=false);
 
 	void ListFaceAreas(Mesh::AreaArr& maxAreas);
@@ -136,13 +132,12 @@ public:
 
 	void ComputeNormalFaces();
 
-	// one energy evaluation: leaves the raw per-vertex terms (BEFORE any combine) in the pinned
-	// host buffer `terms` is pointed into, and the reliability-weighted score in S (S < 0 means
-	// no image pair contributed a single masked pixel -- see the sumR check below); the stepper
-	// (MeshRefineStep, SceneRefineCommon.h) does the combining, not this function. Returns false
-	// (having already VERBOSE'd why) if the GPU->host download failed: a non-sticky copy failure
-	// is not caught by the caller's cuCtxSynchronize() check and would otherwise hand the
-	// stepper finite-looking garbage.
+	// one energy evaluation: leaves the raw per-vertex terms in the pinned host buffer `terms`
+	// is pointed into, and the reliability-weighted score in S (S < 0 means no image pair
+	// contributed a single masked pixel); the stepper (MeshRefineStep, SceneRefineCommon.h)
+	// does the combining. Returns false (having VERBOSE'd why) if a GPU->host download failed:
+	// a non-sticky copy failure is not caught by the caller's cuCtxSynchronize() check and would
+	// otherwise hand the stepper finite-looking garbage.
 	bool ScoreMesh(MeshRefineStep::Terms& terms);
 
 	void ProjectMesh(const Camera& camera, const Image8U::Size& size, uint32_t idxImage, uint32_t* ownerBits);
@@ -170,7 +165,7 @@ public:
 public:
 	const float weightRegularity; // a scalar regularity weight to balance between photo-consistency and regularization terms
 	const unsigned nResolutionLevel; // how many times to scale down the images before mesh optimization
-	const unsigned nMinResolution; // how many times to scale down the images before mesh optimization
+	const unsigned nMinResolution; // do not scale the images below this resolution (longest side, px)
 	unsigned nAlternatePair; // using an image pair alternatively as reference image (0 - both, 1 - alternate, 2 - only left, 3 - only right)
 	unsigned iteration; // current refinement iteration
 	unsigned nScale; // current refinement scale (0-based, coarsest first), for the log
@@ -201,51 +196,47 @@ public:
 	SEACAVE::CUDA::MemDevice pixelGrad; // per pixel of the largest view: g_p, the photometric term the covering face's corners share (kernelComputeWindowStats)
 	SEACAVE::CUDA::MemDevice statsBlockSums; // 2 floats per window-statistics block of every pair-direction of one ScoreMesh(): the partials S is folded from, in slot order
 	// the raw per-vertex terms of one evaluation in ONE device buffer, so that a single download
-	// into its pinned host mirror hands the stepper everything it reads (five pageable copies used
-	// to be a sync point each, staged through the driver's bounce buffer); see TermsLayout
+	// into its pinned host mirror hands the stepper everything it reads; see TermsLayout
 	SEACAVE::CUDA::MemDevice terms;
 	float* termsHost = NULL;
-	// per-FACE private accumulators of the photometric term, the atomic-free replacement for a
-	// per-pixel scatter (see kernelAccumulateFacePhoto), in one buffer: 3 floats per face for the
-	// corners' Sum g_p*b_c, 1 for the pixel count, 1 for the min footprint; accumulated over the
-	// pair-directions of one ScoreMesh() and cleared once per call
+	// per-FACE private accumulators of the photometric term (see kernelAccumulateFacePhoto), in
+	// one buffer: 3 floats per face for the corners' Sum g_p*b_c, 1 for the pixel count, 1 for
+	// the min footprint; accumulated over the pair-directions of one ScoreMesh() and cleared
+	// once per call
 	SEACAVE::CUDA::MemDevice faceTerms;
 	SEACAVE::CUDA::MemDevice vertexStamp; // 1 word per vertex: the last pair-direction that reached it, how kernelAccumulateFacePhoto counts a direction once per vertex
 	SEACAVE::CUDA::MemDevice vertexVerticesCont;
 	SEACAVE::CUDA::MemDevice vertexVerticesSizes;
 	SEACAVE::CUDA::MemDevice vertexVerticesPointers;
-	// the same flattening for the INCIDENT FACES of each vertex (Mesh::ListIncidentFaces order):
-	// the gather half of the photometric accumulation walks it instead of the pixels scattering
+	// the same flattening for the INCIDENT FACES of each vertex (Mesh::ListIncidentFaces order),
+	// the order kernelGatherVertexPhoto folds the face slots in
 	SEACAVE::CUDA::MemDevice vertexFacesCont;
 	SEACAVE::CUDA::MemDevice vertexFacesSizes;
 	SEACAVE::CUDA::MemDevice vertexFacesPointers;
 	SEACAVE::CUDA::MemDevice vertBoundary; // per-vertex 0/1 boundary flag (shared valence/boundary split, see ListVertexFacesPost())
 	// per view, one bit per face set by the rasterizer iff the face owns a pixel there (see
-	// kernelProjectMesh): in a scene of hundreds of views most faces are unseen by any one view,
-	// and the per-direction accumulation runs over the view's owner faces only -- the dense
-	// per-view lists ScoreMesh() packs the bits into once per evaluation (kernelCompactOwners):
-	// the per-view counts, the offsets into the one packed list (one extra entry, the total)
-	// with their host copy the list is sized by and the directions launched from, and the list
-	// itself, kept at the largest total so far
+	// kernelProjectMesh), packed by ScoreMesh() once per evaluation into the dense per-view
+	// lists the accumulations run over (see kernelCompactOwners): the per-view counts, the
+	// offsets into the one packed list (one extra entry, the total) with their host copy the
+	// list is sized by and the directions launched from, and the list itself, kept at the
+	// largest total so far
 	SEACAVE::CUDA::MemDevice ownerBits;
 	SEACAVE::CUDA::MemDevice ownerCounts;
 	SEACAVE::CUDA::MemDevice ownerOffsets;
 	SEACAVE::CUDA::MemDevice ownerList;
 	size_t ownerListCapacity = 0; // entries ownerList, ownerKeys and ownerListSorted hold
 	Unsigned32Arr ownerOffsetsHost;
-	// the list every view's slice of which is reordered by image tile (kernelSortOwnersTile) --
-	// the one the directions run over -- and its scratch; the tile grid: 64x8-pixel tiles (a
-	// tile row of a 4-byte map is 8 sectors; 128x16 measured 1.4-2.6 % slower on Ignatius level
-	// 1), coarsened until the largest view has at most
-	// 4096, set with the views' cameras (one device array for the kernels that cover every view
-	// in one launch) by UploadImages()
+	// the list every view's slice of which is reordered by image tile (kernelSortOwnersTile),
+	// the one the directions run over, and its scratch; the tile grid starts at 64x8 pixels and
+	// is coarsened until the largest view has at most 4096 tiles; the views' cameras in one
+	// device array for the kernels that cover every view in one launch (UploadImages())
 	SEACAVE::CUDA::MemDevice ownerKeys;
 	SEACAVE::CUDA::MemDevice ownerListSorted;
 	SEACAVE::CUDA::MemDevice cudaCameras;
 	int tileShiftX = 6, tileShiftY = 3;
 	uint32_t maxTileBuckets = 0;
 	// the stream the pair-directions are issued on, and the evaluation recorded from them once
-	// per scale as a CUDA graph (see ScoreMesh) -- two when the pairs alternate direction with
+	// per scale as a CUDA graph (see ScoreMesh), two when the pairs alternate direction with
 	// the iteration parity
 	cudaStream_t stream = NULL;
 	cudaGraphExec_t graphExec[2] = {NULL, NULL};
@@ -326,9 +317,9 @@ void MeshRefineCUDA::ReleaseGraphs()
 
 // the host half of a scale's images, one per valid image: load, gray, blur and resize
 // (PrepareRefineImage), the gradient stencil and the keep-mask, into hostViews. Nothing in the
-// scene's Image changes -- PrepareRefineImage sets the working size and camera on a COPY, which
-// HostView carries to UploadImages() -- so this also runs on the PrefetchImages() thread while
-// the previous scale is still being refined on the caller's
+// scene's Image changes (PrepareRefineImage works on a COPY, which HostView carries to
+// UploadImages()), so this also runs on the PrefetchImages() thread while the previous scale
+// is still being refined
 bool MeshRefineCUDA::PrepareImages(float scale, float sigma)
 {
 	hostViews.Resize(images.GetSize());
@@ -359,8 +350,7 @@ bool MeshRefineCUDA::PrepareImages(float scale, float sigma)
 			#endif
 		}
 		// mode 3 samples the bilinear interpolant of the image directly (computePhotoPixel's
-		// bilinearGradient) and never reads this precomputed stencil, so computing (and, at the
-		// upload, uploading) it would be wasted work
+		// bilinearGradient) and never reads a precomputed stencil
 		if (OPTREFINE::nImageGradient != 3)
 			ComputeRefineImageGradient(host.image, host.imageGrad[0], host.imageGrad[1]);
 		// per-view keep-mask at this scale's working size (the same estimator on both backends)
@@ -388,9 +378,8 @@ void* STCALL MeshRefineCUDA::PrefetchWorker(void* pData)
 {
 	MeshRefineCUDA& refine = *(MeshRefineCUDA*)pData;
 	#ifdef MESHCUDAOPT_USE_OPENMP
-	// half the cores for this thread's team (the setting is per thread): a full team runs
-	// alongside the refinement of the current scale and starves the thread feeding the GPU of
-	// its time slices -- measured as 100-800 ms host gaps between evaluations on 24 logical CPUs
+	// half the cores for this thread's team (the setting is per thread): a full team running
+	// alongside the refinement of the current scale starves the thread feeding the GPU
 	omp_set_num_threads(MAXF(1, omp_get_num_procs()/2));
 	#endif
 	refine.prefetchResult = refine.PrepareImages(refine.prefetchScale, refine.prefetchSigma);
@@ -466,7 +455,7 @@ bool MeshRefineCUDA::UploadImages()
 		reportCudaError(view.image.Reset(size, CUDA_ARRAY3D_SURFACE_LDST));
 		reportCudaError(view.image.SetData(host.image));
 		host.image.release();
-		// no gradient stencil texture in mode 3 -- see the comment above where it is computed
+		// no gradient stencil texture in mode 3 (see PrepareImages)
 		if (OPTREFINE::nImageGradient != 3) {
 			for (int i=0; i<2; ++i) {
 				ASSERT(host.imageGrad[i].size() == size);
@@ -550,15 +539,12 @@ void MeshRefineCUDA::ListVertexFacesPost()
 	scene.mesh.ListIncidentVertices();
 	scene.mesh.ListBoundaryVertices();
 	ASSERT(!scene.mesh.vertices.IsEmpty() && scene.mesh.vertices.GetSize() == scene.mesh.vertexVertices.GetSize());
-	// list adjacent vertices for each vertex, uploading the TRUE valence for every vertex
-	// (boundary or not) plus a separate per-vertex boundary flag: kernelComputeSmoothnessGradient
-	// zeroes a boundary vertex's OWN gradient using vertBoundary[], exactly like CPU
-	// MeshRefine::ComputeSmoothnessGradient1/2, but every OTHER vertex's valence-weighted sum
-	// still divides by a boundary neighbour's true valence
-	// the incident FACES of each vertex are flattened the same way, in the order
-	// Mesh::ListIncidentFaces produced (ListVertexFacesPre(), above): kernelGatherVertexPhoto
-	// walks that fixed order to sum the photometric term for the vertex, which is what makes the
-	// sum reproducible without atomics
+	// flatten the adjacent vertices of each vertex, with the TRUE valence of every vertex
+	// (boundary or not) plus a separate boundary flag: kernelComputeSmoothnessGradient zeroes a
+	// boundary vertex's OWN gradient, but every other vertex's valence-weighted sum still
+	// divides by a boundary neighbour's true valence; and the incident FACES of each vertex the
+	// same way, in the order Mesh::ListIncidentFaces produced (ListVertexFacesPre()), the fixed
+	// order kernelGatherVertexPhoto folds the photometric term in
 	const size_t numVertices(scene.mesh.vertices.GetSize());
 	ASSERT(scene.mesh.vertexFaces.GetSize() == numVertices);
 	Unsigned32Arr _vertexVerticesCont(0, numVertices*6);
@@ -613,7 +599,7 @@ void MeshRefineCUDA::ListVertexFacesPost()
 
 // upload the current vertices and rasterize the mesh into every view (depth and face maps, and
 // the per-view owner bits when asked): the whole mesh each time, the kernel rejecting the faces
-// a view does not see -- see kernelProjectMesh for why no host-side frustum cull shortlists them
+// a view does not see (see kernelProjectMesh)
 void MeshRefineCUDA::ListCameraFaces(bool bOwnerBits)
 {
 	reportCudaError(vertices.Reset(scene.mesh.vertices));
@@ -625,14 +611,12 @@ void MeshRefineCUDA::ListCameraFaces(bool bOwnerBits)
 }
 
 // compute for each face the one projected area the preparation and the decimation both read:
-// rasterized per view, then reduced over the refinement's own pairs by ReduceFaceAreasOverPairs
+// rasterized per view, then reduced over the refinement's own pairs like ReduceFaceAreasOverPairs
 // (the smaller view of a pair, the largest pair); ListCameraFaces() must have run before.
 // All on the GPU: per pair, the rasterized pixel counts of its two views (kernelFaceHistogram
-// over the face maps the rasterization left) and their per-face min folded into the max over
-// the pairs (kernelReduceFaceAreasPair), the pairs walked grouped by their first view so that
-// its histogram is built once per group; only the reduced areas come down. The face map of
-// every view used to (one pageable copy each, 560 MB per projection on a 263-view scene at
-// level 1), followed by a host pass over all their pixels and one over faces x pairs
+// over the face maps) and their per-face min folded into the max over the pairs
+// (kernelReduceFaceAreasPair), the pairs walked grouped by their first view so that its
+// histogram is built once per group; only the reduced areas come down
 void MeshRefineCUDA::ListFaceAreas(Mesh::AreaArr& maxAreas)
 {
 	ASSERT(maxAreas.IsEmpty());
@@ -661,8 +645,7 @@ void MeshRefineCUDA::ListFaceAreas(Mesh::AreaArr& maxAreas)
 	maxAreas.Resize(numFaces);
 	reportCudaError(faceAreas.GetData(maxAreas));
 	#ifdef _DEBUG
-	// the host reduction over the downloaded face maps, the path this replaced, must agree on
-	// every face
+	// the host reduction over the downloaded face maps must agree on every face
 	{
 		Unsigned8Arr usedImages;
 		ListPairImages(pairs, images.GetSize(), usedImages);
@@ -700,9 +683,8 @@ void MeshRefineCUDA::SubdivideMesh(uint32_t maxArea, float fDecimate, unsigned n
 void MeshRefineCUDA::SimplifyMesh(float tolerancePx)
 {
 	// the tolerance is a reprojection error, so it is measured in the same projected areas the
-	// preparation splits against -- every other reading of "how big is this face on screen" in
-	// this file goes through ListFaceAreas, and a decimation that used a different one would
-	// keep faces no pair of the refinement can see
+	// preparation splits against (ListFaceAreas): a decimation that used a different measure
+	// would keep faces no pair of the refinement can see
 	ListCameraFaces();
 	Mesh::AreaArr seenAreas;
 	ListFaceAreas(seenAreas);
@@ -730,15 +712,13 @@ void MeshRefineCUDA::ComputeNormalFaces()
 // them into a step
 bool MeshRefineCUDA::ScoreMesh(MeshRefineStep::Terms& out)
 {
-	// rasterize the current vertices into every view, and pack the owner bits it leaves into
-	// the per-view owner lists the accumulations run over (see kernelCompactOwners): the views'
-	// counts and offsets, the offsets down -- the evaluation's one synchronization before the
-	// terms, on the rasterization every direction needs anyway -- and the list, sized by the
-	// total, filled
+	// rasterize the current vertices into every view and pack the owner bits it leaves into the
+	// per-view owner lists the accumulations run over (see kernelCompactOwners): the views'
+	// counts and offsets, the offsets down (the evaluation's one synchronization before the
+	// terms), then the list, sized by the total, compacted and sorted by tile
 	ListCameraFaces(true);
 	const uint32_t numViews((uint32_t)images.GetSize());
-	MVS::CUDA::LaunchCountOwners((const uint32_t*)(CUdeviceptr)ownerBits, (uint32_t*)(CUdeviceptr)ownerCounts, (uint32_t)OwnerWords(), numViews);
-	MVS::CUDA::LaunchScanViewCounts((const uint32_t*)(CUdeviceptr)ownerCounts, (uint32_t*)(CUdeviceptr)ownerOffsets, numViews);
+	MVS::CUDA::LaunchCountOwners((const uint32_t*)(CUdeviceptr)ownerBits, (uint32_t*)(CUdeviceptr)ownerCounts, (uint32_t*)(CUdeviceptr)ownerOffsets, (uint32_t)OwnerWords(), numViews);
 	if (reportCudaError(ownerOffsets.GetData(ownerOffsetsHost)) != CUDA_SUCCESS) {
 		VERBOSE("error: failed downloading the owner counts from the GPU at scale %u, iteration %u", nScale, iteration);
 		return false;
@@ -764,9 +744,9 @@ bool MeshRefineCUDA::ScoreMesh(MeshRefineStep::Terms& out)
 			tileShiftX, tileShiftY, maxTileBuckets, numViews);
 	}
 	#ifdef _DEBUG
+	// the list must be exactly the set bits of every view, in face order, and the sorted list a
+	// permutation of it view by view
 	{
-		// the list must be exactly the set bits of every view, in face order, and the sorted
-		// list a permutation of it view by view
 		const size_t numWords(OwnerWords());
 		Unsigned32Arr bits, list, sorted;
 		bits.Resize(numWords*numViews);
@@ -799,24 +779,22 @@ bool MeshRefineCUDA::ScoreMesh(MeshRefineStep::Terms& out)
 	const TermsLayout layout(numVertices);
 	ComputeSmoothnessGradient(numVertices);
 
-	// clear this evaluation's accumulators: the per-vertex direction count and the per-face
-	// slots (0, and the FLT_MAX the footprint mins start from)
+	// clear this evaluation's accumulators: the per-vertex direction count and stamps, and the
+	// per-face slots (0, and the FLT_MAX the footprint mins start from)
 	const FIndex numFaces(scene.mesh.faces.GetSize());
 	reportCudaError(cuMemsetD32(TermsPtr(layout.photoCount), 0, numVertices));
 	reportCudaError(cuMemsetD32(vertexStamp, 0xFFFFFFFFu, numVertices));
 	reportCudaError(cuMemsetD32(faceTerms, 0, (size_t)numFaces*4));
 	reportCudaError(cuMemsetD32((CUdeviceptr)faceTerms + sizeof(float)*4*numFaces, 0x7F7FFFFF, numFaces));
 
-	// for each pair of images, compute a photo-consistency score between the reference image
-	// and the pixels of the second image projected in the reference image through the mesh
-	// surface; then the two sums S is made of and the per-vertex photometric term. The whole
-	// sequence -- three kernels per pair-direction, thousands of them, every argument a constant
-	// of the scale (the accumulation reads the reference view's owner slice on the device) -- is
-	// recorded ONCE per scale (and per direction parity when the pairs alternate) into a CUDA
-	// graph and replayed by one launch per evaluation: issued one by one, the launches cost the
-	// host ~10 us each under WDDM, 100-200 ms per evaluation, as much as the coarse scales' GPU
-	// time (Ignatius level 1: 98 ms of launch API for 103 ms of kernels at scale 0). Should the
-	// recording fail, the directions are issued one by one as before.
+	// for each pair of images, the photo-consistency between the reference image and the second
+	// image projected into it through the mesh, then the two sums S is made of and the
+	// per-vertex photometric term. The sequence (three kernels per pair-direction, thousands of
+	// them, every argument a constant of the scale since the accumulation reads its view's owner
+	// slice on the device) is recorded ONCE per scale (and per direction parity when the pairs
+	// alternate) into a CUDA graph and replayed by one launch per evaluation: issued one by one,
+	// the launches cost the host as much as the coarse scales' GPU time. Should the recording
+	// fail, the directions are issued one by one.
 	const auto issueDirections = [&]() {
 		uint32_t numSlots(0), direction(0);
 		FOREACHPTR(pPair, pairs) {
@@ -882,10 +860,9 @@ bool MeshRefineCUDA::ScoreMesh(MeshRefineStep::Terms& out)
 	}
 
 	// S = sumRZ/sumR, the reliability-weighted mean of (1-ZNCC). sumR == 0 means no pair-direction
-	// contributed a single masked pixel -- broken outside-world input (no pair overlap, bad
-	// poses), not an internal invariant, so it gets the runtime-validation treatment instead of
-	// an ASSERT alone (which would compile out in Release and feed the stepper NaN): S is left
-	// negative and the caller fails the refinement loudly, exactly like MeshRefine::ScoreMesh
+	// contributed a single masked pixel: broken outside-world input (no pair overlap, bad poses),
+	// not an internal invariant, so S is left negative and the caller fails the refinement
+	// loudly, exactly like MeshRefine::ScoreMesh
 	const float sumR(termsHost[layout.sums]), sumRZ(termsHost[layout.sums+1]);
 	if (sumR > 0) {
 		S = sumRZ/sumR;
@@ -911,12 +888,9 @@ void MeshRefineCUDA::ProjectMesh(const Camera& camera, const Image8U::Size& size
 	ASSERT(projKey.IsValid() && (size_t)size.area() <= projKeyPixels);
 	// pass 1 needs every pixel key at "no face yet" = ~0ull (larger than any real (depth,face) key)
 	reportCudaError(cuMemsetD32(projKey, 0xFFFFFFFFu, 2*(size_t)size.area()));
-	// project mesh: pass 1 elects per pixel the nearest face (the lower id on a depth tie), pass
-	// 2 lets the winner write its payload, then the uncovered pixels are cleared (both maps are
-	// preset so no pixel can carry this view's previous iteration forward: faceMap to NO_ID,
-	// which the Debug check in the last kernel would otherwise let a stale id satisfy, and
-	// depthMap to 0, so that a pixel missing its payload reads as uncovered downstream instead of
-	// pairing a stale depth with a NO_ID face)
+	// pass 1 elects per pixel the nearest face (the lower id on a depth tie), pass 2 lets the
+	// winner write its payload; both maps are preset so that no pixel carries this view's
+	// previous evaluation forward: faceMap to NO_ID, depthMap to 0 (uncovered downstream)
 	const MVS::CUDA::Camera cudaCamera(MakeCUDACamera(camera, size));
 	const FIndex numFaces(scene.mesh.faces.GetSize());
 	reportCudaError(cuMemsetD32(view.faceMap, NO_ID, size.area()));
@@ -975,13 +949,10 @@ void MeshRefineCUDA::ProcessPair(uint32_t idxImageA, uint32_t idxImageB, uint32_
 		OPTREFINE::nImageGradient == 3, RegularizationScale,
 		OPTREFINE::fGateMeanDiff, OPTREFINE::fGateVarRatio,
 		viewA.size.width, viewA.size.height, stream);
-	// the atomic-free accumulation over the faces view A owns, in tile order: every face folds
-	// its pixels into its own slots, then the vertices they reach count the direction (see
-	// kernelAccumulateFacePhoto); the grid is sized by the slice as it is now, with a margin
-	// for the evaluations replaying this launch from the graph
+	// the atomic-free accumulation over the faces view A owns, in tile order (see
+	// kernelAccumulateFacePhoto); the grid is sized by the slice as it is now
 	const FIndex numFaces(scene.mesh.faces.GetSize());
 	const VIndex numVertices(scene.mesh.vertices.GetSize());
-	const uint32_t numOwners(ownerOffsetsHost[idxImageA+1]-ownerOffsetsHost[idxImageA]);
 	MVS::CUDA::LaunchAccumulateFacePhoto(
 		(const MVS::CUDA::Point3*)(CUdeviceptr)vertices,
 		(const MVS::CUDA::Point3u*)(CUdeviceptr)faces,
@@ -997,7 +968,7 @@ void MeshRefineCUDA::ProcessPair(uint32_t idxImageA, uint32_t idxImageB, uint32_
 		(uint32_t*)(CUdeviceptr)vertexStamp,
 		(float*)TermsPtr(TermsLayout(numVertices).photoCount),
 		direction,
-		cudaCamA, MAXF(1u, (numOwners + numOwners/4 + MVS::CUDA::AccumulateBlockSize - 1) / MVS::CUDA::AccumulateBlockSize), stream);
+		cudaCamA, ownerOffsetsHost[idxImageA+1]-ownerOffsetsHost[idxImageA], stream);
 }
 
 void MeshRefineCUDA::ComputeSmoothnessGradient(uint32_t numVertices)
@@ -1042,8 +1013,6 @@ bool Scene::RefineMeshCUDA(unsigned nResolutionLevel, unsigned nMinResolution, u
 			fRegularityWeight, 1.f/MeshRefineStep::StepMax);
 		return false;
 	}
-	// an unknown stencil id used to fall silently to the default one, so an A/B that asked for a
-	// stencil this build does not have measured the default twice
 	if (OPTREFINE::nImageGradient < 0 || OPTREFINE::nImageGradient > 3) {
 		VERBOSE("error: image gradient stencil %d is not implemented (0 - 3x5 separable, 1 - central, 2 - Sobel, 3 - bilinear interpolant derivative)", OPTREFINE::nImageGradient);
 		return false;
@@ -1115,10 +1084,10 @@ bool Scene::RefineMeshCUDA(unsigned nResolutionLevel, unsigned nMinResolution, u
 			refine.iteration = stepper.GetNumEvaluated();
 			MeshRefineStep::Terms terms;
 			const bool bScoreOK(refine.ScoreMesh(terms));
-			// a CUDA fault poisons the whole context: every later call fails, so without this the
-			// loop would keep "refining" a mesh nothing updates any more and still return success;
-			// giving up lets the caller fall back to the CPU path. A false bScoreOK is a download
-			// failure ScoreMesh already reported, folded into the same branch without a second message
+			// a CUDA fault poisons the whole context: every later call fails, so the loop would
+			// keep "refining" a mesh nothing updates any more; giving up lets the caller fall
+			// back to the CPU path. A false bScoreOK is a download failure ScoreMesh already
+			// reported, folded into the same branch without a second message
 			if (!bScoreOK || cuCtxSynchronize() != CUDA_SUCCESS) {
 				GET_LOGCONSOLE().Play();
 				if (bScoreOK)
@@ -1128,15 +1097,14 @@ bool Scene::RefineMeshCUDA(unsigned nResolutionLevel, unsigned nMinResolution, u
 			}
 			if (refine.S < 0) {
 				// no image pair contributed a single masked pixel (see ScoreMesh): an expected,
-				// recoverable outside-world failure -- abort the refinement loudly
+				// recoverable outside-world failure, so abort the refinement loudly
 				VERBOSE("error: no image pair overlap at scale %u: mesh refinement aborted", nScale);
 				GET_LOGCONSOLE().Play();
 				bCudaFailed = true;
 				return MeshRefineStep::STOP;
 			}
 			#ifdef _DEBUG
-			// a non-finite gradient is a producer bug and must fire, not be silently skipped (the
-			// legacy loop's `if (!ISFINITE(grad)) continue;` is gone along with the legacy loop)
+			// a non-finite term is a producer bug and must fire, not be skipped
 			FOREACH(v, mesh.vertices) {
 				ASSERT(ISFINITE(terms.photoGrad[v]));
 				ASSERT(ISFINITE(terms.photoCount[v]));

--- a/libs/MVS/SceneRefineCUDA.cpp
+++ b/libs/MVS/SceneRefineCUDA.cpp
@@ -68,9 +68,6 @@ typedef Mesh::FIndex FIndex;
 
 class MeshRefineCUDA {
 public:
-	typedef Mesh::FaceIdxArr CameraFaces;
-	typedef CLISTDEF2(CameraFaces) CameraFacesArr;
-
 	// store necessary data about a view
 	struct View {
 		Image32F imageHost; // store temporarily the image pixels
@@ -81,7 +78,7 @@ public:
 		SEACAVE::CUDA::ArrayRT32F imageGrad[2]; // x/y derivatives (ComputeRefineImageGradient), sampled by the photometric kernel; kept in float like the CPU's View::imageGrad (half-float cannot hold the sub-6e-5 values a derivative stencil produces on flat regions)
 		SEACAVE::CUDA::MemDevice depthMap;
 		SEACAVE::CUDA::MemDevice faceMap;
-		SEACAVE::CUDA::MemDevice baryMap;
+		SEACAVE::CUDA::MemDevice baryMap; // one ushort4 per pixel: the three half barycentrics and a pad, one 8-byte word each way
 		SEACAVE::CUDA::MemDevice keepMask; // one byte per pixel (non-zero = keep), uploaded from keepMaskHost only when non-empty; invalid (unallocated) == keep everything
 	};
 	typedef CLISTDEF2(View) ViewsArr;
@@ -121,26 +118,30 @@ public:
 
 	void ComputeNormalFaces();
 
-	// downloads the raw per-vertex terms (BEFORE any combine) into the caller's host arrays,
-	// each numVertices long, and leaves the reliability-weighted score in S (S < 0 means no
-	// image pair contributed a single masked pixel -- see the sumR check below); the stepper
+	// one energy evaluation: leaves the raw per-vertex terms (BEFORE any combine) in the pinned
+	// host buffer `terms` is pointed into, and the reliability-weighted score in S (S < 0 means
+	// no image pair contributed a single masked pixel -- see the sumR check below); the stepper
 	// (MeshRefineStep, SceneRefineCommon.h) does the combining, not this function. Returns false
-	// (having already VERBOSE'd why) if a GPU->host download failed: a non-sticky copy failure
+	// (having already VERBOSE'd why) if the GPU->host download failed: a non-sticky copy failure
 	// is not caught by the caller's cuCtxSynchronize() check and would otherwise hand the
 	// stepper finite-looking garbage.
-	bool ScoreMesh(Point3f* photoGradOut, float* photoGradNormOut, float* footprintOut, Point3f* smoothGrad1Out, Point3f* smoothGrad2Out);
+	bool ScoreMesh(MeshRefineStep::Terms& terms);
 
-	void ProjectMesh(
-		const CameraFaces& cameraFaces,
-		const Camera& camera, const Image8U::Size& size, uint32_t idxImage);
-	void ProcessPair(uint32_t idxImageA, uint32_t idxImageB);
-	void ImageMeshWarp(
-		const Camera& cameraA, const Camera& cameraB, const Image8U::Size& size,
-		uint32_t idxImageA, uint32_t idxImageB);
-	void ComputeWindowStats(cudaSurfaceObject_t surfImageA, cudaSurfaceObject_t surfImageProj, const Image8U::Size& size);
-	void ComputePhotometricGradient(const Camera& cameraA, const Camera& cameraB, const Image8U::Size& size,
-		uint32_t idxImageA, uint32_t idxImageB, uint32_t numVertices, float RegularizationScale);
+	void ProjectMesh(const Camera& camera, const Image8U::Size& size, uint32_t idxImage);
+	// one pair-direction: warp B into A, the window statistics with the per-pixel photometric
+	// term, then its accumulation; numSlots counts the window-statistics blocks written so far
+	// into statsBlockSums, which ScoreMesh() reduces once at the end
+	void ProcessPair(uint32_t idxImageA, uint32_t idxImageB, uint32_t& numSlots);
 	void ComputeSmoothnessGradient(uint32_t numVertices);
+
+	// float offsets of the fields of `terms`/`termsHost` for N vertices
+	struct TermsLayout {
+		size_t photoGrad, lap, bilap, photoCount, footprint, sums, size;
+		explicit TermsLayout(size_t N) : photoGrad(0), lap(3*N), bilap(6*N), photoCount(9*N), footprint(10*N), sums(11*N), size(11*N+2) {}
+	};
+	CUdeviceptr TermsPtr(size_t offset) const { return (CUdeviceptr)terms + sizeof(float)*offset; }
+	// how many pair-directions one ScoreMesh() runs
+	uint32_t NumDirections() const { return (uint32_t)pairs.GetSize() * (nAlternatePair == 0 ? 2u : 1u); }
 
 public:
 	const float weightRegularity; // a scalar regularity weight to balance between photo-consistency and regularization terms
@@ -169,23 +170,23 @@ public:
 	SEACAVE::CUDA::MemDevice faces;
 	SEACAVE::CUDA::MemDevice faceNormals;
 	SEACAVE::CUDA::MemDevice mask; // warp validity, the window-sum input
-	SEACAVE::CUDA::MemDevice maskStats; // mask pruned by MinWindowCount and the rejection gates; what every consumer after ComputeWindowStats reads
+	SEACAVE::CUDA::MemDevice maskStats; // the pixels that contribute a photometric term: mask pruned by MinWindowCount, the rejection gates and the grazing-angle test (kernelComputeWindowStats)
 	SEACAVE::CUDA::MemDevice projKey; // rasterizer scratch, one (depth,face) 64-bit key per pixel of the largest view
 	size_t projKeyPixels = 0; // pixels projKey was allocated for (ProjectMesh asserts every view fits)
 	SEACAVE::CUDA::ArrayRT32F imageAB; // warped image B in A, float like the CPU's imageAB
-	SEACAVE::CUDA::MemDevice imageDZNCC;
-	SEACAVE::CUDA::MemDevice photoGrad;
-	SEACAVE::CUDA::MemDevice photoGradNorm;
-	SEACAVE::CUDA::MemDevice footprint; // per-vertex scene units per pixel; 0 exactly where photoGradNorm == 0 (SceneRefineCommon.h)
-	// per-FACE private accumulators of one pair-direction's photometric term: the atomic-free
-	// replacement for the old per-pixel scatter (see kernelAccumulateFacePhoto). Sized for the
-	// whole mesh and rewritten in full by every accumulation launch, so they never need clearing.
-	SEACAVE::CUDA::MemDevice faceAcc; // 3 floats per face: Sum g_p*b_c per corner
-	SEACAVE::CUDA::MemDevice facePixels; // 1 float per face: contributing pixel count
-	SEACAVE::CUDA::MemDevice faceFoot; // 1 float per face: min footprint over the face's pixels
-	SEACAVE::CUDA::MemDevice sumR; // device scalar: Sum r, accumulated by kernelComputeWindowStats/kernelReduceBlockSums over one ScoreMesh() call
-	SEACAVE::CUDA::MemDevice sumRZ; // device scalar: Sum r*(1-ZNCC), same accumulation window as sumR
-	SEACAVE::CUDA::MemDevice statsBlockSums; // 2 floats per window-stats block of the largest view: the partials sumR/sumRZ are folded from, in block order
+	SEACAVE::CUDA::MemDevice pixelGrad; // per pixel of the largest view: g_p, the photometric term the covering face's corners share (kernelComputeWindowStats)
+	SEACAVE::CUDA::MemDevice statsBlockSums; // 2 floats per window-statistics block of every pair-direction of one ScoreMesh(): the partials S is folded from, in slot order
+	// the raw per-vertex terms of one evaluation in ONE device buffer, so that a single download
+	// into its pinned host mirror hands the stepper everything it reads (five pageable copies used
+	// to be a sync point each, staged through the driver's bounce buffer); see TermsLayout
+	SEACAVE::CUDA::MemDevice terms;
+	float* termsHost = NULL;
+	// per-FACE private accumulators of the photometric term, the atomic-free replacement for a
+	// per-pixel scatter (see kernelAccumulateFacePhoto), in one buffer: 3 floats per face for the
+	// corners' Sum g_p*b_c, 1 for the pixel count, 1 for the min footprint; accumulated over the
+	// pair-directions of one ScoreMesh() and cleared once per call
+	SEACAVE::CUDA::MemDevice faceTerms;
+	SEACAVE::CUDA::MemDevice vertexSeen; // 1 byte per vertex: the mark a direction's contributing faces leave for kernelCountSeenVertices
 	SEACAVE::CUDA::MemDevice vertexVerticesCont;
 	SEACAVE::CUDA::MemDevice vertexVerticesSizes;
 	SEACAVE::CUDA::MemDevice vertexVerticesPointers;
@@ -195,8 +196,6 @@ public:
 	SEACAVE::CUDA::MemDevice vertexFacesSizes;
 	SEACAVE::CUDA::MemDevice vertexFacesPointers;
 	SEACAVE::CUDA::MemDevice vertBoundary; // per-vertex 0/1 boundary flag (shared valence/boundary split, see ListVertexFacesPost())
-	SEACAVE::CUDA::MemDevice smoothGrad1;
-	SEACAVE::CUDA::MemDevice smoothGrad2;
 };
 
 MeshRefineCUDA::MeshRefineCUDA(Scene& _scene, unsigned _nAlternatePair, float _weightRegularity, unsigned _nResolutionLevel, unsigned _nMinResolution, unsigned nMaxViews)
@@ -231,6 +230,7 @@ MeshRefineCUDA::~MeshRefineCUDA()
 	for (auto& v : viewGPU)
 		v.Release();
 	if (surfImageProjObj) cudaDestroySurfaceObject(surfImageProjObj);
+	if (termsHost) reportCudaError(cuMemFreeHost(termsHost));
 	scene.mesh.ReleaseExtra();
 }
 
@@ -335,7 +335,7 @@ bool MeshRefineCUDA::InitImages(float scale, float sigma)
 		const size_t area((size_t)size.area());
 		reportCudaError(view.depthMap.Reset(sizeof(float)*area));
 		reportCudaError(view.faceMap.Reset(sizeof(FIndex)*area));
-		reportCudaError(view.baryMap.Reset(sizeof(hfloat)*3*area));
+		reportCudaError(view.baryMap.Reset(sizeof(ushort4)*area));
 		if (view.keepMaskHost.empty()) {
 			view.keepMask.Release();
 		} else {
@@ -364,14 +364,12 @@ bool MeshRefineCUDA::InitImages(float scale, float sigma)
 	reportCudaError(projKey.Reset(sizeof(uint64_t)*area));
 	projKeyPixels = area;
 	reportCudaError(imageAB.Reset(maxSize, CUDA_ARRAY3D_SURFACE_LDST));
-	reportCudaError(imageDZNCC.Reset(sizeof(float)*area));
-	reportCudaError(sumR.Reset(sizeof(float)));
-	reportCudaError(sumRZ.Reset(sizeof(float)));
-	// one slot per 16x16 block of the window-statistics grid; the largest view's width and height
-	// need not come from the same view, so this is an upper bound rather than an exact count
+	reportCudaError(pixelGrad.Reset(sizeof(float)*area));
+	// one slot per 16x16 block of the window-statistics grid per pair-direction; the largest
+	// view's width and height need not come from the same view, so this is an upper bound
 	{
 		const size_t maxBlocks(((size_t)maxSize.width + 15)/16 * (((size_t)maxSize.height + 15)/16));
-		reportCudaError(statsBlockSums.Reset(sizeof(float)*2*maxBlocks));
+		reportCudaError(statsBlockSums.Reset(sizeof(float)*2*maxBlocks*NumDirections()));
 	}
 	// create surface object for projected image
 	{
@@ -406,8 +404,8 @@ void MeshRefineCUDA::ListVertexFacesPost()
 	// still divides by a boundary neighbour's true valence
 	// the incident FACES of each vertex are flattened the same way, in the order
 	// Mesh::ListIncidentFaces produced (ListVertexFacesPre(), above): kernelGatherVertexPhoto
-	// walks that fixed order to sum one pair-direction's photometric term for the vertex, which
-	// is what makes the sum reproducible without atomics
+	// walks that fixed order to sum the photometric term for the vertex, which is what makes the
+	// sum reproducible without atomics
 	const size_t numVertices(scene.mesh.vertices.GetSize());
 	ASSERT(scene.mesh.vertexFaces.GetSize() == numVertices);
 	Unsigned32Arr _vertexVerticesCont(0, numVertices*6);
@@ -438,43 +436,29 @@ void MeshRefineCUDA::ListVertexFacesPost()
 	reportCudaError(vertexFacesCont.Reset(_vertexFacesCont));
 	reportCudaError(vertexFacesSizes.Reset(_vertexFacesSizes));
 	reportCudaError(vertexFacesPointers.Reset(_vertexFacesPointers));
-	// init memory
-	reportCudaError(photoGrad.Reset(sizeof(Point3f)*numVertices));
-	reportCudaError(photoGradNorm.Reset(sizeof(float)*numVertices));
-	reportCudaError(footprint.Reset(sizeof(float)*numVertices));
-	reportCudaError(smoothGrad1.Reset(sizeof(Point3f)*numVertices));
-	reportCudaError(smoothGrad2.Reset(sizeof(Point3f)*numVertices));
-	// the per-face accumulators the photometric pass reduces into (20 bytes per face); this mesh
-	// is final for the scale, so they are sized once here
-	const size_t numFaces(scene.mesh.faces.GetSize());
-	reportCudaError(faceAcc.Reset(sizeof(float)*3*numFaces));
-	reportCudaError(facePixels.Reset(sizeof(float)*numFaces));
-	reportCudaError(faceFoot.Reset(sizeof(float)*numFaces));
+	// the evaluation buffers, sized once here since this mesh is final for the scale: the terms
+	// and their pinned mirror, the per-face accumulators (20 bytes per face) and the vertex marks
+	// (cleared once; kernelCountSeenVertices leaves them clear)
+	const TermsLayout layout(numVertices);
+	reportCudaError(terms.Reset(sizeof(float)*layout.size));
+	if (termsHost)
+		reportCudaError(cuMemFreeHost(termsHost));
+	reportCudaError(cuMemAllocHost((void**)&termsHost, sizeof(float)*layout.size));
+	reportCudaError(faceTerms.Reset(sizeof(float)*5*scene.mesh.faces.GetSize()));
+	reportCudaError(vertexSeen.Reset(numVertices));
+	reportCudaError(cuMemsetD8(vertexSeen, 0, numVertices));
 }
 
-// extract array of faces viewed by each image
+// upload the current vertices and rasterize the mesh into every view (depth, face and
+// barycentric maps): the whole mesh each time, the kernel rejecting the faces a view does not
+// see -- see kernelProjectMesh for why no host-side frustum cull shortlists them
 void MeshRefineCUDA::ListCameraFaces()
 {
-	// extract array of faces viewed by each camera
-	CameraFacesArr arrCameraFaces(images.GetSize()); {
-		Mesh::Octree octree;
-		Mesh::FacesInserter::CreateOctree(octree, scene.mesh);
-		FOREACH(ID, images) {
-			const Image& imageData = images[ID];
-			if (!imageData.IsValid())
-				continue;
-			const TFrustum<float,5> frustum(Matrix3x4f(imageData.camera.P), (float)imageData.width, (float)imageData.height);
-			Mesh::FacesInserter inserter(arrCameraFaces[ID]);
-			octree.Traverse(frustum, inserter);
-		}
-	}
-
-	// project mesh to each camera plane
 	reportCudaError(vertices.Reset(scene.mesh.vertices));
 	FOREACH(idxImage, images) {
 		const Image& imageData = images[idxImage];
 		if (imageData.IsValid())
-			ProjectMesh(arrCameraFaces[idxImage], imageData.camera, views[idxImage].size, idxImage);
+			ProjectMesh(imageData.camera, views[idxImage].size, idxImage);
 	}
 }
 
@@ -548,137 +532,126 @@ void MeshRefineCUDA::ComputeNormalFaces()
 }
 
 
-// score mesh using photo-consistency
-// and download the raw per-vertex terms (photoGrad/photoGradNorm/footprint/smoothGrad1/smoothGrad2)
-// the caller's stepper (MeshRefineStep, SceneRefineCommon.h) combines into a step
-bool MeshRefineCUDA::ScoreMesh(Point3f* photoGradOut, float* photoGradNormOut, float* footprintOut, Point3f* smoothGrad1Out, Point3f* smoothGrad2Out)
+// score mesh using photo-consistency and leave the raw per-vertex terms in `out`, pointing into
+// the pinned host buffer; the caller's stepper (MeshRefineStep, SceneRefineCommon.h) combines
+// them into a step
+bool MeshRefineCUDA::ScoreMesh(MeshRefineStep::Terms& out)
 {
-	// every GPU->host download this function's callers depend on goes through this: reportCudaError
-	// alone only logs and keeps going, so a non-sticky copy failure (unlike a poisoned context,
-	// which cuCtxSynchronize() catches) would otherwise hand the stepper finite-looking garbage
-	const auto CheckDownload = [this](CUresult ret, const char* name) -> bool {
-		if (ret != CUDA_SUCCESS) {
-			VERBOSE("error: failed downloading %s from the GPU at scale %u, iteration %u", name, nScale, iteration);
-			return false;
-		}
-		return true;
-	};
-
-	// extract array of faces viewed by each camera
+	// rasterize the current vertices into every view, then the terms that need nothing else:
+	// the face normals and the two smoothness terms queue up behind the rasterization and run
+	// while the host is still issuing the pairs
 	ListCameraFaces();
-
-	// compute face normals
 	ComputeNormalFaces();
-
-	// init memory
 	const VIndex numVertices(scene.mesh.vertices.GetSize());
-	reportCudaError(cuMemsetD32(photoGrad, 0, numVertices*3));
-	reportCudaError(cuMemsetD32(photoGradNorm, 0, numVertices));
-	reportCudaError(cuMemsetD32(footprint, 0x7F7FFFFF, numVertices)); // FLT_MAX sentinel, resolved below
-	reportCudaError(cuMemsetD32(sumR, 0, 1));
-	reportCudaError(cuMemsetD32(sumRZ, 0, 1));
+	const TermsLayout layout(numVertices);
+	ComputeSmoothnessGradient(numVertices);
+
+	// clear this evaluation's accumulators: the per-vertex direction count and the per-face
+	// slots (0, and the FLT_MAX the footprint mins start from)
+	const FIndex numFaces(scene.mesh.faces.GetSize());
+	reportCudaError(cuMemsetD32(TermsPtr(layout.photoCount), 0, numVertices));
+	reportCudaError(cuMemsetD32(faceTerms, 0, (size_t)numFaces*4));
+	reportCudaError(cuMemsetD32((CUdeviceptr)faceTerms + sizeof(float)*4*numFaces, 0x7F7FFFFF, numFaces));
 
 	// for each pair of images, compute a photo-consistency score
 	// between the reference image and the pixels of the second image
 	// projected in the reference image through the mesh surface
+	uint32_t numSlots(0);
 	FOREACHPTR(pPair, pairs) {
 		ASSERT(pPair->i < pPair->j);
 		switch (nAlternatePair) {
 		case 1: {
 			const PairIdx pair(iteration%2 ? PairIdx(pPair->j,pPair->i) : PairIdx(pPair->i,pPair->j));
-			ProcessPair(pair.i, pair.j);
+			ProcessPair(pair.i, pair.j, numSlots);
 			break; }
 		case 2: {
-			ProcessPair(pPair->i, pPair->j);
+			ProcessPair(pPair->i, pPair->j, numSlots);
 			break; }
 		case 3: {
-			ProcessPair(pPair->j, pPair->i);
+			ProcessPair(pPair->j, pPair->i, numSlots);
 			break; }
 		default:
 			for (int ip=0; ip<2; ++ip) {
 				const PairIdx pair(ip ? PairIdx(pPair->j,pPair->i) : PairIdx(pPair->i,pPair->j));
-				ProcessPair(pair.i, pair.j);
+				ProcessPair(pair.i, pair.j, numSlots);
 			}
 		}
 	}
 
-	// resolve the footprint sentinel now that photoGradNorm holds its final per-vertex count
-	// (contract: footprint[v] > 0 exactly where photoGradNorm[v] > 0), exactly like the CPU's
-	// ScoreMesh resolves it at the same point
-	MVS::CUDA::LaunchFinalizePhotoGrad(
-		(const float*)(CUdeviceptr)photoGradNorm,
-		(float*)(CUdeviceptr)footprint,
+	// the two sums S is made of and the per-vertex photometric term, then everything comes down
+	// in one copy
+	MVS::CUDA::LaunchReduceBlockSums(
+		(const float*)(CUdeviceptr)statsBlockSums, numSlots,
+		(float*)TermsPtr(layout.sums), (float*)TermsPtr(layout.sums+1));
+	MVS::CUDA::LaunchGatherVertexPhoto(
+		(const MVS::CUDA::Point3u*)(CUdeviceptr)faces,
+		(const MVS::CUDA::Point3*)(CUdeviceptr)faceNormals,
+		(const uint32_t*)(CUdeviceptr)vertexFacesCont,
+		(const uint32_t*)(CUdeviceptr)vertexFacesSizes,
+		(const uint32_t*)(CUdeviceptr)vertexFacesPointers,
+		(const float*)(CUdeviceptr)faceTerms,
+		(const float*)((CUdeviceptr)faceTerms + sizeof(float)*3*numFaces),
+		(const float*)((CUdeviceptr)faceTerms + sizeof(float)*4*numFaces),
+		(MVS::CUDA::Point3*)TermsPtr(layout.photoGrad),
+		(float*)TermsPtr(layout.footprint),
 		numVertices);
+	if (reportCudaError(terms.GetData(termsHost, sizeof(float)*layout.size)) != CUDA_SUCCESS) {
+		VERBOSE("error: failed downloading the refinement terms from the GPU at scale %u, iteration %u", nScale, iteration);
+		return false;
+	}
 
 	// S = sumRZ/sumR, the reliability-weighted mean of (1-ZNCC). sumR == 0 means no pair-direction
 	// contributed a single masked pixel -- broken outside-world input (no pair overlap, bad
 	// poses), not an internal invariant, so it gets the runtime-validation treatment instead of
 	// an ASSERT alone (which would compile out in Release and feed the stepper NaN): S is left
 	// negative and the caller fails the refinement loudly, exactly like MeshRefine::ScoreMesh
-	float hSumR, hSumRZ;
-	if (!CheckDownload(reportCudaError(sumR.GetData(&hSumR, sizeof(float))), "sumR") ||
-		!CheckDownload(reportCudaError(sumRZ.GetData(&hSumRZ, sizeof(float))), "sumRZ"))
-		return false;
-	if (hSumR > 0) {
-		S = hSumRZ/hSumR;
+	const float sumR(termsHost[layout.sums]), sumRZ(termsHost[layout.sums+1]);
+	if (sumR > 0) {
+		S = sumRZ/sumR;
 		ASSERT(S >= 0 && S <= 2);
 	} else {
 		S = -1.f;
 	}
-
-	// loop through all vertices and compute the smoothing score
-	ComputeSmoothnessGradient(numVertices);
-
-	// download the raw per-vertex terms: the caller's stepper does the combining
-	if (!CheckDownload(reportCudaError(photoGrad.GetData(photoGradOut, sizeof(Point3f)*numVertices)), "photoGrad") ||
-		!CheckDownload(reportCudaError(photoGradNorm.GetData(photoGradNormOut, sizeof(float)*numVertices)), "photoGradNorm") ||
-		!CheckDownload(reportCudaError(footprint.GetData(footprintOut, sizeof(float)*numVertices)), "footprint") ||
-		!CheckDownload(reportCudaError(smoothGrad1.GetData(smoothGrad1Out, sizeof(Point3f)*numVertices)), "smoothGrad1") ||
-		!CheckDownload(reportCudaError(smoothGrad2.GetData(smoothGrad2Out, sizeof(Point3f)*numVertices)), "smoothGrad2"))
-		return false;
+	out.photoGrad = (const MeshRefineStep::Grad*)(termsHost + layout.photoGrad);
+	out.photoCount = termsHost + layout.photoCount;
+	out.footprint = termsHost + layout.footprint;
+	out.lap = (const MeshRefineStep::Grad*)(termsHost + layout.lap);
+	out.bilap = (const MeshRefineStep::Grad*)(termsHost + layout.bilap);
+	out.S = S;
+	out.numVertices = numVertices;
 	return true;
 }
 
 
 // project mesh to the given camera plane
-void MeshRefineCUDA::ProjectMesh(
-	const CameraFaces& cameraFaces,
-	const Camera& camera, const Image8U::Size& size, uint32_t idxImage)
+void MeshRefineCUDA::ProjectMesh(const Camera& camera, const Image8U::Size& size, uint32_t idxImage)
 {
 	View& view = views[idxImage];
 	ASSERT(projKey.IsValid() && (size_t)size.area() <= projKeyPixels);
 	// pass 1 needs every pixel key at "no face yet" = ~0ull (larger than any real (depth,face) key)
 	reportCudaError(cuMemsetD32(projKey, 0xFFFFFFFFu, 2*(size_t)size.area()));
-	// fetch only the faces viewed by this camera
-	Mesh::FaceIdxArr faceIDsView(0, (FIndex)cameraFaces.size());
-	for (auto idxFace : cameraFaces)
-		faceIDsView.Insert(idxFace);
-	// project mesh: pass 1 elects per pixel the nearest face (first in cameraFaces order on a
-	// depth tie, the CPU's rule), pass 2 lets the winner write its payload, then the uncovered
-	// pixels are cleared (both maps are preset so no pixel can carry this view's previous
-	// iteration forward: faceMap to NO_ID, which the Debug check in the last kernel would
-	// otherwise let a stale id satisfy, and depthMap to 0, so that a pixel missing its payload
-	// reads as uncovered downstream instead of pairing a stale depth with a NO_ID face)
-	SEACAVE::CUDA::MemDevice devFaceIDs(faceIDsView);
+	// project mesh: pass 1 elects per pixel the nearest face (the lower id on a depth tie), pass
+	// 2 lets the winner write its payload, then the uncovered pixels are cleared (both maps are
+	// preset so no pixel can carry this view's previous iteration forward: faceMap to NO_ID,
+	// which the Debug check in the last kernel would otherwise let a stale id satisfy, and
+	// depthMap to 0, so that a pixel missing its payload reads as uncovered downstream instead of
+	// pairing a stale depth with a NO_ID face)
 	const MVS::CUDA::Camera cudaCamera(MakeCUDACamera(camera, size));
+	const FIndex numFaces(scene.mesh.faces.GetSize());
 	reportCudaError(cuMemsetD32(view.faceMap, NO_ID, size.area()));
 	reportCudaError(cuMemsetD32(view.depthMap, 0, size.area()));
 	for (int pass=0; pass<2; ++pass)
 		MVS::CUDA::LaunchProjectMesh(
 			(const MVS::CUDA::Point3*)(CUdeviceptr)vertices,
 			(const MVS::CUDA::Point3u*)(CUdeviceptr)faces,
-			(const uint32_t*)(CUdeviceptr)devFaceIDs,
 			(unsigned long long*)(CUdeviceptr)projKey,
 			(float*)(CUdeviceptr)view.depthMap,
 			(uint32_t*)(CUdeviceptr)view.faceMap,
-			(uint16_t*)(CUdeviceptr)view.baryMap,
-			cudaCamera,
-			faceIDsView.GetSize(),
-			pass == 1);
+			(ushort4*)(CUdeviceptr)view.baryMap,
+			cudaCamera, numFaces, pass == 1);
 	#ifdef _DEBUG
-	// every covered pixel must hold the payload of exactly the thread that won its key
+	// every covered pixel must hold the payload of exactly the face that won its key
 	MVS::CUDA::LaunchCheckProjection(
-		(const uint32_t*)(CUdeviceptr)devFaceIDs,
 		(const unsigned long long*)(CUdeviceptr)projKey,
 		(const float*)(CUdeviceptr)view.depthMap,
 		(const uint32_t*)(CUdeviceptr)view.faceMap,
@@ -686,125 +659,83 @@ void MeshRefineCUDA::ProjectMesh(
 	#endif
 }
 
-void MeshRefineCUDA::ProcessPair(uint32_t idxImageA, uint32_t idxImageB)
+void MeshRefineCUDA::ProcessPair(uint32_t idxImageA, uint32_t idxImageB, uint32_t& numSlots)
 {
-	// fetch view A data
 	const Image& imageDataA = images[idxImageA];
-	ASSERT(imageDataA.IsValid());
-	const Camera& cameraA = imageDataA.camera;
-	const Image8U::Size& sizeA(views[idxImageA].size);
-	// fetch view B data
 	const Image& imageDataB = images[idxImageB];
-	ASSERT(imageDataB.IsValid());
-	const Camera& cameraB = imageDataB.camera;
+	ASSERT(imageDataA.IsValid() && imageDataB.IsValid());
+	const View& viewA = views[idxImageA];
+	const View& viewB = views[idxImageB];
+	const MVS::CUDA::Camera cudaCamA(MakeCUDACamera(imageDataA.camera, viewA.size));
+	const MVS::CUDA::Camera cudaCamB(MakeCUDACamera(imageDataB.camera, viewB.size));
 	// warp imageB to imageA using the mesh
-	ImageMeshWarp(cameraA, cameraB, sizeA, idxImageA, idxImageB);
-	// masked window statistics, rejection gates, ZNCC and its derivative; prunes mask into maskStats
-	ComputeWindowStats(viewGPU[idxImageA].surfObj, surfImageProjObj, sizeA);
-	const float RegularizationScale((float)((REAL)(imageDataA.avgDepth*imageDataB.avgDepth)/(cameraA.GetFocalLength()*cameraB.GetFocalLength())));
-	ComputePhotometricGradient(cameraA, cameraB, sizeA, idxImageA, idxImageB, scene.mesh.vertices.GetSize(), RegularizationScale);
-}
-
-// project image from view B to view A through the mesh;
-// the projected image is stored in imageA
-void MeshRefineCUDA::ImageMeshWarp(
-	const Camera& cameraA, const Camera& cameraB, const Image8U::Size& size,
-	uint32_t idxImageA, uint32_t idxImageB)
-{
-	// project image
 	MVS::CUDA::LaunchImageMeshWarp(
-		(const float*)(CUdeviceptr)views[idxImageA].depthMap,
-		(const float*)(CUdeviceptr)views[idxImageB].depthMap,
-		views[idxImageA].keepMask.IsValid() ? (const uint8_t*)(CUdeviceptr)views[idxImageA].keepMask : NULL,
-		views[idxImageB].keepMask.IsValid() ? (const uint8_t*)(CUdeviceptr)views[idxImageB].keepMask : NULL,
+		(const float*)(CUdeviceptr)viewA.depthMap,
+		(const float*)(CUdeviceptr)viewB.depthMap,
+		viewA.keepMask.IsValid() ? (const uint8_t*)(CUdeviceptr)viewA.keepMask : NULL,
+		viewB.keepMask.IsValid() ? (const uint8_t*)(CUdeviceptr)viewB.keepMask : NULL,
 		(uint8_t*)(CUdeviceptr)mask,
-		MakeCUDACamera(cameraA, size),
-		MakeCUDACamera(cameraB, views[idxImageB].size),
-		viewGPU[idxImageB].texObj,
-		surfImageProjObj);
-}
-
-// masked window statistics, rejection gates, ZNCC and its per-pixel derivative, in one kernel
-void MeshRefineCUDA::ComputeWindowStats(cudaSurfaceObject_t surfImageA, cudaSurfaceObject_t surfImageProj, const Image8U::Size& size)
-{
-	MVS::CUDA::LaunchComputeWindowStats(
+		cudaCamA, cudaCamB, viewGPU[idxImageB].texObj, surfImageProjObj);
+	// masked window statistics, rejection gates, ZNCC and its derivative, and the per-pixel
+	// photometric term; mode 3 samples the bilinear interpolant of image B directly and needs no
+	// precomputed gradient stencil texture (InitImages never uploads one in that mode)
+	const float RegularizationScale((float)((REAL)(imageDataA.avgDepth*imageDataB.avgDepth)/(imageDataA.camera.GetFocalLength()*imageDataB.camera.GetFocalLength())));
+	numSlots += MVS::CUDA::LaunchComputeWindowStats(
 		(const uint8_t*)(CUdeviceptr)mask,
 		(uint8_t*)(CUdeviceptr)maskStats,
-		(float*)(CUdeviceptr)imageDZNCC,
-		surfImageA, surfImageProj,
-		(float*)(CUdeviceptr)sumR,
-		(float*)(CUdeviceptr)sumRZ,
-		(float*)(CUdeviceptr)statsBlockSums,
+		(float*)(CUdeviceptr)pixelGrad,
+		(float*)((CUdeviceptr)statsBlockSums + sizeof(float)*2*numSlots),
+		viewGPU[idxImageA].surfObj, surfImageProjObj,
+		(const MVS::CUDA::Point3*)(CUdeviceptr)faceNormals,
+		(const uint32_t*)(CUdeviceptr)viewA.faceMap,
+		(const float*)(CUdeviceptr)viewA.depthMap,
+		cudaCamA, cudaCamB,
+		viewGPU[idxImageB].texObj, viewGPU[idxImageB].texGrad[0], viewGPU[idxImageB].texGrad[1],
+		OPTREFINE::nImageGradient == 3, RegularizationScale,
 		OPTREFINE::fGateMeanDiff, OPTREFINE::fGateVarRatio,
-		size.width, size.height);
-}
-
-// compute the photometric gradient for all vertices seen by an image pair
-void MeshRefineCUDA::ComputePhotometricGradient(const Camera& cameraA, const Camera& cameraB, const Image8U::Size& size,
-	uint32_t idxImageA, uint32_t idxImageB, uint32_t numVertices, float RegularizationScale)
-{
-	const MVS::CUDA::Camera cudaCamA(MakeCUDACamera(cameraA, size));
-	const MVS::CUDA::Camera cudaCamB(MakeCUDACamera(cameraB, views[idxImageB].size));
+		viewA.size.width, viewA.size.height);
+	// the atomic-free accumulation: every face folds its pixels into its own slots, then the
+	// vertices they reach count the direction (see kernelAccumulateFacePhoto)
 	const FIndex numFaces(scene.mesh.faces.GetSize());
-	// mode 3 samples the bilinear interpolant of image B directly and needs no precomputed
-	// gradient stencil texture (InitImages never uploads one in that mode)
-	const bool bBilinearGrad(OPTREFINE::nImageGradient == 3);
-	// the atomic-free accumulation: reduce every face's pixels into its own slots, then let each
-	// vertex gather its incident faces in a fixed order, so no float sum depends on the schedule
-	// and two identical runs produce identical meshes (see kernelAccumulateFacePhoto)
+	const VIndex numVertices(scene.mesh.vertices.GetSize());
 	MVS::CUDA::LaunchAccumulateFacePhoto(
 		(const MVS::CUDA::Point3*)(CUdeviceptr)vertices,
 		(const MVS::CUDA::Point3u*)(CUdeviceptr)faces,
-		(const MVS::CUDA::Point3*)(CUdeviceptr)faceNormals,
-		(const float*)(CUdeviceptr)views[idxImageA].depthMap,
-		(const uint32_t*)(CUdeviceptr)views[idxImageA].faceMap,
-		(const uint16_t*)(CUdeviceptr)views[idxImageA].baryMap,
-		(const float*)(CUdeviceptr)imageDZNCC,
+		(const float*)(CUdeviceptr)viewA.depthMap,
+		(const uint32_t*)(CUdeviceptr)viewA.faceMap,
+		(const ushort4*)(CUdeviceptr)viewA.baryMap,
+		(const float*)(CUdeviceptr)pixelGrad,
 		(const uint8_t*)(CUdeviceptr)maskStats,
-		(float*)(CUdeviceptr)faceAcc,
-		(float*)(CUdeviceptr)facePixels,
-		(float*)(CUdeviceptr)faceFoot,
-		cudaCamA, cudaCamB,
-		viewGPU[idxImageB].texObj, viewGPU[idxImageB].texGrad[0], viewGPU[idxImageB].texGrad[1],
-		bBilinearGrad,
-		RegularizationScale,
-		numFaces);
-	MVS::CUDA::LaunchGatherVertexPhoto(
-		(const MVS::CUDA::Point3u*)(CUdeviceptr)faces,
-		(const MVS::CUDA::Point3*)(CUdeviceptr)faceNormals,
-		(const uint32_t*)(CUdeviceptr)vertexFacesCont,
-		(const uint32_t*)(CUdeviceptr)vertexFacesSizes,
-		(const uint32_t*)(CUdeviceptr)vertexFacesPointers,
-		(const float*)(CUdeviceptr)faceAcc,
-		(const float*)(CUdeviceptr)facePixels,
-		(const float*)(CUdeviceptr)faceFoot,
-		(MVS::CUDA::Point3*)(CUdeviceptr)photoGrad,
-		(float*)(CUdeviceptr)photoGradNorm,
-		(float*)(CUdeviceptr)footprint,
+		(float*)(CUdeviceptr)faceTerms,
+		(float*)((CUdeviceptr)faceTerms + sizeof(float)*3*numFaces),
+		(float*)((CUdeviceptr)faceTerms + sizeof(float)*4*numFaces),
+		(uint8_t*)(CUdeviceptr)vertexSeen,
+		cudaCamA, numFaces);
+	MVS::CUDA::LaunchCountSeenVertices(
+		(uint8_t*)(CUdeviceptr)vertexSeen,
+		(float*)TermsPtr(TermsLayout(numVertices).photoCount),
 		numVertices);
-	// this pair-direction's photoGradNorm bookkeeping is done by the gather above; the footprint
-	// sentinel is resolved separately, once, after every pair-direction of this ScoreMesh() has
-	// run (see kernelFinalizePhotoGrad)
 }
 
 void MeshRefineCUDA::ComputeSmoothnessGradient(uint32_t numVertices)
 {
 	// compute smoothness gradient for all vertices
+	const TermsLayout layout(numVertices);
 	MVS::CUDA::LaunchComputeSmoothnessGradient(
 		(const MVS::CUDA::Point3*)(CUdeviceptr)vertices,
 		(const uint32_t*)(CUdeviceptr)vertexVerticesCont,
 		(const uint32_t*)(CUdeviceptr)vertexVerticesSizes,
 		(const uint32_t*)(CUdeviceptr)vertexVerticesPointers,
 		(const uint8_t*)(CUdeviceptr)vertBoundary,
-		(MVS::CUDA::Point3*)(CUdeviceptr)smoothGrad1,
+		(MVS::CUDA::Point3*)TermsPtr(layout.lap),
 		numVertices, uint8_t(0));
 	MVS::CUDA::LaunchComputeSmoothnessGradient(
-		(const MVS::CUDA::Point3*)(CUdeviceptr)smoothGrad1,
+		(const MVS::CUDA::Point3*)TermsPtr(layout.lap),
 		(const uint32_t*)(CUdeviceptr)vertexVerticesCont,
 		(const uint32_t*)(CUdeviceptr)vertexVerticesSizes,
 		(const uint32_t*)(CUdeviceptr)vertexVerticesPointers,
 		(const uint8_t*)(CUdeviceptr)vertBoundary,
-		(MVS::CUDA::Point3*)(CUdeviceptr)smoothGrad2,
+		(MVS::CUDA::Point3*)TermsPtr(layout.bilap),
 		numVertices, uint8_t(1));
 }
 /*----------------------------------------------------------------*/
@@ -888,13 +819,6 @@ bool Scene::RefineMeshCUDA(unsigned nResolutionLevel, unsigned nMinResolution, u
 		MeshRefineStep stepper;
 		stepper.Reset(mesh.vertices.GetSize());
 
-		// host-side landing buffers for the raw per-vertex terms ScoreMesh downloads every
-		// evaluation; unlike the CPU, CUDA has no mid-scale vertex removal, so these are sized
-		// once here instead of every ScoreMesh() call
-		const uint32_t numVertices(mesh.vertices.GetSize());
-		Point3fArr photoGrad(numVertices), smoothGrad1(numVertices), smoothGrad2(numVertices);
-		FloatArr photoGradNorm(numVertices), footprint(numVertices);
-
 		bool bCudaFailed(false);
 		GET_LOGCONSOLE().Pause();
 
@@ -902,7 +826,8 @@ bool Scene::RefineMeshCUDA(unsigned nResolutionLevel, unsigned nMinResolution, u
 		// which differ only in the rho they pass in
 		const auto RunEvaluation = [&](float rho) -> MeshRefineStep::Action {
 			refine.iteration = stepper.GetNumEvaluated();
-			const bool bScoreOK(refine.ScoreMesh(photoGrad.Begin(), photoGradNorm.Begin(), footprint.Begin(), smoothGrad1.Begin(), smoothGrad2.Begin()));
+			MeshRefineStep::Terms terms;
+			const bool bScoreOK(refine.ScoreMesh(terms));
 			// a CUDA fault poisons the whole context: every later call fails, so without this the
 			// loop would keep "refining" a mesh nothing updates any more and still return success;
 			// giving up lets the caller fall back to the CPU path. A false bScoreOK is a download
@@ -926,24 +851,16 @@ bool Scene::RefineMeshCUDA(unsigned nResolutionLevel, unsigned nMinResolution, u
 			// a non-finite gradient is a producer bug and must fire, not be silently skipped (the
 			// legacy loop's `if (!ISFINITE(grad)) continue;` is gone along with the legacy loop)
 			FOREACH(v, mesh.vertices) {
-				ASSERT(ISFINITE(photoGrad[v]));
-				ASSERT(ISFINITE(photoGradNorm[v]));
-				ASSERT(ISFINITE(footprint[v]));
-				ASSERT(ISFINITE(smoothGrad1[v]));
-				ASSERT(ISFINITE(smoothGrad2[v]));
+				ASSERT(ISFINITE(terms.photoGrad[v]));
+				ASSERT(ISFINITE(terms.photoCount[v]));
+				ASSERT(ISFINITE(terms.footprint[v]));
+				ASSERT(ISFINITE(terms.lap[v]));
+				ASSERT(ISFINITE(terms.bilap[v]));
 			}
 			#endif
 
-			MeshRefineStep::Terms terms;
-			terms.photoGrad = photoGrad.Begin();
-			terms.photoCount = photoGradNorm.Begin();
-			terms.footprint = footprint.Begin();
-			terms.lap = smoothGrad1.Begin();
-			terms.bilap = smoothGrad2.Begin();
-			terms.S = refine.S;
 			terms.rigidity = rho;
 			terms.regularityWeight = refine.weightRegularity;
-			terms.numVertices = numVertices;
 			terms.alternating = bAlternating;
 
 			MeshRefineStep::Stats stats;

--- a/libs/MVS/SceneRefineCUDA.cpp
+++ b/libs/MVS/SceneRefineCUDA.cpp
@@ -70,18 +70,27 @@ class MeshRefineCUDA {
 public:
 	// store necessary data about a view
 	struct View {
-		Image32F imageHost; // store temporarily the image pixels
-		Image32F imageGradHost[2]; // store temporarily the image x/y derivatives
-		BitMatrix keepMaskHost; // store temporarily the per-view keep-mask (bit set = keep); empty == no mask == keep everything
 		Image8U::Size size;
 		SEACAVE::CUDA::ArrayRT32F image; // float like the CPU's View::image (was half-float; see readSurfFloat in the .cu)
 		SEACAVE::CUDA::ArrayRT32F imageGrad[2]; // x/y derivatives (ComputeRefineImageGradient), sampled by the photometric kernel; kept in float like the CPU's View::imageGrad (half-float cannot hold the sub-6e-5 values a derivative stencil produces on flat regions)
 		SEACAVE::CUDA::MemDevice depthMap;
-		SEACAVE::CUDA::MemDevice faceMap;
-		SEACAVE::CUDA::MemDevice baryMap; // one ushort4 per pixel: the three half barycentrics and a pad, one 8-byte word each way
-		SEACAVE::CUDA::MemDevice keepMask; // one byte per pixel (non-zero = keep), uploaded from keepMaskHost only when non-empty; invalid (unallocated) == keep everything
+		SEACAVE::CUDA::MemDevice faceMap; // the barycentrics are not kept per pixel: kernelAccumulateFacePhoto recomputes them from the face's projection (was a ushort4 per pixel of every view)
+		SEACAVE::CUDA::MemDevice keepMask; // one byte per pixel (non-zero = keep), uploaded from HostView::keepMask only when non-empty; invalid (unallocated) == keep everything
 	};
 	typedef CLISTDEF2(View) ViewsArr;
+	// one view's images at a scale as the host prepares them (PrepareImages) for UploadImages:
+	// the gray image, its gradient stencil, the keep-mask, and the working size and camera that
+	// PrepareRefineImage derives on a COPY of the scene's Image -- applied to the scene's at the
+	// upload, so that a scale can be prepared on a thread while the previous one is still
+	// being refined (PrefetchImages)
+	struct HostView {
+		Image32F image;
+		Image32F imageGrad[2];
+		BitMatrix keepMask; // empty == no mask == keep everything
+		uint32_t width = 0, height = 0;
+		Camera camera;
+	};
+	typedef CLISTDEF2(HostView) HostViewsArr;
 
 	// GPU texture/surface objects per view
 	struct ViewGPU {
@@ -104,11 +113,19 @@ public:
 	bool IsValid() const { return !pairs.IsEmpty(); }
 
 	bool InitKernels();
+	// the images at the given scale: the host half (PrepareImages, unless PrefetchImages() was
+	// started for exactly this scale, whose thread is joined instead) and then their upload
 	bool InitImages(float scale, float sigma=0);
+	// start PrepareImages(scale, sigma) on a thread, for the InitImages() of the next scale
+	void PrefetchImages(float scale, float sigma);
+	bool PrepareImages(float scale, float sigma);
+	bool UploadImages();
 
 	void ListVertexFacesPre();
 	void ListVertexFacesPost();
-	void ListCameraFaces();
+	// upload the current vertices and rasterize the mesh into every view; with bOwnerBits, the
+	// per-view owner bits ScoreMesh()'s accumulation skips the unseen faces by are left too
+	void ListCameraFaces(bool bOwnerBits=false);
 
 	void ListFaceAreas(Mesh::AreaArr& maxAreas);
 	void SubdivideMesh(uint32_t maxArea, float fDecimate=1.f, unsigned nCloseHoles=15, unsigned nEnsureEdgeSize=1);
@@ -127,7 +144,7 @@ public:
 	// stepper finite-looking garbage.
 	bool ScoreMesh(MeshRefineStep::Terms& terms);
 
-	void ProjectMesh(const Camera& camera, const Image8U::Size& size, uint32_t idxImage);
+	void ProjectMesh(const Camera& camera, const Image8U::Size& size, uint32_t idxImage, uint32_t* ownerBits);
 	// one pair-direction: warp B into A, the window statistics with the per-pixel photometric
 	// term, then its accumulation; numSlots counts the window-statistics blocks written so far
 	// into statsBlockSums, which ScoreMesh() reduces once at the end
@@ -142,6 +159,10 @@ public:
 	CUdeviceptr TermsPtr(size_t offset) const { return (CUdeviceptr)terms + sizeof(float)*offset; }
 	// how many pair-directions one ScoreMesh() runs
 	uint32_t NumDirections() const { return (uint32_t)pairs.GetSize() * (nAlternatePair == 0 ? 2u : 1u); }
+	// the owner bits of one view: (numFaces+31)/32 words per view, in image order
+	size_t OwnerWords() const { return ((size_t)scene.mesh.faces.GetSize() + 31) / 32; }
+	CUdeviceptr OwnerBits(uint32_t idxImage) const { return (CUdeviceptr)ownerBits + sizeof(uint32_t)*OwnerWords()*idxImage; }
+	static void* STCALL PrefetchWorker(void* pData);
 
 public:
 	const float weightRegularity; // a scalar regularity weight to balance between photo-consistency and regularization terms
@@ -196,6 +217,20 @@ public:
 	SEACAVE::CUDA::MemDevice vertexFacesSizes;
 	SEACAVE::CUDA::MemDevice vertexFacesPointers;
 	SEACAVE::CUDA::MemDevice vertBoundary; // per-vertex 0/1 boundary flag (shared valence/boundary split, see ListVertexFacesPost())
+	// per view, one bit per face set by the rasterizer iff the face owns a pixel there (see
+	// kernelProjectMesh): in a scene of hundreds of views most faces are unseen by any one view,
+	// and the per-direction accumulation exits on the bit before touching them
+	SEACAVE::CUDA::MemDevice ownerBits;
+	// ListFaceAreas() scratch: two per-view face histograms and the reduced per-face areas
+	SEACAVE::CUDA::MemDevice faceHist;
+	SEACAVE::CUDA::MemDevice faceAreas;
+
+	// the next scale's images, prepared by PrefetchImages()' thread while this scale runs
+	HostViewsArr hostViews;
+	SEACAVE::Thread prefetchThread;
+	float prefetchScale = 0, prefetchSigma = 0;
+	bool prefetchPending = false; // a thread was started and not joined yet
+	bool prefetchResult = false; // what its PrepareImages returned
 };
 
 MeshRefineCUDA::MeshRefineCUDA(Scene& _scene, unsigned _nAlternatePair, float _weightRegularity, unsigned _nResolutionLevel, unsigned _nMinResolution, unsigned nMaxViews)
@@ -227,6 +262,7 @@ MeshRefineCUDA::MeshRefineCUDA(Scene& _scene, unsigned _nAlternatePair, float _w
 }
 MeshRefineCUDA::~MeshRefineCUDA()
 {
+	prefetchThread.join();
 	for (auto& v : viewGPU)
 		v.Release();
 	if (surfImageProjObj) cudaDestroySurfaceObject(surfImageProjObj);
@@ -242,12 +278,14 @@ bool MeshRefineCUDA::InitKernels()
 	return true;
 }
 
-// load and initialize all images at the given scale
-// and compute the gradient for each input image
-// optional: blur them using the given sigma
-bool MeshRefineCUDA::InitImages(float scale, float sigma)
+// the host half of a scale's images, one per valid image: load, gray, blur and resize
+// (PrepareRefineImage), the gradient stencil and the keep-mask, into hostViews. Nothing in the
+// scene's Image changes -- PrepareRefineImage sets the working size and camera on a COPY, which
+// HostView carries to UploadImages() -- so this also runs on the PrefetchImages() thread while
+// the previous scale is still being refined on the caller's
+bool MeshRefineCUDA::PrepareImages(float scale, float sigma)
 {
-	views.Resize(images.GetSize());
+	hostViews.Resize(images.GetSize());
 	#ifdef MESHCUDAOPT_USE_OPENMP
 	bool bAbort(false);
 	#pragma omp parallel for
@@ -259,13 +297,13 @@ bool MeshRefineCUDA::InitImages(float scale, float sigma)
 	#else
 	FOREACH(idxImage, images) {
 	#endif
-		Image& imageData = images[idxImage];
+		const Image& imageData = images[idxImage];
+		HostView& host = hostViews[idxImage];
+		host.image.release();
 		if (!imageData.IsValid())
 			continue;
-		// load and init image
-		View& view = views[idxImage];
-		Image32F& img = view.imageHost;
-		if (!PrepareRefineImage(imageData, scene.platforms, nResolutionLevel, nMinResolution, scale, sigma, img)) {
+		Image imageCopy(imageData);
+		if (!PrepareRefineImage(imageCopy, scene.platforms, nResolutionLevel, nMinResolution, scale, sigma, host.image)) {
 			#ifdef MESHCUDAOPT_USE_OPENMP
 			bAbort = true;
 			#pragma omp flush (bAbort)
@@ -275,17 +313,68 @@ bool MeshRefineCUDA::InitImages(float scale, float sigma)
 			#endif
 		}
 		// mode 3 samples the bilinear interpolant of the image directly (computePhotoPixel's
-		// bilinearGradient) and never reads this precomputed stencil, so computing (and, below,
-		// uploading) it would be wasted work
+		// bilinearGradient) and never reads this precomputed stencil, so computing (and, at the
+		// upload, uploading) it would be wasted work
 		if (OPTREFINE::nImageGradient != 3)
-			ComputeRefineImageGradient(img, view.imageGradHost[0], view.imageGradHost[1]);
+			ComputeRefineImageGradient(host.image, host.imageGrad[0], host.imageGrad[1]);
 		// per-view keep-mask at this scale's working size (the same estimator on both backends)
-		PrepareRefineImageMask(imageData, img.size(), view.keepMaskHost);
+		PrepareRefineImageMask(imageCopy, host.image.size(), host.keepMask);
+		host.width = imageCopy.width;
+		host.height = imageCopy.height;
+		host.camera = imageCopy.camera;
 	}
 	#ifdef MESHCUDAOPT_USE_OPENMP
 	if (bAbort)
 		return false;
 	#endif
+	return true;
+}
+
+void MeshRefineCUDA::PrefetchImages(float scale, float sigma)
+{
+	ASSERT(!prefetchPending);
+	prefetchScale = scale;
+	prefetchSigma = sigma;
+	prefetchResult = false;
+	prefetchPending = prefetchThread.start(PrefetchWorker, this);
+}
+void* STCALL MeshRefineCUDA::PrefetchWorker(void* pData)
+{
+	MeshRefineCUDA& refine = *(MeshRefineCUDA*)pData;
+	#ifdef MESHCUDAOPT_USE_OPENMP
+	// half the cores for this thread's team (the setting is per thread): a full team runs
+	// alongside the refinement of the current scale and starves the thread feeding the GPU of
+	// its time slices -- measured as 100-800 ms host gaps between evaluations on 24 logical CPUs
+	omp_set_num_threads(MAXF(1, omp_get_num_procs()/2));
+	#endif
+	refine.prefetchResult = refine.PrepareImages(refine.prefetchScale, refine.prefetchSigma);
+	return NULL;
+}
+
+// load and initialize all images at the given scale
+// and compute the gradient for each input image
+// optional: blur them using the given sigma
+bool MeshRefineCUDA::InitImages(float scale, float sigma)
+{
+	bool bPrepared(false);
+	if (prefetchPending) {
+		prefetchThread.join();
+		prefetchPending = false;
+		// used only if it was asked for exactly this scale (the caller's loop always does)
+		bPrepared = (prefetchScale == scale && prefetchSigma == sigma && prefetchResult);
+	}
+	if (!bPrepared && !PrepareImages(scale, sigma))
+		return false;
+	return UploadImages();
+}
+
+// the GPU half: the per-view arrays, textures and surfaces at the new working size, the upload
+// of what PrepareImages() left in hostViews (freed as it goes), and the working size and camera
+// it derived applied to the scene's Image
+bool MeshRefineCUDA::UploadImages()
+{
+	ASSERT(hostViews.GetSize() == images.GetSize());
+	views.Resize(images.GetSize());
 	// init GPU memory
 	Image8U::Size maxSize(0,0);
 	// destroy old texture/surface objects before recreating
@@ -313,21 +402,29 @@ bool MeshRefineCUDA::InitImages(float scale, float sigma)
 		return reportRtError(cudaCreateTextureObject(&tex, &resDesc, &texDesc, nullptr), "cudaCreateTextureObject");
 	};
 	FOREACH(idxImage, views) {
-		View& view = views[idxImage];
-		if (view.imageHost.empty())
+		HostView& host = hostViews[idxImage];
+		if (host.image.empty())
 			continue;
+		// what PrepareRefineImage did to its copy of the Image, applied now: the pixels it loaded
+		// (if the scene held any) released, the working size and camera at this scale set
+		Image& imageData = images[idxImage];
+		imageData.ReleaseImage();
+		imageData.width = host.width;
+		imageData.height = host.height;
+		imageData.camera = host.camera;
+		View& view = views[idxImage];
 		Image8U::Size& size(view.size);
-		size = view.imageHost.size();
+		size = host.image.size();
 		reportCudaError(view.image.Reset(size, CUDA_ARRAY3D_SURFACE_LDST));
-		reportCudaError(view.image.SetData(view.imageHost));
-		view.imageHost.release();
+		reportCudaError(view.image.SetData(host.image));
+		host.image.release();
 		// no gradient stencil texture in mode 3 -- see the comment above where it is computed
 		if (OPTREFINE::nImageGradient != 3) {
 			for (int i=0; i<2; ++i) {
-				ASSERT(view.imageGradHost[i].size() == size);
+				ASSERT(host.imageGrad[i].size() == size);
 				reportCudaError(view.imageGrad[i].Reset(size, CUDA_ARRAY3D_SURFACE_LDST));
-				reportCudaError(view.imageGrad[i].SetData(view.imageGradHost[i]));
-				view.imageGradHost[i].release();
+				reportCudaError(view.imageGrad[i].SetData(host.imageGrad[i]));
+				host.imageGrad[i].release();
 				if (!createTexture(view.imageGrad[i], viewGPU[idxImage].texGrad[i]))
 					return false;
 			}
@@ -335,16 +432,15 @@ bool MeshRefineCUDA::InitImages(float scale, float sigma)
 		const size_t area((size_t)size.area());
 		reportCudaError(view.depthMap.Reset(sizeof(float)*area));
 		reportCudaError(view.faceMap.Reset(sizeof(FIndex)*area));
-		reportCudaError(view.baryMap.Reset(sizeof(ushort4)*area));
-		if (view.keepMaskHost.empty()) {
+		if (host.keepMask.empty()) {
 			view.keepMask.Release();
 		} else {
 			// dense byte mask (non-zero = keep) the kernel can index directly; BitMatrix::copyTo()
 			// already does this exact bit-to-byte expansion (255/0)
 			Image8U keepBytes;
-			view.keepMaskHost.copyTo(keepBytes);
+			host.keepMask.copyTo(keepBytes);
 			reportCudaError(view.keepMask.Reset(keepBytes));
-			view.keepMaskHost.release();
+			host.keepMask.release();
 		}
 		if (maxSize.width < size.width)
 			maxSize.width = size.width;
@@ -449,51 +545,82 @@ void MeshRefineCUDA::ListVertexFacesPost()
 	reportCudaError(cuMemsetD8(vertexSeen, 0, numVertices));
 }
 
-// upload the current vertices and rasterize the mesh into every view (depth, face and
-// barycentric maps): the whole mesh each time, the kernel rejecting the faces a view does not
-// see -- see kernelProjectMesh for why no host-side frustum cull shortlists them
-void MeshRefineCUDA::ListCameraFaces()
+// upload the current vertices and rasterize the mesh into every view (depth and face maps, and
+// the per-view owner bits when asked): the whole mesh each time, the kernel rejecting the faces
+// a view does not see -- see kernelProjectMesh for why no host-side frustum cull shortlists them
+void MeshRefineCUDA::ListCameraFaces(bool bOwnerBits)
 {
 	reportCudaError(vertices.Reset(scene.mesh.vertices));
 	FOREACH(idxImage, images) {
 		const Image& imageData = images[idxImage];
 		if (imageData.IsValid())
-			ProjectMesh(imageData.camera, views[idxImage].size, idxImage);
+			ProjectMesh(imageData.camera, views[idxImage].size, idxImage, bOwnerBits ? (uint32_t*)OwnerBits(idxImage) : NULL);
 	}
 }
 
 // compute for each face the one projected area the preparation and the decimation both read:
 // rasterized per view, then reduced over the refinement's own pairs by ReduceFaceAreasOverPairs
-// (the smaller view of a pair, the largest pair); ListCameraFaces() must have run before
+// (the smaller view of a pair, the largest pair); ListCameraFaces() must have run before.
+// All on the GPU: per pair, the rasterized pixel counts of its two views (kernelFaceHistogram
+// over the face maps the rasterization left) and their per-face min folded into the max over
+// the pairs (kernelReduceFaceAreasPair), the pairs walked grouped by their first view so that
+// its histogram is built once per group; only the reduced areas come down. The face map of
+// every view used to (one pageable copy each, 560 MB per projection on a 263-view scene at
+// level 1), followed by a host pass over all their pixels and one over faces x pairs
 void MeshRefineCUDA::ListFaceAreas(Mesh::AreaArr& maxAreas)
 {
 	ASSERT(maxAreas.IsEmpty());
-	// for each image a pair uses, compute the projection area of visible faces
-	Unsigned8Arr usedImages;
-	ListPairImages(pairs, images.GetSize(), usedImages);
-	ViewAreaArr viewAreas(images.GetSize());
-	FOREACH(idxImage, images) {
-		const Image& imageData = images[idxImage];
-		if (!imageData.IsValid() || !usedImages[idxImage])
-			continue;
-		Mesh::AreaArr& areas = viewAreas[idxImage];
-		areas.Resize(scene.mesh.faces.GetSize());
-		areas.Memset(0);
-		// get faceMap from the GPU memory
-		TImage<FIndex> faceMap(imageData.height, imageData.width);
-		views[idxImage].faceMap.GetData(faceMap);
-		// compute area covered by all vertices (incident faces) viewed by this image
-		for (int j=0; j<faceMap.rows; ++j) {
-			for (int i=0; i<faceMap.cols; ++i) {
-				const FIndex idxFace(faceMap(j,i));
-				if (idxFace == NO_ID)
-					continue;
-				++areas[idxFace];
-			}
-		}
+	const FIndex numFaces(scene.mesh.faces.GetSize());
+	reportCudaError(faceHist.Reset(sizeof(uint32_t)*2*(size_t)numFaces));
+	reportCudaError(faceAreas.Reset(sizeof(uint16_t)*numFaces));
+	reportCudaError(cuMemsetD16(faceAreas, 0, numFaces));
+	const CUdeviceptr histA((CUdeviceptr)faceHist), histB((CUdeviceptr)faceHist + sizeof(uint32_t)*numFaces);
+	const auto histogram = [&](uint32_t idxImage, CUdeviceptr hist) {
+		const View& view = views[idxImage];
+		reportCudaError(cuMemsetD32(hist, 0, numFaces));
+		MVS::CUDA::LaunchFaceHistogram((const uint32_t*)(CUdeviceptr)view.faceMap, (uint32_t*)hist, (uint32_t)view.size.area());
+	};
+	std::vector<PairIdx> sortedPairs(pairs.GetData(), pairs.GetData()+pairs.GetSize());
+	std::sort(sortedPairs.begin(), sortedPairs.end(), [](const PairIdx& a, const PairIdx& b) {
+		return a.i != b.i ? a.i < b.i : a.j < b.j;
+	});
+	uint32_t idxImageA(NO_ID);
+	for (const PairIdx& pair: sortedPairs) {
+		ASSERT(pair.i < pair.j);
+		if (pair.i != idxImageA)
+			histogram(idxImageA = pair.i, histA);
+		histogram(pair.j, histB);
+		MVS::CUDA::LaunchReduceFaceAreasPair((const uint32_t*)histA, (const uint32_t*)histB, (uint16_t*)(CUdeviceptr)faceAreas, numFaces);
 	}
-	maxAreas.Resize(scene.mesh.faces.GetSize());
-	ReduceFaceAreasOverPairs(viewAreas, pairs, maxAreas);
+	maxAreas.Resize(numFaces);
+	reportCudaError(faceAreas.GetData(maxAreas));
+	#ifdef _DEBUG
+	// the host reduction over the downloaded face maps, the path this replaced, must agree on
+	// every face
+	{
+		Unsigned8Arr usedImages;
+		ListPairImages(pairs, images.GetSize(), usedImages);
+		ViewAreaArr viewAreas(images.GetSize());
+		FOREACH(idxImage, images) {
+			const Image& imageData = images[idxImage];
+			if (!imageData.IsValid() || !usedImages[idxImage])
+				continue;
+			Mesh::AreaArr& areas = viewAreas[idxImage];
+			areas.Resize(numFaces);
+			areas.Memset(0);
+			TImage<FIndex> faceMap(imageData.height, imageData.width);
+			views[idxImage].faceMap.GetData(faceMap);
+			for (int j=0; j<faceMap.rows; ++j)
+				for (int i=0; i<faceMap.cols; ++i)
+					if (faceMap(j,i) != NO_ID)
+						++areas[faceMap(j,i)];
+		}
+		Mesh::AreaArr hostAreas(numFaces);
+		ReduceFaceAreasOverPairs(viewAreas, pairs, hostAreas);
+		FOREACH(f, maxAreas)
+			ASSERT(maxAreas[f] == hostAreas[f]);
+	}
+	#endif
 }
 
 // the shared preparation (PrepareRefineMesh, SceneRefineCommon.h): decimate, remesh and
@@ -540,7 +667,8 @@ bool MeshRefineCUDA::ScoreMesh(MeshRefineStep::Terms& out)
 	// rasterize the current vertices into every view, then the terms that need nothing else:
 	// the face normals and the two smoothness terms queue up behind the rasterization and run
 	// while the host is still issuing the pairs
-	ListCameraFaces();
+	reportCudaError(ownerBits.Reset(sizeof(uint32_t)*OwnerWords()*images.GetSize()));
+	ListCameraFaces(true);
 	ComputeNormalFaces();
 	const VIndex numVertices(scene.mesh.vertices.GetSize());
 	const TermsLayout layout(numVertices);
@@ -624,7 +752,7 @@ bool MeshRefineCUDA::ScoreMesh(MeshRefineStep::Terms& out)
 
 
 // project mesh to the given camera plane
-void MeshRefineCUDA::ProjectMesh(const Camera& camera, const Image8U::Size& size, uint32_t idxImage)
+void MeshRefineCUDA::ProjectMesh(const Camera& camera, const Image8U::Size& size, uint32_t idxImage, uint32_t* ownerBits)
 {
 	View& view = views[idxImage];
 	ASSERT(projKey.IsValid() && (size_t)size.area() <= projKeyPixels);
@@ -647,7 +775,7 @@ void MeshRefineCUDA::ProjectMesh(const Camera& camera, const Image8U::Size& size
 			(unsigned long long*)(CUdeviceptr)projKey,
 			(float*)(CUdeviceptr)view.depthMap,
 			(uint32_t*)(CUdeviceptr)view.faceMap,
-			(ushort4*)(CUdeviceptr)view.baryMap,
+			ownerBits,
 			cudaCamera, numFaces, pass == 1);
 	#ifdef _DEBUG
 	// every covered pixel must hold the payload of exactly the face that won its key
@@ -701,9 +829,8 @@ void MeshRefineCUDA::ProcessPair(uint32_t idxImageA, uint32_t idxImageB, uint32_
 	MVS::CUDA::LaunchAccumulateFacePhoto(
 		(const MVS::CUDA::Point3*)(CUdeviceptr)vertices,
 		(const MVS::CUDA::Point3u*)(CUdeviceptr)faces,
-		(const float*)(CUdeviceptr)viewA.depthMap,
+		(const uint32_t*)OwnerBits(idxImageA),
 		(const uint32_t*)(CUdeviceptr)viewA.faceMap,
-		(const ushort4*)(CUdeviceptr)viewA.baryMap,
 		(const float*)(CUdeviceptr)pixelGrad,
 		(const uint8_t*)(CUdeviceptr)maskStats,
 		(float*)(CUdeviceptr)faceTerms,
@@ -785,15 +912,19 @@ bool Scene::RefineMeshCUDA(unsigned nResolutionLevel, unsigned nMinResolution, u
 	if (!refine.IsValid())
 		return false;
 
-	// run the mesh optimization on multiple scales (coarse to fine)
+	// the image scale and blur of every refinement scale (coarse to fine); the sigma multiplier
+	// is tied to MeshRefineStep::StepGrow, see the note there
+	const auto ScaleOf = [&](unsigned s) { return POWI(fScaleStep, nScales-s-1); };
+	const auto SigmaOf = [&](unsigned s) { return 0.09f*POWI(2.f, nScales-s)+0.15f; };
+	// run the mesh optimization on multiple scales
 	for (unsigned nScale=0; nScale<nScales; ++nScale) {
-		// init images
-		const float scale(POWI(fScaleStep, nScales-nScale-1));
-		const float step(POWI(2.f, nScales-nScale));
-		DEBUG_ULTIMATE("Refine mesh at: %.2f image scale", scale);
-		// the sigma multiplier is tied to MeshRefineStep::StepGrow, see the note there
-		if (!refine.InitImages(scale, 0.09f*step+0.15f))
+		// init images; the next scale's are prepared on a thread from here on, while this one's
+		// mesh preparation and refinement run, so its switch pays only the upload
+		DEBUG_ULTIMATE("Refine mesh at: %.2f image scale", ScaleOf(nScale));
+		if (!refine.InitImages(ScaleOf(nScale), SigmaOf(nScale)))
 			return false;
+		if (nScale+1 < nScales)
+			refine.PrefetchImages(ScaleOf(nScale+1), SigmaOf(nScale+1));
 		refine.nScale = nScale;
 
 		// extract array of triangles incident to each vertex

--- a/libs/MVS/SceneRefineCUDA.cpp
+++ b/libs/MVS/SceneRefineCUDA.cpp
@@ -124,7 +124,8 @@ public:
 	void ListVertexFacesPre();
 	void ListVertexFacesPost();
 	// upload the current vertices and rasterize the mesh into every view; with bOwnerBits, the
-	// per-view owner bits ScoreMesh()'s accumulation skips the unseen faces by are left too
+	// per-view owner bits ScoreMesh() packs into the owner lists its accumulations run over are
+	// left too
 	void ListCameraFaces(bool bOwnerBits=false);
 
 	void ListFaceAreas(Mesh::AreaArr& maxAreas);
@@ -148,7 +149,9 @@ public:
 	// one pair-direction: warp B into A, the window statistics with the per-pixel photometric
 	// term, then its accumulation; numSlots counts the window-statistics blocks written so far
 	// into statsBlockSums, which ScoreMesh() reduces once at the end
-	void ProcessPair(uint32_t idxImageA, uint32_t idxImageB, uint32_t& numSlots);
+	void ProcessPair(uint32_t idxImageA, uint32_t idxImageB, uint32_t& numSlots, uint32_t direction);
+	// drop the recorded evaluation graphs (see ScoreMesh): whenever a buffer they reference moves
+	void ReleaseGraphs();
 	void ComputeSmoothnessGradient(uint32_t numVertices);
 
 	// float offsets of the fields of `terms`/`termsHost` for N vertices
@@ -207,7 +210,7 @@ public:
 	// corners' Sum g_p*b_c, 1 for the pixel count, 1 for the min footprint; accumulated over the
 	// pair-directions of one ScoreMesh() and cleared once per call
 	SEACAVE::CUDA::MemDevice faceTerms;
-	SEACAVE::CUDA::MemDevice vertexSeen; // 1 byte per vertex: the mark a direction's contributing faces leave for kernelCountSeenVertices
+	SEACAVE::CUDA::MemDevice vertexStamp; // 1 word per vertex: the last pair-direction that reached it, how kernelAccumulateFacePhoto counts a direction once per vertex
 	SEACAVE::CUDA::MemDevice vertexVerticesCont;
 	SEACAVE::CUDA::MemDevice vertexVerticesSizes;
 	SEACAVE::CUDA::MemDevice vertexVerticesPointers;
@@ -219,8 +222,33 @@ public:
 	SEACAVE::CUDA::MemDevice vertBoundary; // per-vertex 0/1 boundary flag (shared valence/boundary split, see ListVertexFacesPost())
 	// per view, one bit per face set by the rasterizer iff the face owns a pixel there (see
 	// kernelProjectMesh): in a scene of hundreds of views most faces are unseen by any one view,
-	// and the per-direction accumulation exits on the bit before touching them
+	// and the per-direction accumulation runs over the view's owner faces only -- the dense
+	// per-view lists ScoreMesh() packs the bits into once per evaluation (kernelCompactOwners):
+	// the per-view counts, the offsets into the one packed list (one extra entry, the total)
+	// with their host copy the list is sized by and the directions launched from, and the list
+	// itself, kept at the largest total so far
 	SEACAVE::CUDA::MemDevice ownerBits;
+	SEACAVE::CUDA::MemDevice ownerCounts;
+	SEACAVE::CUDA::MemDevice ownerOffsets;
+	SEACAVE::CUDA::MemDevice ownerList;
+	size_t ownerListCapacity = 0; // entries ownerList, ownerKeys and ownerListSorted hold
+	Unsigned32Arr ownerOffsetsHost;
+	// the list every view's slice of which is reordered by image tile (kernelSortOwnersTile) --
+	// the one the directions run over -- and its scratch; the tile grid: 64x8-pixel tiles (a
+	// tile row of a 4-byte map is 8 sectors; 128x16 measured 1.4-2.6 % slower on Ignatius level
+	// 1), coarsened until the largest view has at most
+	// 4096, set with the views' cameras (one device array for the kernels that cover every view
+	// in one launch) by UploadImages()
+	SEACAVE::CUDA::MemDevice ownerKeys;
+	SEACAVE::CUDA::MemDevice ownerListSorted;
+	SEACAVE::CUDA::MemDevice cudaCameras;
+	int tileShiftX = 6, tileShiftY = 3;
+	uint32_t maxTileBuckets = 0;
+	// the stream the pair-directions are issued on, and the evaluation recorded from them once
+	// per scale as a CUDA graph (see ScoreMesh) -- two when the pairs alternate direction with
+	// the iteration parity
+	cudaStream_t stream = NULL;
+	cudaGraphExec_t graphExec[2] = {NULL, NULL};
 	// ListFaceAreas() scratch: two per-view face histograms and the reduced per-face areas
 	SEACAVE::CUDA::MemDevice faceHist;
 	SEACAVE::CUDA::MemDevice faceAreas;
@@ -263,6 +291,8 @@ MeshRefineCUDA::MeshRefineCUDA(Scene& _scene, unsigned _nAlternatePair, float _w
 MeshRefineCUDA::~MeshRefineCUDA()
 {
 	prefetchThread.join();
+	ReleaseGraphs();
+	if (stream) cudaStreamDestroy(stream);
 	for (auto& v : viewGPU)
 		v.Release();
 	if (surfImageProjObj) cudaDestroySurfaceObject(surfImageProjObj);
@@ -275,7 +305,23 @@ bool MeshRefineCUDA::InitKernels()
 	// initialize CUDA device if needed
 	if (!SEACAVE::CUDA::isEnabled() && SEACAVE::CUDA::initDevices(SEACAVE::CUDA::desiredDeviceIDs) != CUDA_SUCCESS)
 		return false;
+	// a blocking stream: ordered after the legacy stream's work before it and before the legacy
+	// stream's after it (the rasterization, compaction and memsets, then the terms download)
+	if (cudaStreamCreate(&stream) != cudaSuccess) {
+		stream = NULL;
+		return false;
+	}
 	return true;
+}
+
+void MeshRefineCUDA::ReleaseGraphs()
+{
+	for (cudaGraphExec_t& graph: graphExec) {
+		if (graph) {
+			cudaGraphExecDestroy(graph);
+			graph = NULL;
+		}
+	}
 }
 
 // the host half of a scale's images, one per valid image: load, gray, blur and resize
@@ -401,6 +447,7 @@ bool MeshRefineCUDA::UploadImages()
 		texDesc.readMode = cudaReadModeElementType;
 		return reportRtError(cudaCreateTextureObject(&tex, &resDesc, &texDesc, nullptr), "cudaCreateTextureObject");
 	};
+	std::vector<MVS::CUDA::Camera> cameras(views.GetSize());
 	FOREACH(idxImage, views) {
 		HostView& host = hostViews[idxImage];
 		if (host.image.empty())
@@ -415,6 +462,7 @@ bool MeshRefineCUDA::UploadImages()
 		View& view = views[idxImage];
 		Image8U::Size& size(view.size);
 		size = host.image.size();
+		cameras[idxImage] = MakeCUDACamera(imageData.camera, size);
 		reportCudaError(view.image.Reset(size, CUDA_ARRAY3D_SURFACE_LDST));
 		reportCudaError(view.image.SetData(host.image));
 		host.image.release();
@@ -459,6 +507,15 @@ bool MeshRefineCUDA::UploadImages()
 	reportCudaError(maskStats.Reset(sizeof(uint8_t)*area));
 	reportCudaError(projKey.Reset(sizeof(uint64_t)*area));
 	projKeyPixels = area;
+	// the views' cameras and the owner-sort tile grid (see ownerListSorted)
+	reportCudaError(cudaCameras.Reset(cameras.data(), sizeof(MVS::CUDA::Camera)*cameras.size()));
+	tileShiftX = 6; tileShiftY = 3;
+	const auto tileBuckets = [&]() {
+		return (((uint32_t)maxSize.width + (1u<<tileShiftX) - 1) >> tileShiftX) * (((uint32_t)maxSize.height + (1u<<tileShiftY) - 1) >> tileShiftY);
+	};
+	for (bool bX=true; tileBuckets() > 4096; bX=!bX)
+		++(bX ? tileShiftX : tileShiftY);
+	maxTileBuckets = tileBuckets();
 	reportCudaError(imageAB.Reset(maxSize, CUDA_ARRAY3D_SURFACE_LDST));
 	reportCudaError(pixelGrad.Reset(sizeof(float)*area));
 	// one slot per 16x16 block of the window-statistics grid per pair-direction; the largest
@@ -533,16 +590,25 @@ void MeshRefineCUDA::ListVertexFacesPost()
 	reportCudaError(vertexFacesSizes.Reset(_vertexFacesSizes));
 	reportCudaError(vertexFacesPointers.Reset(_vertexFacesPointers));
 	// the evaluation buffers, sized once here since this mesh is final for the scale: the terms
-	// and their pinned mirror, the per-face accumulators (20 bytes per face) and the vertex marks
-	// (cleared once; kernelCountSeenVertices leaves them clear)
+	// and their pinned mirror, the per-face accumulators (20 bytes per face) and the vertex
+	// stamps (reset by every ScoreMesh())
 	const TermsLayout layout(numVertices);
 	reportCudaError(terms.Reset(sizeof(float)*layout.size));
 	if (termsHost)
 		reportCudaError(cuMemFreeHost(termsHost));
 	reportCudaError(cuMemAllocHost((void**)&termsHost, sizeof(float)*layout.size));
 	reportCudaError(faceTerms.Reset(sizeof(float)*5*scene.mesh.faces.GetSize()));
-	reportCudaError(vertexSeen.Reset(numVertices));
-	reportCudaError(cuMemsetD8(vertexSeen, 0, numVertices));
+	reportCudaError(vertexStamp.Reset(sizeof(uint32_t)*numVertices));
+	// the per-view owner bits and the compaction scratch (see kernelCompactOwners): every word of
+	// a valid view is rewritten by each rasterization, an invalid view's words stay clear
+	const size_t numViews(images.GetSize());
+	reportCudaError(ownerBits.Reset(sizeof(uint32_t)*OwnerWords()*numViews));
+	reportCudaError(cuMemsetD32(ownerBits, 0, OwnerWords()*numViews));
+	reportCudaError(ownerCounts.Reset(sizeof(uint32_t)*numViews));
+	reportCudaError(ownerOffsets.Reset(sizeof(uint32_t)*(numViews+1)));
+	ownerOffsetsHost.Resize(numViews+1);
+	// a new mesh: the evaluation's buffers above moved, so its graphs are recorded again
+	ReleaseGraphs();
 }
 
 // upload the current vertices and rasterize the mesh into every view (depth and face maps, and
@@ -664,11 +730,70 @@ void MeshRefineCUDA::ComputeNormalFaces()
 // them into a step
 bool MeshRefineCUDA::ScoreMesh(MeshRefineStep::Terms& out)
 {
-	// rasterize the current vertices into every view, then the terms that need nothing else:
-	// the face normals and the two smoothness terms queue up behind the rasterization and run
-	// while the host is still issuing the pairs
-	reportCudaError(ownerBits.Reset(sizeof(uint32_t)*OwnerWords()*images.GetSize()));
+	// rasterize the current vertices into every view, and pack the owner bits it leaves into
+	// the per-view owner lists the accumulations run over (see kernelCompactOwners): the views'
+	// counts and offsets, the offsets down -- the evaluation's one synchronization before the
+	// terms, on the rasterization every direction needs anyway -- and the list, sized by the
+	// total, filled
 	ListCameraFaces(true);
+	const uint32_t numViews((uint32_t)images.GetSize());
+	MVS::CUDA::LaunchCountOwners((const uint32_t*)(CUdeviceptr)ownerBits, (uint32_t*)(CUdeviceptr)ownerCounts, (uint32_t)OwnerWords(), numViews);
+	MVS::CUDA::LaunchScanViewCounts((const uint32_t*)(CUdeviceptr)ownerCounts, (uint32_t*)(CUdeviceptr)ownerOffsets, numViews);
+	if (reportCudaError(ownerOffsets.GetData(ownerOffsetsHost)) != CUDA_SUCCESS) {
+		VERBOSE("error: failed downloading the owner counts from the GPU at scale %u, iteration %u", nScale, iteration);
+		return false;
+	}
+	const size_t numOwners(ownerOffsetsHost.Last());
+	if (numOwners > ownerListCapacity) {
+		ownerListCapacity = numOwners + numOwners/4;
+		reportCudaError(ownerList.Reset(sizeof(uint32_t)*ownerListCapacity));
+		reportCudaError(ownerKeys.Reset(sizeof(uint32_t)*ownerListCapacity));
+		reportCudaError(ownerListSorted.Reset(sizeof(uint32_t)*ownerListCapacity));
+		ReleaseGraphs(); // the graphs hold the old list
+	}
+	if (numOwners > 0) {
+		MVS::CUDA::LaunchCompactOwners((const uint32_t*)(CUdeviceptr)ownerBits, (const uint32_t*)(CUdeviceptr)ownerOffsets, (uint32_t*)(CUdeviceptr)ownerList, (uint32_t)OwnerWords(), numViews);
+		MVS::CUDA::LaunchSortOwnersTile(
+			(const MVS::CUDA::Point3*)(CUdeviceptr)vertices,
+			(const MVS::CUDA::Point3u*)(CUdeviceptr)faces,
+			(const MVS::CUDA::Camera*)(CUdeviceptr)cudaCameras,
+			(const uint32_t*)(CUdeviceptr)ownerOffsets,
+			(const uint32_t*)(CUdeviceptr)ownerList,
+			(uint32_t*)(CUdeviceptr)ownerKeys,
+			(uint32_t*)(CUdeviceptr)ownerListSorted,
+			tileShiftX, tileShiftY, maxTileBuckets, numViews);
+	}
+	#ifdef _DEBUG
+	{
+		// the list must be exactly the set bits of every view, in face order, and the sorted
+		// list a permutation of it view by view
+		const size_t numWords(OwnerWords());
+		Unsigned32Arr bits, list, sorted;
+		bits.Resize(numWords*numViews);
+		reportCudaError(ownerBits.GetData(bits));
+		if (numOwners > 0) {
+			list.Resize(numOwners);
+			reportCudaError(ownerList.GetData(list));
+			sorted.Resize(numOwners);
+			reportCudaError(ownerListSorted.GetData(sorted));
+		}
+		for (uint32_t v=0; v<numViews; ++v) {
+			uint32_t n(ownerOffsetsHost[v]);
+			for (size_t w=0; w<numWords; ++w) {
+				const uint32_t word(bits[numWords*v+w]);
+				for (uint32_t b=0; b<32; ++b)
+					if ((word >> b) & 1u)
+						ASSERT(list[n++] == (uint32_t)(w*32+b));
+			}
+			ASSERT(n == ownerOffsetsHost[v+1]);
+			std::vector<uint32_t> perm(sorted.GetData()+ownerOffsetsHost[v], sorted.GetData()+n);
+			std::sort(perm.begin(), perm.end());
+			ASSERT(std::equal(perm.begin(), perm.end(), list.GetData()+ownerOffsetsHost[v]));
+		}
+	}
+	#endif
+	// the terms that need nothing else: the face normals and the two smoothness terms queue up
+	// behind the compaction, ahead of the evaluation graph
 	ComputeNormalFaces();
 	const VIndex numVertices(scene.mesh.vertices.GetSize());
 	const TermsLayout layout(numVertices);
@@ -678,51 +803,79 @@ bool MeshRefineCUDA::ScoreMesh(MeshRefineStep::Terms& out)
 	// slots (0, and the FLT_MAX the footprint mins start from)
 	const FIndex numFaces(scene.mesh.faces.GetSize());
 	reportCudaError(cuMemsetD32(TermsPtr(layout.photoCount), 0, numVertices));
+	reportCudaError(cuMemsetD32(vertexStamp, 0xFFFFFFFFu, numVertices));
 	reportCudaError(cuMemsetD32(faceTerms, 0, (size_t)numFaces*4));
 	reportCudaError(cuMemsetD32((CUdeviceptr)faceTerms + sizeof(float)*4*numFaces, 0x7F7FFFFF, numFaces));
 
-	// for each pair of images, compute a photo-consistency score
-	// between the reference image and the pixels of the second image
-	// projected in the reference image through the mesh surface
-	uint32_t numSlots(0);
-	FOREACHPTR(pPair, pairs) {
-		ASSERT(pPair->i < pPair->j);
-		switch (nAlternatePair) {
-		case 1: {
-			const PairIdx pair(iteration%2 ? PairIdx(pPair->j,pPair->i) : PairIdx(pPair->i,pPair->j));
-			ProcessPair(pair.i, pair.j, numSlots);
-			break; }
-		case 2: {
-			ProcessPair(pPair->i, pPair->j, numSlots);
-			break; }
-		case 3: {
-			ProcessPair(pPair->j, pPair->i, numSlots);
-			break; }
-		default:
-			for (int ip=0; ip<2; ++ip) {
-				const PairIdx pair(ip ? PairIdx(pPair->j,pPair->i) : PairIdx(pPair->i,pPair->j));
-				ProcessPair(pair.i, pair.j, numSlots);
+	// for each pair of images, compute a photo-consistency score between the reference image
+	// and the pixels of the second image projected in the reference image through the mesh
+	// surface; then the two sums S is made of and the per-vertex photometric term. The whole
+	// sequence -- three kernels per pair-direction, thousands of them, every argument a constant
+	// of the scale (the accumulation reads the reference view's owner slice on the device) -- is
+	// recorded ONCE per scale (and per direction parity when the pairs alternate) into a CUDA
+	// graph and replayed by one launch per evaluation: issued one by one, the launches cost the
+	// host ~10 us each under WDDM, 100-200 ms per evaluation, as much as the coarse scales' GPU
+	// time (Ignatius level 1: 98 ms of launch API for 103 ms of kernels at scale 0). Should the
+	// recording fail, the directions are issued one by one as before.
+	const auto issueDirections = [&]() {
+		uint32_t numSlots(0), direction(0);
+		FOREACHPTR(pPair, pairs) {
+			ASSERT(pPair->i < pPair->j);
+			switch (nAlternatePair) {
+			case 1: {
+				const PairIdx pair(iteration%2 ? PairIdx(pPair->j,pPair->i) : PairIdx(pPair->i,pPair->j));
+				ProcessPair(pair.i, pair.j, numSlots, direction++);
+				break; }
+			case 2: {
+				ProcessPair(pPair->i, pPair->j, numSlots, direction++);
+				break; }
+			case 3: {
+				ProcessPair(pPair->j, pPair->i, numSlots, direction++);
+				break; }
+			default:
+				for (int ip=0; ip<2; ++ip) {
+					const PairIdx pair(ip ? PairIdx(pPair->j,pPair->i) : PairIdx(pPair->i,pPair->j));
+					ProcessPair(pair.i, pair.j, numSlots, direction++);
+				}
 			}
 		}
+		MVS::CUDA::LaunchReduceBlockSums(
+			(const float*)(CUdeviceptr)statsBlockSums, numSlots,
+			(float*)TermsPtr(layout.sums), (float*)TermsPtr(layout.sums+1), stream);
+		MVS::CUDA::LaunchGatherVertexPhoto(
+			(const MVS::CUDA::Point3u*)(CUdeviceptr)faces,
+			(const MVS::CUDA::Point3*)(CUdeviceptr)faceNormals,
+			(const uint32_t*)(CUdeviceptr)vertexFacesCont,
+			(const uint32_t*)(CUdeviceptr)vertexFacesSizes,
+			(const uint32_t*)(CUdeviceptr)vertexFacesPointers,
+			(const float*)(CUdeviceptr)faceTerms,
+			(const float*)((CUdeviceptr)faceTerms + sizeof(float)*3*numFaces),
+			(const float*)((CUdeviceptr)faceTerms + sizeof(float)*4*numFaces),
+			(MVS::CUDA::Point3*)TermsPtr(layout.photoGrad),
+			(float*)TermsPtr(layout.footprint),
+			numVertices, stream);
+	};
+	cudaGraphExec_t& graph(graphExec[nAlternatePair == 1 ? iteration%2 : 0]);
+	if (graph == NULL) {
+		bool bRecorded(false);
+		if (cudaStreamBeginCapture(stream, cudaStreamCaptureModeThreadLocal) == cudaSuccess) {
+			issueDirections();
+			cudaGraph_t recording(NULL);
+			if (cudaStreamEndCapture(stream, &recording) == cudaSuccess) {
+				bRecorded = cudaGraphInstantiate(&graph, recording, 0) == cudaSuccess;
+				cudaGraphDestroy(recording);
+			}
+		}
+		if (!bRecorded) {
+			graph = NULL;
+			VERBOSE("warning: the refinement evaluation could not be recorded as a CUDA graph (%s), its kernels are launched one by one", cudaGetErrorString(cudaGetLastError()));
+			issueDirections();
+		}
 	}
-
-	// the two sums S is made of and the per-vertex photometric term, then everything comes down
-	// in one copy
-	MVS::CUDA::LaunchReduceBlockSums(
-		(const float*)(CUdeviceptr)statsBlockSums, numSlots,
-		(float*)TermsPtr(layout.sums), (float*)TermsPtr(layout.sums+1));
-	MVS::CUDA::LaunchGatherVertexPhoto(
-		(const MVS::CUDA::Point3u*)(CUdeviceptr)faces,
-		(const MVS::CUDA::Point3*)(CUdeviceptr)faceNormals,
-		(const uint32_t*)(CUdeviceptr)vertexFacesCont,
-		(const uint32_t*)(CUdeviceptr)vertexFacesSizes,
-		(const uint32_t*)(CUdeviceptr)vertexFacesPointers,
-		(const float*)(CUdeviceptr)faceTerms,
-		(const float*)((CUdeviceptr)faceTerms + sizeof(float)*3*numFaces),
-		(const float*)((CUdeviceptr)faceTerms + sizeof(float)*4*numFaces),
-		(MVS::CUDA::Point3*)TermsPtr(layout.photoGrad),
-		(float*)TermsPtr(layout.footprint),
-		numVertices);
+	if (graph != NULL && cudaGraphLaunch(graph, stream) != cudaSuccess) {
+		VERBOSE("error: failed launching the refinement evaluation graph at scale %u, iteration %u (%s)", nScale, iteration, cudaGetErrorString(cudaGetLastError()));
+		return false;
+	}
 	if (reportCudaError(terms.GetData(termsHost, sizeof(float)*layout.size)) != CUDA_SUCCESS) {
 		VERBOSE("error: failed downloading the refinement terms from the GPU at scale %u, iteration %u", nScale, iteration);
 		return false;
@@ -787,7 +940,7 @@ void MeshRefineCUDA::ProjectMesh(const Camera& camera, const Image8U::Size& size
 	#endif
 }
 
-void MeshRefineCUDA::ProcessPair(uint32_t idxImageA, uint32_t idxImageB, uint32_t& numSlots)
+void MeshRefineCUDA::ProcessPair(uint32_t idxImageA, uint32_t idxImageB, uint32_t& numSlots, uint32_t direction)
 {
 	const Image& imageDataA = images[idxImageA];
 	const Image& imageDataB = images[idxImageB];
@@ -803,7 +956,7 @@ void MeshRefineCUDA::ProcessPair(uint32_t idxImageA, uint32_t idxImageB, uint32_
 		viewA.keepMask.IsValid() ? (const uint8_t*)(CUdeviceptr)viewA.keepMask : NULL,
 		viewB.keepMask.IsValid() ? (const uint8_t*)(CUdeviceptr)viewB.keepMask : NULL,
 		(uint8_t*)(CUdeviceptr)mask,
-		cudaCamA, cudaCamB, viewGPU[idxImageB].texObj, surfImageProjObj);
+		cudaCamA, cudaCamB, viewGPU[idxImageB].texObj, surfImageProjObj, stream);
 	// masked window statistics, rejection gates, ZNCC and its derivative, and the per-pixel
 	// photometric term; mode 3 samples the bilinear interpolant of image B directly and needs no
 	// precomputed gradient stencil texture (InitImages never uploads one in that mode)
@@ -821,27 +974,30 @@ void MeshRefineCUDA::ProcessPair(uint32_t idxImageA, uint32_t idxImageB, uint32_
 		viewGPU[idxImageB].texObj, viewGPU[idxImageB].texGrad[0], viewGPU[idxImageB].texGrad[1],
 		OPTREFINE::nImageGradient == 3, RegularizationScale,
 		OPTREFINE::fGateMeanDiff, OPTREFINE::fGateVarRatio,
-		viewA.size.width, viewA.size.height);
-	// the atomic-free accumulation: every face folds its pixels into its own slots, then the
-	// vertices they reach count the direction (see kernelAccumulateFacePhoto)
+		viewA.size.width, viewA.size.height, stream);
+	// the atomic-free accumulation over the faces view A owns, in tile order: every face folds
+	// its pixels into its own slots, then the vertices they reach count the direction (see
+	// kernelAccumulateFacePhoto); the grid is sized by the slice as it is now, with a margin
+	// for the evaluations replaying this launch from the graph
 	const FIndex numFaces(scene.mesh.faces.GetSize());
 	const VIndex numVertices(scene.mesh.vertices.GetSize());
+	const uint32_t numOwners(ownerOffsetsHost[idxImageA+1]-ownerOffsetsHost[idxImageA]);
 	MVS::CUDA::LaunchAccumulateFacePhoto(
 		(const MVS::CUDA::Point3*)(CUdeviceptr)vertices,
 		(const MVS::CUDA::Point3u*)(CUdeviceptr)faces,
-		(const uint32_t*)OwnerBits(idxImageA),
+		(const uint32_t*)(CUdeviceptr)ownerListSorted,
+		(const uint32_t*)(CUdeviceptr)ownerOffsets,
+		idxImageA,
 		(const uint32_t*)(CUdeviceptr)viewA.faceMap,
 		(const float*)(CUdeviceptr)pixelGrad,
 		(const uint8_t*)(CUdeviceptr)maskStats,
 		(float*)(CUdeviceptr)faceTerms,
 		(float*)((CUdeviceptr)faceTerms + sizeof(float)*3*numFaces),
 		(float*)((CUdeviceptr)faceTerms + sizeof(float)*4*numFaces),
-		(uint8_t*)(CUdeviceptr)vertexSeen,
-		cudaCamA, numFaces);
-	MVS::CUDA::LaunchCountSeenVertices(
-		(uint8_t*)(CUdeviceptr)vertexSeen,
+		(uint32_t*)(CUdeviceptr)vertexStamp,
 		(float*)TermsPtr(TermsLayout(numVertices).photoCount),
-		numVertices);
+		direction,
+		cudaCamA, MAXF(1u, (numOwners + numOwners/4 + MVS::CUDA::AccumulateBlockSize - 1) / MVS::CUDA::AccumulateBlockSize), stream);
 }
 
 void MeshRefineCUDA::ComputeSmoothnessGradient(uint32_t numVertices)

--- a/libs/MVS/SceneRefineCUDA.cu
+++ b/libs/MVS/SceneRefineCUDA.cu
@@ -33,6 +33,7 @@
 #include "SceneRefineCommon.h"
 
 #include <cuda_fp16.h>
+#include <float.h>
 
 
 namespace MVS {
@@ -157,32 +158,34 @@ __device__ inline bool faceBBox(const ProjectedFace& pf, const Camera& camera,
 	return ixMin <= ixMax && iyMin <= iyMax;
 }
 
-// 1. ProjectMesh — 1D, 1 thread per visible face, launched twice. Pass 1 (RESOLVE=false):
-// every covered pixel receives one 64-bit key (depth bits << 32 | position in faceIDs) through
-// a single atomicMin, so the nearest face wins and, at exactly equal depth, the face that comes
-// first in the camera's face list -- the CPU's RasterMesh keeps the first face it rasterises
-// (`depth > z`, strict) walking that same list (octree-traversal order, not ascending ids), so
-// this is the same tie-break. Pass 2 (RESOLVE=true): the same threads redo the same arithmetic
-// and the one whose key is the pixel's winner writes depth/face/bary -- one writer per pixel,
-// no payload race, hence a deterministic face map.
+// 1. ProjectMesh — 1D, one thread per mesh face, launched twice. Pass 1 (RESOLVE=false):
+// every covered pixel receives one 64-bit key (depth bits << 32 | face id) through a single
+// atomicMin, so the nearest face wins and, at exactly equal depth, the lower face id. Pass 2
+// (RESOLVE=true): the same threads redo the same arithmetic and the one whose key is the pixel's
+// winner writes depth/face/bary -- one writer per pixel, no payload race, hence a deterministic
+// face map. The whole mesh is rasterized into every view: a face behind the camera or off the
+// image costs its thread three projections and an early exit, cheaper than the host-side
+// frustum cull that used to shortlist the faces (an octree over the mesh rebuilt for every
+// evaluation, plus one face-list upload per view, while the GPU sat idle). The CPU's RasterMesh
+// keeps the first face it rasterises in that cull's (octree-traversal) order, so the two
+// backends can differ only on an exact depth tie: a pixel centre exactly on a shared edge, where
+// either face hands the pixel to the same two vertices.
 template <bool RESOLVE>
 __global__ void kernelProjectMesh(
 	const Point3* __restrict__ vertices,
 	const Point3u* __restrict__ faces,
-	const uint32_t* __restrict__ faceIDs,
 	unsigned long long* __restrict__ projKey,
 	float* __restrict__ depthMap,
 	uint32_t* __restrict__ faceMap,
-	uint16_t* __restrict__ baryMap,
+	ushort4* __restrict__ baryMap,
 	Camera camera,
-	uint32_t numFacesView)
+	uint32_t numFaces)
 {
 	const int tid = blockIdx.x * blockDim.x + threadIdx.x;
-	if (tid >= (int)numFacesView) return;
+	if (tid >= (int)numFaces) return;
 
-	const uint32_t faceID = faceIDs[tid];
 	ProjectedFace pf;
-	if (!projectFace(vertices, faces[faceID], camera, pf)) return;
+	if (!projectFace(vertices, faces[tid], camera, pf)) return;
 
 	int ixMin, ixMax, iyMin, iyMax;
 	if (!faceBBox(pf, camera, ixMin, ixMax, iyMin, iyMax)) return;
@@ -198,10 +201,10 @@ __global__ void kernelProjectMesh(
 			if (RESOLVE) {
 				if (projKey[pixIdx] != key) continue;
 				depthMap[pixIdx] = depth;
-				faceMap[pixIdx] = faceID;
-				baryMap[pixIdx * 3 + 0] = __half_as_ushort(__float2half(nb0));
-				baryMap[pixIdx * 3 + 1] = __half_as_ushort(__float2half(nb1));
-				baryMap[pixIdx * 3 + 2] = __half_as_ushort(__float2half(nb2));
+				faceMap[pixIdx] = (uint32_t)tid;
+				// the three barycentrics in one 8-byte store (three 2-byte ones cost three transactions)
+				baryMap[pixIdx] = make_ushort4(
+					__half_as_ushort(__float2half(nb0)), __half_as_ushort(__float2half(nb1)), __half_as_ushort(__float2half(nb2)), 0);
 			} else {
 				atomicMin(&projKey[pixIdx], key);
 			}
@@ -212,11 +215,10 @@ __global__ void kernelProjectMesh(
 
 #ifdef _DEBUG
 // 2. CheckProjection — 2D, 1 thread per pixel, Debug only, after both ProjectMesh passes: every
-// covered pixel must hold the payload of exactly the thread that produced its winning key (the
+// covered pixel must hold the payload of exactly the face that produced its winning key (the
 // host presets faceMap to NO_ID and depthMap to 0 before pass 2, so a stale value from the
 // previous evaluation cannot satisfy this by accident)
 __global__ void kernelCheckProjection(
-	const uint32_t* __restrict__ faceIDs,
 	const unsigned long long* __restrict__ projKey,
 	const float* __restrict__ depthMap,
 	const uint32_t* __restrict__ faceMap,
@@ -231,7 +233,7 @@ __global__ void kernelCheckProjection(
 	if (key == ~0ull) {
 		ASSERT(faceMap[pixIdx] == (uint32_t)-1);
 	} else {
-		ASSERT(faceMap[pixIdx] == faceIDs[(uint32_t)key] && __float_as_uint(depthMap[pixIdx]) == (unsigned)(key >> 32));
+		ASSERT(faceMap[pixIdx] == (uint32_t)key && __float_as_uint(depthMap[pixIdx]) == (unsigned)(key >> 32));
 	}
 }
 #endif
@@ -311,146 +313,6 @@ __global__ void kernelImageMeshWarp(
 }
 
 
-// 4. ComputeWindowStats — 2D, one thread per pixel: the six MASKED window sums, the two
-// rejection gates, ZNCC, its derivative and this pair-direction's reliability sums, all in one
-// pass over the 7x7 window. Replaces the former five kernels (mean/var/cov/zncc/dzncc) and the
-// six full-image buffers they exchanged. Only successfully warped pixels enter the sums, so a
-// window straddling an occlusion boundary is described by the pixels that actually matched
-// instead of by image A's own values (the old unmasked statistics drove ZNCC towards 1 exactly
-// there). Writes maskOut rather than editing mask in place: the window loop of a neighbouring
-// thread is still reading mask.
-__global__ void kernelComputeWindowStats(
-	const uint8_t* __restrict__ mask,
-	uint8_t* __restrict__ maskOut,
-	float* __restrict__ dzncc,
-	cudaSurfaceObject_t surfImageA,
-	cudaSurfaceObject_t surfImageProj,
-	float* __restrict__ blockSums, // 2 floats per block: this block's reliability partials
-	float gateMeanDiff, float gateVarRatio,
-	int width, int height)
-{
-	const int x = blockIdx.x * blockDim.x + threadIdx.x;
-	const int y = blockIdx.y * blockDim.y + threadIdx.y;
-
-	// the 7x7 windows of the 16x16 threads of a block overlap heavily, so the (image A, warped
-	// image B, mask) triple of the 22x22 tile they span is staged in shared memory once instead
-	// of being re-read 49 times per thread from global/surface memory -- the naive version cost
-	// 1.4-1.8x the wall of the five separate kernels this one replaces
-	constexpr int Block = 16;
-	constexpr int Tile = Block + 2*Refine::HalfSize;
-	__shared__ float sA[Tile*Tile], sB[Tile*Tile], sW[Tile*Tile];
-	const int x0 = blockIdx.x * Block - Refine::HalfSize;
-	const int y0 = blockIdx.y * Block - Refine::HalfSize;
-	for (int i = threadIdx.y * Block + threadIdx.x; i < Tile*Tile; i += Block*Block) {
-		const int gx = x0 + i % Tile, gy = y0 + i / Tile;
-		float a(0.f), b(0.f), w(0.f);
-		// invalid samples are staged as zeros so the accumulation below needs no branch: they
-		// contribute nothing to any of the six sums, which is exactly what masking them means
-		if (gx >= 0 && gy >= 0 && gx < width && gy < height && mask[gy * width + gx] == 1) {
-			a = readSurfFloat(surfImageA, gx, gy);
-			b = readSurfFloat(surfImageProj, gx, gy);
-			w = 1.f;
-		}
-		sA[i] = a; sB[i] = b; sW[i] = w;
-	}
-	__syncthreads();
-
-	// per-thread contribution to this block's reliability sums; stays 0 for every pixel outside
-	// the image (the grid is rounded up to the block size), outside the valid border, unmasked or
-	// gated -- exactly the pixels the CPU's ScoreMesh S skips; no early "return" here so every
-	// thread in the block reaches the reduction below
-	float contribR(0.f), contribRZ(0.f);
-	if (x < width && y < height) {
-		const int pixIdx = y * width + x;
-		float dz(0.f), zn(0.f), cf(0.f);
-		uint8_t valid(0);
-		if (x >= Refine::HalfSize && y >= Refine::HalfSize &&
-			x < width - Refine::HalfSize && y < height - Refine::HalfSize && mask[pixIdx] == 1)
-		{
-			const int centre = (threadIdx.y + Refine::HalfSize) * Tile + threadIdx.x + Refine::HalfSize;
-			float n(0.f), sumA(0.f), sumB(0.f), sumAA(0.f), sumBB(0.f), sumAB(0.f);
-			for (int dy = -Refine::HalfSize; dy <= Refine::HalfSize; ++dy) {
-				const int row = centre + dy*Tile;
-				for (int dx = -Refine::HalfSize; dx <= Refine::HalfSize; ++dx) {
-					const int t = row + dx;
-					const float a = sA[t], b = sB[t];
-					n += sW[t]; sumA += a; sumB += b; sumAA += a*a; sumBB += b*b; sumAB += a*b;
-				}
-			}
-			Refine::WindowStats s;
-			if (Refine::WindowStatsFromSums(n, sumA, sumB, sumAA, sumBB, sumAB, gateMeanDiff, gateVarRatio, s)) {
-				Refine::ZnccAndDerivative(s, n, sA[centre], sB[centre], zn, dz, cf);
-				valid = 1;
-				contribR = cf;
-				contribRZ = cf * (1.f - zn);
-			}
-		}
-		dzncc[pixIdx] = dz;
-		maskOut[pixIdx] = valid;
-	}
-
-	// shared-memory block reduction (a fixed tree over a fixed thread mapping, so its result does
-	// not depend on the schedule); sized for the 16x16 block LaunchComputeWindowStats always
-	// launches. The block's two partials go to its OWN slot rather than into a global atomicAdd,
-	// and kernelReduceBlockSums below folds the slots in block order, so S is reproducible too.
-	__shared__ float sSumR[256];
-	__shared__ float sSumRZ[256];
-	const int tid = threadIdx.y * blockDim.x + threadIdx.x;
-	sSumR[tid] = contribR;
-	sSumRZ[tid] = contribRZ;
-	__syncthreads();
-	for (int stride = (blockDim.x * blockDim.y) >> 1; stride > 0; stride >>= 1) {
-		if (tid < stride) {
-			sSumR[tid] += sSumR[tid + stride];
-			sSumRZ[tid] += sSumRZ[tid + stride];
-		}
-		__syncthreads();
-	}
-	if (tid == 0) {
-		const int idxBlock = blockIdx.y * gridDim.x + blockIdx.x;
-		blockSums[idxBlock*2 + 0] = sSumR[0];
-		blockSums[idxBlock*2 + 1] = sSumRZ[0];
-	}
-}
-
-
-// 5. ReduceBlockSums — a single block, right after ComputeWindowStats: adds this
-// pair-direction's per-block partials into the two persistent ScoreMesh accumulators in a fixed
-// order (each thread walks a strided, fixed subset, then a fixed shared-memory tree), so S is
-// the same number on every run. The pair-directions themselves are already ordered: their kernel
-// launches serialize on the default stream.
-__global__ void kernelReduceBlockSums(
-	const float* __restrict__ blockSums,
-	float* __restrict__ sumR,
-	float* __restrict__ sumRZ,
-	uint32_t numBlocks)
-{
-	constexpr int Threads = 256;
-	__shared__ float sR[Threads];
-	__shared__ float sRZ[Threads];
-	const int tid = threadIdx.x;
-	float r(0.f), rz(0.f);
-	for (uint32_t i = (uint32_t)tid; i < numBlocks; i += Threads) {
-		r += blockSums[i*2 + 0];
-		rz += blockSums[i*2 + 1];
-	}
-	sR[tid] = r;
-	sRZ[tid] = rz;
-	__syncthreads();
-	for (int stride = Threads >> 1; stride > 0; stride >>= 1) {
-		if (tid < stride) {
-			sR[tid] += sR[tid + stride];
-			sRZ[tid] += sRZ[tid + stride];
-		}
-		__syncthreads();
-	}
-	if (tid == 0) {
-		sumR[0] += sR[0];
-		sumRZ[0] += sRZ[0];
-	}
-}
-
-
 // fetch one texel of a float texture at its exact centre (tex2D pixel-centre convention, +0.5),
 // or 0 for a tap outside the image -- the out-of-range rule BilinearGradient below matches
 __device__ inline float texelOrZero(cudaTextureObject_t tex, int x, int y, int width, int height)
@@ -478,18 +340,15 @@ __device__ inline void bilinearGradient(cudaTextureObject_t texImage, int width,
 	gy = (1.f-dx)*(v10-v00) + dx*(v11-v01);
 }
 
-// 6. the per-pixel half of the photometric gradient, factored out of the two kernels below so
-// that it is a PURE FUNCTION OF THE PIXEL: nothing it returns depends on which thread computes it
-// or in what order, which is what lets the accumulation be atomic-free and bit-reproducible.
-// The caller has already established that this pixel is inside the valid border, masked in, and
-// covered by the face whose normal it passes in. Returns false if the pixel contributes nothing.
-struct PhotoPixel {
-	float g; // the scalar the face's three corners share before their barycentrics (the CPU's sg)
-	float foot; // scene units per pixel at camera A (Camera::GetFootprintWorld = depth/focalLength)
-};
+// the per-pixel half of the photometric gradient: g, the scalar the covering face's three
+// corners share before their barycentrics (the CPU's sg). A PURE FUNCTION OF THE PIXEL: nothing
+// it returns depends on which thread computes it or in what order, which is what lets the
+// face-parallel accumulation be atomic-free and bit-reproducible. The caller has already
+// established that this pixel is inside the valid border, masked in, and covered by the face
+// whose normal it passes in; dz is the pixel's ZNCC derivative. Returns false if the pixel
+// contributes nothing (the surface is seen at a grazing angle).
 __device__ inline bool computePhotoPixel(
-	int x, int y, int pixIdx, float depth, const Point3& normal,
-	const float* __restrict__ dznccMap,
+	int x, int y, float depth, const Point3& normal, float dz,
 	const Camera& camA,
 	const Camera& camB,
 	cudaTextureObject_t texImageB, // sampled directly in bilinear-derivative mode (nImageGradient == 3)
@@ -497,7 +356,7 @@ __device__ inline bool computePhotoPixel(
 	cudaTextureObject_t texGradYB,
 	bool bBilinearGrad,
 	float regScale,
-	PhotoPixel& out)
+	float& g)
 {
 	// View direction in world space (normalized)
 	const Point3 camRay = camA.model.TransformPointI2C(Point2((float)x, (float)y));
@@ -544,42 +403,36 @@ __device__ inline bool computePhotoPixel(
 
 	// 3D gradient = dzncc * J^T * [dx, dy]
 	const Point3 gradDir = dx * dudX + dy * dvdX;
-	const float dz = dznccMap[pixIdx];
 	const Point3 grad = dz * gradDir;
 
 	// Project gradient along view direction, scale by 1/dot(viewDir, normal)
 	const float projMag = grad.dot(viewDir) / viewDotNormal;
 
-	out.g = regScale * projMag;
-	out.foot = depth / camA.model.f.x();
+	g = regScale * projMag;
 	return true;
 }
 
 
-// 7. AccumulateFacePhoto — 1D, one thread per mesh face; the first half of the atomic-free
-// photometric accumulation. Each thread reduces ITS OWN face's pixels into registers and writes
-// one private slot per output, so there is not a single atomic and not a single float sum whose
-// order depends on the schedule -- float addition is not associative, and an atomicAdd scatter
-// gives a different per-vertex gradient on every run.
-//
-// The thread projects its face and walks its clipped bounding box exactly as kernelProjectMesh
-// did, in a fixed row-then-column order, and keeps the pixels whose faceMap entry is this face --
-// which is also what makes iterating over ALL faces (rather than over this view's cameraFaces)
-// correct AND cheap: faceMap only ever holds ids the rasterizer wrote, so a face outside this
-// camera's list can never match a pixel, and every thread writes its slot (zeros included) so no
-// per-pair-direction memset is needed either.
-__global__ void kernelAccumulateFacePhoto(
-	const Point3* __restrict__ vertices,
-	const Point3u* __restrict__ faces,
-	const Point3* __restrict__ normals,
-	const float* __restrict__ depthMap,
-	const uint32_t* __restrict__ faceMap,
-	const uint16_t* __restrict__ baryMap,
-	const float* __restrict__ dznccMap,
+// 4. ComputeWindowStats — 2D, one thread per pixel: the six MASKED window sums, the two
+// rejection gates, ZNCC, its derivative, this pair-direction's reliability sums and the pixel's
+// photometric term, all in one pass over the 7x7 window. Replaces the former five kernels
+// (mean/var/cov/zncc/dzncc) and the six full-image buffers they exchanged. Only successfully
+// warped pixels enter the sums, so a window straddling an occlusion boundary is described by the
+// pixels that actually matched instead of by image A's own values (the old unmasked statistics
+// drove ZNCC towards 1 exactly there). Writes maskOut rather than editing mask in place: the
+// window loop of a neighbouring thread is still reading mask. The photometric term used to be
+// computed by the face-parallel accumulation kernel, one thread walking every pixel of its face:
+// a warp there waits for its largest face, while here every pixel is one thread of equal work.
+__global__ void kernelComputeWindowStats(
 	const uint8_t* __restrict__ mask,
-	float* __restrict__ faceAcc, // 3 per face: Sum over the face's pixels of g_p*b_c, one per corner
-	float* __restrict__ facePixels, // 1 per face: how many pixels contributed (0 = the face contributed nothing)
-	float* __restrict__ faceFoot, // 1 per face: min footprint over the face's pixels; only read where facePixels > 0
+	uint8_t* __restrict__ maskOut, // the pixels that contribute a photometric term
+	float* __restrict__ pixelGrad, // their term g (computePhotoPixel), 0 elsewhere
+	float* __restrict__ blockSums, // 2 floats per block: this block's reliability partials
+	cudaSurfaceObject_t surfImageA,
+	cudaSurfaceObject_t surfImageProj,
+	const Point3* __restrict__ normals,
+	const uint32_t* __restrict__ faceMap,
+	const float* __restrict__ depthMap,
 	Camera camA,
 	Camera camB,
 	cudaTextureObject_t texImageB,
@@ -587,62 +440,237 @@ __global__ void kernelAccumulateFacePhoto(
 	cudaTextureObject_t texGradYB,
 	bool bBilinearGrad,
 	float regScale,
+	float gateMeanDiff, float gateVarRatio,
+	int width, int height)
+{
+	const int x = blockIdx.x * blockDim.x + threadIdx.x;
+	const int y = blockIdx.y * blockDim.y + threadIdx.y;
+
+	// the 7x7 windows of the 16x16 threads of a block overlap heavily, so the (image A, warped
+	// image B, mask) triple of the 22x22 tile they span is staged in shared memory once instead
+	// of being re-read 49 times per thread from global/surface memory -- the naive version cost
+	// 1.4-1.8x the wall of the five separate kernels this one replaces
+	constexpr int Block = 16;
+	constexpr int Tile = Block + 2*Refine::HalfSize;
+	__shared__ float sA[Tile*Tile], sB[Tile*Tile], sW[Tile*Tile];
+	const int x0 = blockIdx.x * Block - Refine::HalfSize;
+	const int y0 = blockIdx.y * Block - Refine::HalfSize;
+	for (int i = threadIdx.y * Block + threadIdx.x; i < Tile*Tile; i += Block*Block) {
+		const int gx = x0 + i % Tile, gy = y0 + i / Tile;
+		float a(0.f), b(0.f), w(0.f);
+		// invalid samples are staged as zeros so the accumulation below needs no branch: they
+		// contribute nothing to any of the six sums, which is exactly what masking them means
+		if (gx >= 0 && gy >= 0 && gx < width && gy < height && mask[gy * width + gx] == 1) {
+			a = readSurfFloat(surfImageA, gx, gy);
+			b = readSurfFloat(surfImageProj, gx, gy);
+			w = 1.f;
+		}
+		sA[i] = a; sB[i] = b; sW[i] = w;
+	}
+	__syncthreads();
+
+	// per-thread contribution to this block's reliability sums; stays 0 for every pixel outside
+	// the image (the grid is rounded up to the block size), outside the valid border, unmasked or
+	// gated -- exactly the pixels the CPU's ScoreMesh S skips; no early "return" here so every
+	// thread in the block reaches the reduction below
+	float contribR(0.f), contribRZ(0.f);
+	if (x < width && y < height) {
+		const int pixIdx = y * width + x;
+		float g(0.f);
+		uint8_t contributes(0);
+		if (x >= Refine::HalfSize && y >= Refine::HalfSize &&
+			x < width - Refine::HalfSize && y < height - Refine::HalfSize && mask[pixIdx] == 1)
+		{
+			const int centre = (threadIdx.y + Refine::HalfSize) * Tile + threadIdx.x + Refine::HalfSize;
+			float n(0.f), sumA(0.f), sumB(0.f), sumAA(0.f), sumBB(0.f), sumAB(0.f);
+			for (int dy = -Refine::HalfSize; dy <= Refine::HalfSize; ++dy) {
+				const int row = centre + dy*Tile;
+				for (int dx = -Refine::HalfSize; dx <= Refine::HalfSize; ++dx) {
+					const int t = row + dx;
+					const float a = sA[t], b = sB[t];
+					n += sW[t]; sumA += a; sumB += b; sumAA += a*a; sumBB += b*b; sumAB += a*b;
+				}
+			}
+			Refine::WindowStats s;
+			if (Refine::WindowStatsFromSums(n, sumA, sumB, sumAA, sumBB, sumAB, gateMeanDiff, gateVarRatio, s)) {
+				float zn, dz, cf;
+				Refine::ZnccAndDerivative(s, n, sA[centre], sB[centre], zn, dz, cf);
+				contribR = cf;
+				contribRZ = cf * (1.f - zn);
+				// mask==1 means the rasterizer covered this pixel (the warp seeds nothing where
+				// depthMap is 0), so faceMap holds the covering face; a grazing view of it
+				// contributes to S (above, like the CPU) but no photometric term
+				const float depth = depthMap[pixIdx];
+				ASSERT(depth > 0.f);
+				if (computePhotoPixel(x, y, depth, normals[faceMap[pixIdx]], dz,
+						camA, camB, texImageB, texGradXB, texGradYB, bBilinearGrad, regScale, g))
+					contributes = 1;
+			}
+		}
+		pixelGrad[pixIdx] = g;
+		maskOut[pixIdx] = contributes;
+	}
+
+	// shared-memory block reduction (a fixed tree over a fixed thread mapping, so its result does
+	// not depend on the schedule); sized for the 16x16 block LaunchComputeWindowStats always
+	// launches. The block's two partials go to its OWN slot rather than into a global atomicAdd,
+	// and kernelReduceBlockSums below folds the slots in order, so S is reproducible too.
+	__shared__ float sSumR[256];
+	__shared__ float sSumRZ[256];
+	const int tid = threadIdx.y * blockDim.x + threadIdx.x;
+	sSumR[tid] = contribR;
+	sSumRZ[tid] = contribRZ;
+	__syncthreads();
+	for (int stride = (blockDim.x * blockDim.y) >> 1; stride > 0; stride >>= 1) {
+		if (tid < stride) {
+			sSumR[tid] += sSumR[tid + stride];
+			sSumRZ[tid] += sSumRZ[tid + stride];
+		}
+		__syncthreads();
+	}
+	if (tid == 0) {
+		const int idxBlock = blockIdx.y * gridDim.x + blockIdx.x;
+		blockSums[idxBlock*2 + 0] = sSumR[0];
+		blockSums[idxBlock*2 + 1] = sSumRZ[0];
+	}
+}
+
+
+// 5. ReduceBlockSums — a single block, once per ScoreMesh() after every pair-direction: adds
+// the per-block partials of all of them (each direction's blocks occupy their own slots, in
+// launch order) into the two accumulators S is computed from, in a fixed order (each thread walks
+// a strided, fixed subset of the slots, then a fixed shared-memory tree), so S is the same number
+// on every run.
+__global__ void kernelReduceBlockSums(
+	const float* __restrict__ blockSums,
+	uint32_t numSlots,
+	float* __restrict__ sumR,
+	float* __restrict__ sumRZ)
+{
+	constexpr int Threads = 1024;
+	__shared__ float sR[Threads];
+	__shared__ float sRZ[Threads];
+	const int tid = threadIdx.x;
+	float r(0.f), rz(0.f);
+	for (uint32_t i = (uint32_t)tid; i < numSlots; i += Threads) {
+		r += blockSums[i*2 + 0];
+		rz += blockSums[i*2 + 1];
+	}
+	sR[tid] = r;
+	sRZ[tid] = rz;
+	__syncthreads();
+	for (int stride = Threads >> 1; stride > 0; stride >>= 1) {
+		if (tid < stride) {
+			sR[tid] += sR[tid + stride];
+			sRZ[tid] += sRZ[tid + stride];
+		}
+		__syncthreads();
+	}
+	if (tid == 0) {
+		sumR[0] = sR[0];
+		sumRZ[0] = sRZ[0];
+	}
+}
+
+
+// 6. AccumulateFacePhoto — 1D, one thread per mesh face; the per-pair-direction half of the
+// atomic-free photometric accumulation. Each thread reduces ITS OWN face's pixels into registers
+// and folds them into its private slots, so there is not a single atomic and not a single float
+// sum whose order depends on the schedule -- float addition is not associative, and an atomicAdd
+// scatter gives a different per-vertex gradient on every run. The slots accumulate across the
+// pair-directions of one ScoreMesh() (one writer per face, in launch order, so that too is a
+// fixed sequence), which lets the per-vertex gather run once per ScoreMesh() instead of once
+// per direction.
+//
+// The thread projects its face and walks its clipped bounding box exactly as kernelProjectMesh
+// did, in a fixed row-then-column order, and keeps the pixels whose faceMap entry is this face:
+// faceMap only ever holds ids the rasterizer wrote, and a face this view does not see exits
+// after its three projections. The per-pixel term itself comes from kernelComputeWindowStats,
+// one balanced thread per pixel; here it is only weighted by the barycentrics, so the imbalance
+// between large and small faces costs little.
+__global__ void kernelAccumulateFacePhoto(
+	const Point3* __restrict__ vertices,
+	const Point3u* __restrict__ faces,
+	const float* __restrict__ depthMap,
+	const uint32_t* __restrict__ faceMap,
+	const ushort4* __restrict__ baryMap,
+	const float* __restrict__ pixelGrad,
+	const uint8_t* __restrict__ mask,
+	float* __restrict__ faceAcc, // 3 per face: Sum over the face's pixels of g_p*b_c, one per corner
+	float* __restrict__ facePixels, // 1 per face: how many pixels contributed (0 = the face contributed nothing)
+	float* __restrict__ faceFoot, // 1 per face: min footprint over the face's pixels; only read where facePixels > 0
+	uint8_t* __restrict__ vertexSeen, // 1 per vertex: set for the corners of a face that contributed (every writer stores the same value, so the race is benign)
+	Camera camA,
 	uint32_t numFaces)
 {
 	const int tid = blockIdx.x * blockDim.x + threadIdx.x;
 	if (tid >= (int)numFaces) return;
 
-	float sum0 = 0.f, sum1 = 0.f, sum2 = 0.f;
-	float pixels = 0.f, foot = 0.f;
-
+	const Point3u face = faces[tid];
 	ProjectedFace pf;
 	int ixMin, ixMax, iyMin, iyMax;
-	if (projectFace(vertices, faces[tid], camA, pf) && faceBBox(pf, camA, ixMin, ixMax, iyMin, iyMax)) {
-		const Point3& normal = normals[tid];
-		const int width = camA.size.x();
-		for (int iy = iyMin; iy <= iyMax; ++iy) {
-			for (int ix = ixMin; ix <= ixMax; ++ix) {
-				const int pixIdx = iy * width + ix;
-				if (faceMap[pixIdx] != (uint32_t)tid || mask[pixIdx] != 1)
-					continue;
-				// this pixel's winning rasterizer key was this face's, so its payload is this face's
-				// perspective-correct depth and barycentrics -- a positive depth by construction
-				const float depth = depthMap[pixIdx];
-				ASSERT(depth > 0.f);
-				PhotoPixel pp;
-				if (!computePhotoPixel(ix, iy, pixIdx, depth, normal, dznccMap,
-						camA, camB, texImageB, texGradXB, texGradYB, bBilinearGrad, regScale, pp))
-					continue;
-				const float bary0 = __half2float(*reinterpret_cast<const __half*>(&baryMap[pixIdx * 3 + 0]));
-				const float bary1 = __half2float(*reinterpret_cast<const __half*>(&baryMap[pixIdx * 3 + 1]));
-				const float bary2 = __half2float(*reinterpret_cast<const __half*>(&baryMap[pixIdx * 3 + 2]));
-				sum0 += pp.g * bary0;
-				sum1 += pp.g * bary1;
-				sum2 += pp.g * bary2;
-				// per-vertex footprint at camera A, scene units per pixel: min over every
-				// contributing pixel of every pair-direction, matching the CPU's min-of-mins
-				// (MeshRefine::ComputePhotometricGradient/ThProcessPair). min is exact and
-				// associative, so this half of it is reproducible for free.
-				foot = pixels == 0.f ? pp.foot : fminf(foot, pp.foot);
-				pixels += 1.f;
-			}
+	if (!projectFace(vertices, face, camA, pf) || !faceBBox(pf, camA, ixMin, ixMax, iyMin, iyMax))
+		return;
+	float sum0 = 0.f, sum1 = 0.f, sum2 = 0.f;
+	float pixels = 0.f, foot = FLT_MAX;
+	const int width = camA.size.x();
+	for (int iy = iyMin; iy <= iyMax; ++iy) {
+		for (int ix = ixMin; ix <= ixMax; ++ix) {
+			const int pixIdx = iy * width + ix;
+			if (faceMap[pixIdx] != (uint32_t)tid || mask[pixIdx] != 1)
+				continue;
+			// this pixel's winning rasterizer key was this face's, so its payload is this face's
+			// perspective-correct depth and barycentrics
+			const float g = pixelGrad[pixIdx];
+			const ushort4 bary = baryMap[pixIdx];
+			sum0 += g * __half2float(__ushort_as_half(bary.x));
+			sum1 += g * __half2float(__ushort_as_half(bary.y));
+			sum2 += g * __half2float(__ushort_as_half(bary.z));
+			// per-vertex footprint at camera A, scene units per pixel (Camera::GetFootprintWorld =
+			// depth/focalLength): min over every contributing pixel of every pair-direction,
+			// matching the CPU's min-of-mins (MeshRefine::ComputePhotometricGradient/ThProcessPair);
+			// min is exact and associative, so this half of it is reproducible for free
+			foot = fminf(foot, depthMap[pixIdx] / camA.model.f.x());
+			pixels += 1.f;
 		}
 	}
-
-	faceAcc[tid*3 + 0] = sum0;
-	faceAcc[tid*3 + 1] = sum1;
-	faceAcc[tid*3 + 2] = sum2;
-	facePixels[tid] = pixels;
-	faceFoot[tid] = foot;
+	if (pixels == 0.f)
+		return; // nothing to fold in; the slots keep what the earlier directions left
+	faceAcc[tid*3 + 0] += sum0;
+	faceAcc[tid*3 + 1] += sum1;
+	faceAcc[tid*3 + 2] += sum2;
+	facePixels[tid] += pixels;
+	faceFoot[tid] = fminf(faceFoot[tid], foot);
+	vertexSeen[face.x()] = 1;
+	vertexSeen[face.y()] = 1;
+	vertexSeen[face.z()] = 1;
 }
 
 
-// 8. GatherVertexPhoto — 1D, one thread per vertex; the second half. It walks the vertex's
-// incident faces in the fixed order Mesh::ListIncidentFaces produced (uploaded per scale, see
-// MeshRefineCUDA::ListVertexFacesPost) and folds in each face's private accumulator, so a
-// vertex's sum is a fixed sequence of float additions. Only this thread writes this vertex, so
-// the per-pair-direction bookkeeping (the +1 on photoGradNorm for a direction that saw the
-// vertex) is done here too.
+// 7. CountSeenVertices — 1D, one thread per vertex, right after each AccumulateFacePhoto:
+// exactly the CPU's `photoGradNorm[idxVert] += 1.f`, one count per pair-direction that
+// contributed at least one pixel to a face of the vertex; the mark is cleared for the next
+// direction
+__global__ void kernelCountSeenVertices(
+	uint8_t* __restrict__ vertexSeen,
+	float* __restrict__ photoCount,
+	uint32_t numVertices)
+{
+	const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+	if (tid >= (int)numVertices) return;
+	if (vertexSeen[tid]) {
+		photoCount[tid] += 1.f;
+		vertexSeen[tid] = 0;
+	}
+}
+
+
+// 8. GatherVertexPhoto — 1D, one thread per vertex, once per ScoreMesh() after every
+// pair-direction. It walks the vertex's incident faces in the fixed order Mesh::ListIncidentFaces
+// produced (uploaded per scale, see MeshRefineCUDA::ListVertexFacesPost) and folds in each
+// face's slots, so a vertex's sum is a fixed sequence of float additions. The footprint sentinel
+// is resolved here: 0 exactly where no face contributed, which is exactly where no direction
+// counted the vertex (contract: footprint[v] > 0 iff photoCount[v] > 0, matches CPU ScoreMesh).
 //
 // Every corner whose vertex id matches is folded in, not just the first: a degenerate face
 // listing the same vertex twice handed that vertex both corners' shares under the old scatter,
@@ -657,7 +685,6 @@ __global__ void kernelGatherVertexPhoto(
 	const float* __restrict__ facePixels,
 	const float* __restrict__ faceFoot,
 	Point3* __restrict__ photoGrad,
-	float* __restrict__ photoGradNorm,
 	float* __restrict__ footprint,
 	uint32_t numVertices)
 {
@@ -667,7 +694,8 @@ __global__ void kernelGatherVertexPhoto(
 	const uint32_t ptr = vertFacePointers[tid];
 	const uint32_t numIncident = vertFaceSizes[tid];
 	Point3 grad = Point3::Zero();
-	float pixels = 0.f, foot = 0.f;
+	float foot = FLT_MAX;
+	bool seen = false;
 	for (uint32_t i = 0; i < numIncident; ++i) {
 		const uint32_t idxFace = vertFaces[ptr + i];
 		const Point3u& face = faces[idxFace];
@@ -675,50 +703,21 @@ __global__ void kernelGatherVertexPhoto(
 		// the adjacency is the transpose of the face list: a face this vertex is incident to must
 		// name it back, or the two uploads describe different meshes
 		ASSERT(fv[0] == (uint32_t)tid || fv[1] == (uint32_t)tid || fv[2] == (uint32_t)tid);
-		const float facePix = facePixels[idxFace];
-		if (facePix == 0.f)
+		if (facePixels[idxFace] == 0.f)
 			continue; // nothing was accumulated, so every other slot of this face is a zero
 		const Point3& normal = normals[idxFace];
-		for (int c = 0; c < 3; ++c) {
-			if (fv[c] != (uint32_t)tid)
-				continue;
-			grad += normal * faceAcc[idxFace*3 + c];
-			foot = pixels == 0.f ? faceFoot[idxFace] : fminf(foot, faceFoot[idxFace]);
-			pixels += facePix;
-		}
+		for (int c = 0; c < 3; ++c)
+			if (fv[c] == (uint32_t)tid)
+				grad += normal * faceAcc[idxFace*3 + c];
+		foot = fminf(foot, faceFoot[idxFace]);
+		seen = true;
 	}
-	if (pixels == 0.f)
-		return; // this pair-direction saw nothing of this vertex
-
-	photoGrad[tid] += grad;
-	// exactly the CPU's `photoGradNorm[idxVert] += 1.f;`: one count per pair-direction that
-	// contributed at least one pixel to this vertex
-	photoGradNorm[tid] += 1.f;
-	if (foot < footprint[tid])
-		footprint[tid] = foot;
+	photoGrad[tid] = grad;
+	footprint[tid] = seen ? foot : 0.f;
 }
 
 
-// 9. FinalizePhotoGrad — 1D, once after every pair-direction of this ScoreMesh() has run:
-// resolves the footprint sentinel now that photoGradNorm holds its final value (contract:
-// footprint[v] > 0 exactly where photoGradNorm[v] > 0, matches CPU ScoreMesh); doing it inside a
-// per-pair-direction launch would clobber the sentinel for a vertex a later direction is the
-// first to touch. The per-pair-direction half this kernel used to carry (the +1 on
-// photoGradNorm) now lives in kernelGatherVertexPhoto, which already holds that direction's
-// pixel count in a register.
-__global__ void kernelFinalizePhotoGrad(
-	const float* __restrict__ photoGradNorm,
-	float* __restrict__ footprint,
-	uint32_t numVertices)
-{
-	const int tid = blockIdx.x * blockDim.x + threadIdx.x;
-	if (tid >= (int)numVertices) return;
-	if (photoGradNorm[tid] == 0.f)
-		footprint[tid] = 0.f;
-}
-
-
-// 10. ComputeSmoothnessGradient — 1D
+// 9. ComputeSmoothnessGradient — 1D
 __global__ void kernelComputeSmoothnessGradient(
 	const Point3* __restrict__ vertices,
 	const uint32_t* __restrict__ vertVertices,
@@ -774,7 +773,7 @@ __global__ void kernelComputeSmoothnessGradient(
 }
 
 
-// 11. ComputeFaceNormal — 1D, 1 thread per face
+// 10. ComputeFaceNormal — 1D, 1 thread per face
 __global__ void kernelComputeFaceNormal(
 	const Point3* __restrict__ vertices,
 	const Point3u* __restrict__ faces,
@@ -798,28 +797,26 @@ __global__ void kernelComputeFaceNormal(
 // H O S T   L A U N C H E R S ////////////////////////////////////////
 
 void LaunchProjectMesh(
-	const Point3* vertices, const Point3u* faces, const uint32_t* faceIDs,
-	unsigned long long* projKey, float* depthMap, uint32_t* faceMap, uint16_t* baryMap,
-	const Camera& camera, uint32_t numFacesView, bool resolve)
+	const Point3* vertices, const Point3u* faces,
+	unsigned long long* projKey, float* depthMap, uint32_t* faceMap, ushort4* baryMap,
+	const Camera& camera, uint32_t numFaces, bool resolve)
 {
 	const int blockSize = 256;
-	const int numBlocks = ((int)numFacesView + blockSize - 1) / blockSize;
+	const int numBlocks = ((int)numFaces + blockSize - 1) / blockSize;
 	if (resolve)
-		kernelProjectMesh<true><<<numBlocks, blockSize>>>(
-			vertices, faces, faceIDs, projKey, depthMap, faceMap, baryMap, camera, numFacesView);
+		kernelProjectMesh<true><<<numBlocks, blockSize>>>(vertices, faces, projKey, depthMap, faceMap, baryMap, camera, numFaces);
 	else
-		kernelProjectMesh<false><<<numBlocks, blockSize>>>(
-			vertices, faces, faceIDs, projKey, depthMap, faceMap, baryMap, camera, numFacesView);
+		kernelProjectMesh<false><<<numBlocks, blockSize>>>(vertices, faces, projKey, depthMap, faceMap, baryMap, camera, numFaces);
 }
 
 #ifdef _DEBUG
 void LaunchCheckProjection(
-	const uint32_t* faceIDs, const unsigned long long* projKey,
+	const unsigned long long* projKey,
 	const float* depthMap, const uint32_t* faceMap, int width, int height)
 {
 	const dim3 block(16, 16);
 	const dim3 grid((width + block.x - 1) / block.x, (height + block.y - 1) / block.y);
-	kernelCheckProjection<<<grid, block>>>(faceIDs, projKey, depthMap, faceMap, width, height);
+	kernelCheckProjection<<<grid, block>>>(projKey, depthMap, faceMap, width, height);
 }
 #endif
 
@@ -835,53 +832,59 @@ void LaunchImageMeshWarp(
 	kernelImageMeshWarp<<<grid, block>>>(depthMapA, depthMapB, keepA, keepB, mask, camA, camB, texImageB, surfImageProj);
 }
 
-void LaunchComputeWindowStats(
-	const uint8_t* mask, uint8_t* maskOut, float* dzncc,
+uint32_t LaunchComputeWindowStats(
+	const uint8_t* mask, uint8_t* maskOut, float* pixelGrad, float* blockSums,
 	cudaSurfaceObject_t surfImageA, cudaSurfaceObject_t surfImageProj,
-	float* sumR, float* sumRZ, float* blockSums, float gateMeanDiff, float gateVarRatio, int width, int height)
+	const Point3* normals, const uint32_t* faceMap, const float* depthMap,
+	const Camera& camA, const Camera& camB,
+	cudaTextureObject_t texImageB, cudaTextureObject_t texGradXB, cudaTextureObject_t texGradYB,
+	bool bBilinearGrad, float regScale, float gateMeanDiff, float gateVarRatio, int width, int height)
 {
 	const dim3 block(16, 16);
 	const dim3 grid((width + block.x - 1) / block.x, (height + block.y - 1) / block.y);
-	kernelComputeWindowStats<<<grid, block>>>(mask, maskOut, dzncc,
-		surfImageA, surfImageProj, blockSums, gateMeanDiff, gateVarRatio, width, height);
-	// fold this pair-direction's per-block partials into S's accumulators in block order
-	kernelReduceBlockSums<<<1, 256>>>(blockSums, sumR, sumRZ, grid.x*grid.y);
+	kernelComputeWindowStats<<<grid, block>>>(mask, maskOut, pixelGrad, blockSums,
+		surfImageA, surfImageProj, normals, faceMap, depthMap, camA, camB,
+		texImageB, texGradXB, texGradYB, bBilinearGrad, regScale, gateMeanDiff, gateVarRatio, width, height);
+	return grid.x*grid.y;
+}
+
+void LaunchReduceBlockSums(const float* blockSums, uint32_t numSlots, float* sumR, float* sumRZ)
+{
+	kernelReduceBlockSums<<<1, 1024>>>(blockSums, numSlots, sumR, sumRZ);
 }
 
 void LaunchAccumulateFacePhoto(
-	const Point3* vertices, const Point3u* faces, const Point3* normals,
-	const float* depthMap, const uint32_t* faceMap, const uint16_t* baryMap,
-	const float* dzncc, const uint8_t* mask,
-	float* faceAcc, float* facePixels, float* faceFoot,
-	const Camera& camA, const Camera& camB,
-	cudaTextureObject_t texImageB, cudaTextureObject_t texGradXB, cudaTextureObject_t texGradYB,
-	bool bBilinearGrad, float regScale, uint32_t numFaces)
+	const Point3* vertices, const Point3u* faces,
+	const float* depthMap, const uint32_t* faceMap, const ushort4* baryMap,
+	const float* pixelGrad, const uint8_t* mask,
+	float* faceAcc, float* facePixels, float* faceFoot, uint8_t* vertexSeen,
+	const Camera& camA, uint32_t numFaces)
 {
 	const int blockSize = 256;
 	const int numBlocks = ((int)numFaces + blockSize - 1) / blockSize;
 	kernelAccumulateFacePhoto<<<numBlocks, blockSize>>>(
-		vertices, faces, normals, depthMap, faceMap, baryMap, dzncc, mask,
-		faceAcc, facePixels, faceFoot, camA, camB, texImageB, texGradXB, texGradYB, bBilinearGrad, regScale, numFaces);
+		vertices, faces, depthMap, faceMap, baryMap, pixelGrad, mask,
+		faceAcc, facePixels, faceFoot, vertexSeen, camA, numFaces);
+}
+
+void LaunchCountSeenVertices(uint8_t* vertexSeen, float* photoCount, uint32_t numVertices)
+{
+	const int blockSize = 256;
+	const int numBlocks = ((int)numVertices + blockSize - 1) / blockSize;
+	kernelCountSeenVertices<<<numBlocks, blockSize>>>(vertexSeen, photoCount, numVertices);
 }
 
 void LaunchGatherVertexPhoto(
 	const Point3u* faces, const Point3* normals,
 	const uint32_t* vertFaces, const uint32_t* vertFaceSizes, const uint32_t* vertFacePointers,
 	const float* faceAcc, const float* facePixels, const float* faceFoot,
-	Point3* photoGrad, float* photoGradNorm, float* footprint, uint32_t numVertices)
+	Point3* photoGrad, float* footprint, uint32_t numVertices)
 {
 	const int blockSize = 256;
 	const int numBlocks = ((int)numVertices + blockSize - 1) / blockSize;
 	kernelGatherVertexPhoto<<<numBlocks, blockSize>>>(
 		faces, normals, vertFaces, vertFaceSizes, vertFacePointers,
-		faceAcc, facePixels, faceFoot, photoGrad, photoGradNorm, footprint, numVertices);
-}
-
-void LaunchFinalizePhotoGrad(const float* photoGradNorm, float* footprint, uint32_t numVertices)
-{
-	const int blockSize = 256;
-	const int numBlocks = ((int)numVertices + blockSize - 1) / blockSize;
-	kernelFinalizePhotoGrad<<<numBlocks, blockSize>>>(photoGradNorm, footprint, numVertices);
+		faceAcc, facePixels, faceFoot, photoGrad, footprint, numVertices);
 }
 
 void LaunchComputeSmoothnessGradient(

--- a/libs/MVS/SceneRefineCUDA.cu
+++ b/libs/MVS/SceneRefineCUDA.cu
@@ -248,7 +248,173 @@ __global__ void kernelCheckProjection(
 #endif
 
 
-// 3. ImageMeshWarp — 2D, texture + 2 surfaces
+// 3. CompactOwners — the dense per-view lists of the faces the rasterizer's owner bits mark,
+// built once per evaluation after every view is rasterized: kernelCountOwners (one block per
+// view) popcounts the view's words, kernelScanViewCounts (one block) turns the counts into the
+// views' offsets into one packed list (numViews+1 entries, the last the total the host sizes
+// the list by), and kernelCompactOwners (one block per view) writes the face ids, in face order.
+// The per-direction accumulation then runs one thread per OWNER face of its reference view
+// instead of one per mesh face exiting on the bit: a view owns a fraction of the faces (a
+// quarter to a third on Ignatius at level 1, where the cameras ring one object; less in a scene
+// of hundreds of views along a path), and the exits left the warps that did reach the pixel
+// loop 4-5 active lanes of 32 (Nsight Compute, Ignatius level 1, both scales: 4.4 threads per
+// warp-instruction, 13 of 20 warp cycles stalled on the scattered loads, compute 27 % and
+// memory 37 % of peak, the kernel 55 % of the GPU time); with the lists, 9.4/7.7 lanes and 2.3x
+// fewer instructions issued.
+// The list order does not touch the result -- a face still reduces its own pixels in raster
+// order into its own slot, and the fold order across directions is the launch order -- and
+// face order is kept because consecutive faces are neighbours on the mesh, so a warp's 32
+// boxes land near one another in the image.
+
+// exclusive prefix sum of one value per thread over the block (blockDim.x a multiple of 32, at
+// most 1024): returns the thread's exclusive prefix and leaves the block total in `total`;
+// warpSums is 32 words of shared memory, free for reuse when this returns
+__device__ inline uint32_t blockScanExclusive(uint32_t v, uint32_t& total, uint32_t* warpSums)
+{
+	const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5, numWarps = blockDim.x >> 5;
+	uint32_t incl = v;
+	#pragma unroll
+	for (int d = 1; d < 32; d <<= 1) {
+		const uint32_t t = __shfl_up_sync(0xffffffffu, incl, d);
+		if (lane >= d) incl += t;
+	}
+	if (lane == 31) warpSums[warp] = incl;
+	__syncthreads();
+	if (warp == 0) {
+		uint32_t s = lane < numWarps ? warpSums[lane] : 0u;
+		#pragma unroll
+		for (int d = 1; d < 32; d <<= 1) {
+			const uint32_t t = __shfl_up_sync(0xffffffffu, s, d);
+			if (lane >= d) s += t;
+		}
+		if (lane < numWarps) warpSums[lane] = s;
+	}
+	__syncthreads();
+	const uint32_t prefix = (warp ? warpSums[warp-1] : 0u) + incl - v;
+	total = warpSums[numWarps-1];
+	__syncthreads();
+	return prefix;
+}
+
+__global__ void kernelCountOwners(
+	const uint32_t* __restrict__ ownerBits, // numWords per view, view-major
+	uint32_t* __restrict__ counts, // 1 per view
+	uint32_t numWords)
+{
+	__shared__ uint32_t warpSums[32];
+	const uint32_t* words = ownerBits + (size_t)blockIdx.x * numWords;
+	uint32_t n = 0;
+	for (uint32_t w = threadIdx.x; w < numWords; w += blockDim.x)
+		n += __popc(words[w]);
+	uint32_t total;
+	blockScanExclusive(n, total, warpSums);
+	if (threadIdx.x == 0)
+		counts[blockIdx.x] = total;
+}
+
+__global__ void kernelScanViewCounts(
+	const uint32_t* __restrict__ counts,
+	uint32_t* __restrict__ offsets, // numViews+1: the exclusive prefix sum of counts, then the total
+	uint32_t numViews)
+{
+	__shared__ uint32_t warpSums[32];
+	uint32_t running = 0;
+	for (uint32_t base = 0; base < numViews; base += blockDim.x) {
+		const uint32_t i = base + threadIdx.x;
+		uint32_t total;
+		const uint32_t prefix = blockScanExclusive(i < numViews ? counts[i] : 0u, total, warpSums);
+		if (i < numViews)
+			offsets[i] = running + prefix;
+		running += total;
+	}
+	if (threadIdx.x == 0)
+		offsets[numViews] = running;
+}
+
+__global__ void kernelCompactOwners(
+	const uint32_t* __restrict__ ownerBits,
+	const uint32_t* __restrict__ offsets,
+	uint32_t* __restrict__ ownerList, // offsets[numViews] entries: every view's owner faces, in face order
+	uint32_t numWords)
+{
+	__shared__ uint32_t warpSums[32];
+	const uint32_t* words = ownerBits + (size_t)blockIdx.x * numWords;
+	uint32_t* list = ownerList + offsets[blockIdx.x];
+	uint32_t running = 0;
+	for (uint32_t base = 0; base < numWords; base += blockDim.x) {
+		const uint32_t w = base + threadIdx.x;
+		uint32_t bits = w < numWords ? words[w] : 0u;
+		uint32_t total;
+		uint32_t pos = running + blockScanExclusive(__popc(bits), total, warpSums);
+		while (bits) {
+			list[pos++] = w*32 + (uint32_t)(__ffs(bits) - 1);
+			bits &= bits - 1;
+		}
+		running += total;
+	}
+	// what kernelCountOwners counted for this view
+	ASSERT(running == offsets[blockIdx.x+1] - offsets[blockIdx.x]);
+}
+
+
+// 4. SortOwnersTile — one block per view, right after the compaction: the view's owner list
+// reordered by the image tile (2^tileShiftX x 2^tileShiftY pixels, row-major) the face's
+// clipped box starts in, so that the 32 lanes of a warp of the accumulation walk boxes a tile
+// or two apart at most. In face order the lanes' boxes were scattered over the image and every
+// load fetched its own lines (Nsight Compute: 4 of 32 bytes of every sector used, L1 hit 52-54 %,
+// 18-21 of 25-28 warp cycles on the long scoreboard even with a chunk's loads in flight). The
+// projection is the accumulation's own (projectFace + faceBBox). A counting sort in shared
+// memory: the bucket histogram, its exclusive scan, and a scatter whose order WITHIN a bucket is
+// the atomics' -- the result does not depend on the list order (see kernelCompactOwners).
+__global__ void kernelSortOwnersTile(
+	const Point3* __restrict__ vertices,
+	const Point3u* __restrict__ faces,
+	const Camera* __restrict__ cameras, // one per view
+	const uint32_t* __restrict__ offsets,
+	const uint32_t* __restrict__ listIn,
+	uint32_t* __restrict__ keys, // scratch, one per list entry
+	uint32_t* __restrict__ listOut,
+	int tileShiftX, int tileShiftY)
+{
+	extern __shared__ uint32_t hist[]; // the view's tile count + 32 words for the scan
+	const Camera camera = cameras[blockIdx.x];
+	const uint32_t off = offsets[blockIdx.x], n = offsets[blockIdx.x+1] - off;
+	const int tilesX = (camera.size.x() + (1 << tileShiftX) - 1) >> tileShiftX;
+	const int numBuckets = tilesX * ((camera.size.y() + (1 << tileShiftY) - 1) >> tileShiftY);
+	uint32_t* warpSums = hist + numBuckets;
+	for (int b = threadIdx.x; b < numBuckets; b += blockDim.x)
+		hist[b] = 0;
+	__syncthreads();
+	for (uint32_t i = threadIdx.x; i < n; i += blockDim.x) {
+		const uint32_t idxFace = listIn[off + i];
+		ProjectedFace pf;
+		int ixMin(0), ixMax(-1), iyMin(0), iyMax(-1);
+		const bool seen(projectFace(vertices, faces[idxFace], camera, pf) && faceBBox(pf, camera, ixMin, ixMax, iyMin, iyMax));
+		ASSERT(seen); (void)seen; // it owns a pixel of this view
+		const uint32_t key = (uint32_t)((iyMin >> tileShiftY) * tilesX + (ixMin >> tileShiftX));
+		keys[off + i] = key;
+		atomicAdd(&hist[key], 1u);
+	}
+	__syncthreads();
+	// exclusive scan: hist[b] becomes the bucket's first position
+	uint32_t running = 0;
+	for (int base = 0; base < numBuckets; base += blockDim.x) {
+		const int b = base + threadIdx.x;
+		uint32_t total;
+		const uint32_t prefix = blockScanExclusive(b < numBuckets ? hist[b] : 0u, total, warpSums);
+		if (b < numBuckets)
+			hist[b] = running + prefix;
+		running += total;
+	}
+	__syncthreads();
+	for (uint32_t i = threadIdx.x; i < n; i += blockDim.x) {
+		const uint32_t pos = atomicAdd(&hist[keys[off + i]], 1u);
+		listOut[off + pos] = listIn[off + i];
+	}
+}
+
+
+// 5. ImageMeshWarp — 2D, texture + 2 surfaces
 __global__ void kernelImageMeshWarp(
 	const float* __restrict__ depthMapA,
 	const float* __restrict__ depthMapB,
@@ -422,7 +588,7 @@ __device__ inline bool computePhotoPixel(
 }
 
 
-// 4. ComputeWindowStats — 2D, one thread per pixel: the six MASKED window sums, the two
+// 6. ComputeWindowStats — 2D, one thread per pixel: the six MASKED window sums, the two
 // rejection gates, ZNCC, its derivative, this pair-direction's reliability sums and the pixel's
 // photometric term, all in one pass over the 7x7 window. Replaces the former five kernels
 // (mean/var/cov/zncc/dzncc) and the six full-image buffers they exchanged. Only successfully
@@ -563,7 +729,7 @@ __global__ void kernelComputeWindowStats(
 }
 
 
-// 5. ReduceBlockSums — a single block, once per ScoreMesh() after every pair-direction: adds
+// 7. ReduceBlockSums — a single block, once per ScoreMesh() after every pair-direction: adds
 // the per-block partials of all of them (each direction's blocks occupy their own slots, in
 // launch order) into the two accumulators S is computed from, in a fixed order (each thread walks
 // a strided, fixed subset of the slots, then a fixed shared-memory tree), so S is the same number
@@ -600,45 +766,50 @@ __global__ void kernelReduceBlockSums(
 }
 
 
-// 6. AccumulateFacePhoto — 1D, one thread per mesh face; the per-pair-direction half of the
-// atomic-free photometric accumulation. Each thread reduces ITS OWN face's pixels into registers
-// and folds them into its private slots, so there is not a single atomic and not a single float
-// sum whose order depends on the schedule -- float addition is not associative, and an atomicAdd
-// scatter gives a different per-vertex gradient on every run. The slots accumulate across the
-// pair-directions of one ScoreMesh() (one writer per face, in launch order, so that too is a
-// fixed sequence), which lets the per-vertex gather run once per ScoreMesh() instead of once
-// per direction.
+// see kernelAccumulateFacePhoto's tail: stamp vertex v with this direction and count it once
+__device__ inline void countDirection(uint32_t* __restrict__ vertexStamp, float* __restrict__ photoCount, uint32_t v, uint32_t direction)
+{
+	if (atomicExch(&vertexStamp[v], direction) != direction)
+		photoCount[v] += 1.f;
+}
+
+// 8. AccumulateFacePhoto — 1D, one thread per face the reference view OWNS (its slice of the
+// list kernelCompactOwners built and kernelSortOwnersTile ordered); the per-pair-direction half
+// of the atomic-free photometric accumulation. Each thread reduces ITS OWN face's pixels into
+// registers and folds them into its private slots, so there is not a single atomic and not a
+// single float sum whose order depends on the schedule -- float addition is not associative,
+// and an atomicAdd scatter gives a different per-vertex gradient on every run. The slots
+// accumulate across the pair-directions of one ScoreMesh() (one writer per face, in launch
+// order, so that too is a fixed sequence), which lets the per-vertex gather run once per
+// ScoreMesh() instead of once per direction.
 //
 // A face this view does not see -- behind the camera, off the image, back-facing or occluded --
-// exits on its owner bit (kernelProjectMesh, pass 2), one coalesced word per warp, before its
-// face or vertices are read. The rest project their face and walk its clipped bounding box
-// exactly as kernelProjectMesh did, keeping the pixels whose faceMap entry is this face (faceMap
-// only ever holds ids the rasterizer wrote); a kept pixel's barycentrics and depth are recomputed
-// from the same projection, the same arithmetic the rasterizer keyed the pixel with, so they are
-// the rasterizer's bit for bit, in a fixed row-then-column order. The per-pixel term itself comes
+// is not in the list (kernelProjectMesh pass 2 left its owner bit clear). The rest project their
+// face and walk its clipped bounding box exactly as kernelProjectMesh did, keeping the pixels
+// whose faceMap entry is this face (faceMap only ever holds ids the rasterizer wrote); a kept
+// pixel's barycentrics and depth are recomputed from the same projection, the same arithmetic
+// the rasterizer keyed the pixel with, so they are the rasterizer's bit for bit, in a fixed
+// row-then-column order. The per-pixel term itself comes
 // from kernelComputeWindowStats, one balanced thread per pixel; here it is only weighted by the
 // barycentrics. (Eight lanes sharing a face, each taking every eighth pixel of the box with a
 // fixed shuffle tree over their partials, was measured at 49/88 us per launch against 26/64 us
 // for this form on Ignatius at level 1, scales 0/1: on the small boxes most lanes idle, and the
 // extra threads and shuffles cost more than the divergence they remove.)
-__global__ void kernelAccumulateFacePhoto(
+__device__ inline void accumulateFacePhoto(
+	uint32_t tid, // the face, one of the reference view's owners
 	const Point3* __restrict__ vertices,
 	const Point3u* __restrict__ faces,
-	const uint32_t* __restrict__ ownerBits, // this view's, from the rasterizer: bit f set iff face f owns a pixel
 	const uint32_t* __restrict__ faceMap,
 	const float* __restrict__ pixelGrad,
 	const uint8_t* __restrict__ mask,
 	float* __restrict__ faceAcc, // 3 per face: Sum over the face's pixels of g_p*b_c, one per corner
 	float* __restrict__ facePixels, // 1 per face: how many pixels contributed (0 = the face contributed nothing)
 	float* __restrict__ faceFoot, // 1 per face: min footprint over the face's pixels; only read where facePixels > 0
-	uint8_t* __restrict__ vertexSeen, // 1 per vertex: set for the corners of a face that contributed (every writer stores the same value, so the race is benign)
-	Camera camA,
-	uint32_t numFaces)
+	uint32_t* __restrict__ vertexStamp, // 1 per vertex: the last direction that reached it (~0u at the start of an evaluation)
+	float* __restrict__ photoCount, // 1 per vertex: how many directions reached it
+	uint32_t direction, // this pair-direction's index within the evaluation
+	const Camera& camA)
 {
-	const int tid = blockIdx.x * blockDim.x + threadIdx.x;
-	if (tid >= (int)numFaces) return;
-	if (!((ownerBits[tid >> 5] >> (tid & 31)) & 1u)) return;
-
 	// it owns a pixel, so the rasterizer's projection of it succeeded
 	const Point3u face = faces[tid];
 	ProjectedFace pf;
@@ -648,27 +819,46 @@ __global__ void kernelAccumulateFacePhoto(
 	float sum0 = 0.f, sum1 = 0.f, sum2 = 0.f;
 	float pixels = 0.f, foot = FLT_MAX;
 	const int width = camA.size.x();
+	// the box row by row, in chunks of RowChunk pixels whose face ids, mask bytes and terms are
+	// loaded together before any is tested, so that a chunk's loads are in flight at once: one
+	// load per pixel between branches paid a full memory round trip per pixel (Nsight Compute:
+	// 21 of 28 warp cycles per instruction on the long scoreboard, the lanes' boxes being
+	// scattered over the image). The pixels are still folded in raster order, so the sums are
+	// the same sequence of float additions
+	constexpr int RowChunk = 4;
 	for (int iy = iyMin; iy <= iyMax; ++iy) {
-		for (int ix = ixMin; ix <= ixMax; ++ix) {
-			const int pixIdx = iy * width + ix;
-			if (faceMap[pixIdx] != (uint32_t)tid || mask[pixIdx] != 1)
-				continue;
-			// this pixel's winning rasterizer key was this face's, computed by pixelBary from
-			// this very projection, so the same call reproduces its perspective-correct
-			// barycentrics and depth
-			float nb0, nb1, nb2, depth;
-			const bool inside(pixelBary(ix, iy, pf, nb0, nb1, nb2, depth));
-			ASSERT(inside); (void)inside;
-			const float g = pixelGrad[pixIdx];
-			sum0 += g * nb0;
-			sum1 += g * nb1;
-			sum2 += g * nb2;
-			// per-vertex footprint at camera A, scene units per pixel (Camera::GetFootprintWorld =
-			// depth/focalLength): min over every contributing pixel of every pair-direction,
-			// matching the CPU's min-of-mins (MeshRefine::ComputePhotometricGradient/ThProcessPair);
-			// min is exact and associative, so this half of it is reproducible for free
-			foot = fminf(foot, depth / camA.model.f.x());
-			pixels += 1.f;
+		for (int ix0 = ixMin; ix0 <= ixMax; ix0 += RowChunk) {
+			const int base = iy * width + ix0;
+			const int n = min(RowChunk, ixMax - ix0 + 1);
+			uint32_t f[RowChunk]; uint8_t m[RowChunk]; float g[RowChunk];
+			#pragma unroll
+			for (int k = 0; k < RowChunk; ++k) {
+				const bool in = k < n;
+				f[k] = in ? faceMap[base + k] : (uint32_t)-1;
+				m[k] = in ? mask[base + k] : (uint8_t)0;
+				g[k] = in ? pixelGrad[base + k] : 0.f;
+			}
+			#pragma unroll
+			for (int k = 0; k < RowChunk; ++k) {
+				if (f[k] != tid || m[k] != 1)
+					continue;
+				// this pixel's winning rasterizer key was this face's, computed by pixelBary
+				// from this very projection, so the same call reproduces its
+				// perspective-correct barycentrics and depth
+				float nb0, nb1, nb2, depth;
+				const bool inside(pixelBary(ix0 + k, iy, pf, nb0, nb1, nb2, depth));
+				ASSERT(inside); (void)inside;
+				sum0 += g[k] * nb0;
+				sum1 += g[k] * nb1;
+				sum2 += g[k] * nb2;
+				// per-vertex footprint at camera A, scene units per pixel
+				// (Camera::GetFootprintWorld = depth/focalLength): min over every contributing
+				// pixel of every pair-direction, matching the CPU's min-of-mins
+				// (MeshRefine::ComputePhotometricGradient/ThProcessPair); min is exact and
+				// associative, so this half of it is reproducible for free
+				foot = fminf(foot, depth / camA.model.f.x());
+				pixels += 1.f;
+			}
 		}
 	}
 	if (pixels == 0.f)
@@ -678,31 +868,45 @@ __global__ void kernelAccumulateFacePhoto(
 	faceAcc[tid*3 + 2] += sum2;
 	facePixels[tid] += pixels;
 	faceFoot[tid] = fminf(faceFoot[tid], foot);
-	vertexSeen[face.x()] = 1;
-	vertexSeen[face.y()] = 1;
-	vertexSeen[face.z()] = 1;
+	// the direction counts once per vertex it reaches (the CPU's `photoGradNorm[idxVert] += 1.f`
+	// per pair-direction): of the faces of the vertex contributing to this direction, exactly
+	// one thread gets the previous stamp back from the exchange and counts, so the count grows
+	// by an integer 1 exactly once per direction whatever the schedule -- reproducible, and no
+	// per-direction kernel over the vertices (one launch in four, host-bound at the coarse
+	// scales) to clear the marks and count them
+	countDirection(vertexStamp, photoCount, face.x(), direction);
+	countDirection(vertexStamp, photoCount, face.y(), direction);
+	countDirection(vertexStamp, photoCount, face.z(), direction);
 }
-
-
-// 7. CountSeenVertices — 1D, one thread per vertex, right after each AccumulateFacePhoto:
-// exactly the CPU's `photoGradNorm[idxVert] += 1.f`, one count per pair-direction that
-// contributed at least one pixel to a face of the vertex; the mark is cleared for the next
-// direction
-__global__ void kernelCountSeenVertices(
-	uint8_t* __restrict__ vertexSeen,
+__global__ void kernelAccumulateFacePhoto(
+	const Point3* __restrict__ vertices,
+	const Point3u* __restrict__ faces,
+	const uint32_t* __restrict__ ownerList, // every view's owner faces (kernelSortOwnersTile)
+	const uint32_t* __restrict__ ownerOffsets, // the views' slices of it, numViews+1 entries
+	uint32_t idxView, // the reference view
+	const uint32_t* __restrict__ faceMap,
+	const float* __restrict__ pixelGrad,
+	const uint8_t* __restrict__ mask,
+	float* __restrict__ faceAcc,
+	float* __restrict__ facePixels,
+	float* __restrict__ faceFoot,
+	uint32_t* __restrict__ vertexStamp,
 	float* __restrict__ photoCount,
-	uint32_t numVertices)
+	uint32_t direction,
+	Camera camA)
 {
-	const int tid = blockIdx.x * blockDim.x + threadIdx.x;
-	if (tid >= (int)numVertices) return;
-	if (vertexSeen[tid]) {
-		photoCount[tid] += 1.f;
-		vertexSeen[tid] = 0;
-	}
+	// the view's slice is read here, not passed: the launch is recorded once per scale into a
+	// graph (MeshRefineCUDA::ScoreMesh) while the slices move with the mesh, so the grid is the
+	// slice's size at the recording with a margin, and the stride loop covers whatever it has
+	// grown to since
+	const uint32_t off = ownerOffsets[idxView], numOwners = ownerOffsets[idxView+1] - off;
+	for (uint32_t idx = blockIdx.x * blockDim.x + threadIdx.x; idx < numOwners; idx += gridDim.x * blockDim.x)
+		accumulateFacePhoto(ownerList[off + idx], vertices, faces, faceMap, pixelGrad, mask,
+			faceAcc, facePixels, faceFoot, vertexStamp, photoCount, direction, camA);
 }
 
 
-// 8. GatherVertexPhoto — 1D, one thread per vertex, once per ScoreMesh() after every
+// 9. GatherVertexPhoto — 1D, one thread per vertex, once per ScoreMesh() after every
 // pair-direction. It walks the vertex's incident faces in the fixed order Mesh::ListIncidentFaces
 // produced (uploaded per scale, see MeshRefineCUDA::ListVertexFacesPost) and folds in each
 // face's slots, so a vertex's sum is a fixed sequence of float additions. The footprint sentinel
@@ -754,7 +958,7 @@ __global__ void kernelGatherVertexPhoto(
 }
 
 
-// 9. ComputeSmoothnessGradient — 1D
+// 10. ComputeSmoothnessGradient — 1D
 __global__ void kernelComputeSmoothnessGradient(
 	const Point3* __restrict__ vertices,
 	const uint32_t* __restrict__ vertVertices,
@@ -810,7 +1014,7 @@ __global__ void kernelComputeSmoothnessGradient(
 }
 
 
-// 10. ComputeFaceNormal — 1D, 1 thread per face
+// 11. ComputeFaceNormal — 1D, 1 thread per face
 __global__ void kernelComputeFaceNormal(
 	const Point3* __restrict__ vertices,
 	const Point3u* __restrict__ faces,
@@ -833,7 +1037,7 @@ __global__ void kernelComputeFaceNormal(
 
 // H O S T   L A U N C H E R S ////////////////////////////////////////
 
-// 9. FaceHistogram -- 1D over the pixels of one view, after the rasterization: the rasterized
+// 12. FaceHistogram -- 1D over the pixels of one view, after the rasterization: the rasterized
 // area of every face in it, in pixels, exactly the pixel count the host's ListFaceAreas took
 // from the downloaded face map; integer atomics, so the counts are exact whatever the schedule
 __global__ void kernelFaceHistogram(
@@ -849,7 +1053,7 @@ __global__ void kernelFaceHistogram(
 }
 
 
-// 10. ReduceFaceAreasPair -- 1D, one thread per face, once per pair: the smaller of the face's
+// 13. ReduceFaceAreasPair -- 1D, one thread per face, once per pair: the smaller of the face's
 // two rasterized areas in the pair (a pair resolves a face only as well as its worse view) folded
 // into the largest over the pairs, exactly ReduceFaceAreasOverPairs (SceneRefineCommon.cpp), the
 // truncation to 16 bits included (the host counts in uint16_t)
@@ -897,11 +1101,12 @@ void LaunchImageMeshWarp(
 	const uint8_t* keepA, const uint8_t* keepB, uint8_t* mask,
 	const Camera& camA, const Camera& camB,
 	cudaTextureObject_t texImageB,
-	cudaSurfaceObject_t surfImageProj)
+	cudaSurfaceObject_t surfImageProj,
+	cudaStream_t stream)
 {
 	const dim3 block(16, 16);
 	const dim3 grid((camA.size.x() + block.x - 1) / block.x, (camA.size.y() + block.y - 1) / block.y);
-	kernelImageMeshWarp<<<grid, block>>>(depthMapA, depthMapB, keepA, keepB, mask, camA, camB, texImageB, surfImageProj);
+	kernelImageMeshWarp<<<grid, block, 0, stream>>>(depthMapA, depthMapB, keepA, keepB, mask, camA, camB, texImageB, surfImageProj);
 }
 
 uint32_t LaunchComputeWindowStats(
@@ -910,32 +1115,59 @@ uint32_t LaunchComputeWindowStats(
 	const Point3* normals, const uint32_t* faceMap, const float* depthMap,
 	const Camera& camA, const Camera& camB,
 	cudaTextureObject_t texImageB, cudaTextureObject_t texGradXB, cudaTextureObject_t texGradYB,
-	bool bBilinearGrad, float regScale, float gateMeanDiff, float gateVarRatio, int width, int height)
+	bool bBilinearGrad, float regScale, float gateMeanDiff, float gateVarRatio, int width, int height,
+	cudaStream_t stream)
 {
 	const dim3 block(16, 16);
 	const dim3 grid((width + block.x - 1) / block.x, (height + block.y - 1) / block.y);
-	kernelComputeWindowStats<<<grid, block>>>(mask, maskOut, pixelGrad, blockSums,
+	kernelComputeWindowStats<<<grid, block, 0, stream>>>(mask, maskOut, pixelGrad, blockSums,
 		surfImageA, surfImageProj, normals, faceMap, depthMap, camA, camB,
 		texImageB, texGradXB, texGradYB, bBilinearGrad, regScale, gateMeanDiff, gateVarRatio, width, height);
 	return grid.x*grid.y;
 }
 
-void LaunchReduceBlockSums(const float* blockSums, uint32_t numSlots, float* sumR, float* sumRZ)
+void LaunchReduceBlockSums(const float* blockSums, uint32_t numSlots, float* sumR, float* sumRZ, cudaStream_t stream)
 {
-	kernelReduceBlockSums<<<1, 1024>>>(blockSums, numSlots, sumR, sumRZ);
+	kernelReduceBlockSums<<<1, 1024, 0, stream>>>(blockSums, numSlots, sumR, sumRZ);
+}
+
+void LaunchCountOwners(const uint32_t* ownerBits, uint32_t* counts, uint32_t numWords, uint32_t numViews)
+{
+	kernelCountOwners<<<numViews, 1024>>>(ownerBits, counts, numWords);
+}
+
+void LaunchScanViewCounts(const uint32_t* counts, uint32_t* offsets, uint32_t numViews)
+{
+	kernelScanViewCounts<<<1, 1024>>>(counts, offsets, numViews);
+}
+
+void LaunchCompactOwners(const uint32_t* ownerBits, const uint32_t* offsets, uint32_t* ownerList, uint32_t numWords, uint32_t numViews)
+{
+	kernelCompactOwners<<<numViews, 1024>>>(ownerBits, offsets, ownerList, numWords);
+}
+
+void LaunchSortOwnersTile(
+	const Point3* vertices, const Point3u* faces, const Camera* cameras,
+	const uint32_t* offsets, const uint32_t* listIn, uint32_t* keys, uint32_t* listOut,
+	int tileShiftX, int tileShiftY, uint32_t maxBuckets, uint32_t numViews)
+{
+	ASSERT(maxBuckets <= 8192); // static limit of the dynamic shared memory
+	kernelSortOwnersTile<<<numViews, 1024, sizeof(uint32_t)*(maxBuckets + 32)>>>(
+		vertices, faces, cameras, offsets, listIn, keys, listOut, tileShiftX, tileShiftY);
 }
 
 void LaunchAccumulateFacePhoto(
-	const Point3* vertices, const Point3u* faces, const uint32_t* ownerBits,
+	const Point3* vertices, const Point3u* faces,
+	const uint32_t* ownerList, const uint32_t* ownerOffsets, uint32_t idxView,
 	const uint32_t* faceMap, const float* pixelGrad, const uint8_t* mask,
-	float* faceAcc, float* facePixels, float* faceFoot, uint8_t* vertexSeen,
-	const Camera& camA, uint32_t numFaces)
+	float* faceAcc, float* facePixels, float* faceFoot,
+	uint32_t* vertexStamp, float* photoCount, uint32_t direction,
+	const Camera& camA, uint32_t numBlocks, cudaStream_t stream)
 {
-	const int blockSize = 256;
-	const int numBlocks = ((int)numFaces + blockSize - 1) / blockSize;
-	kernelAccumulateFacePhoto<<<numBlocks, blockSize>>>(
-		vertices, faces, ownerBits, faceMap, pixelGrad, mask,
-		faceAcc, facePixels, faceFoot, vertexSeen, camA, numFaces);
+	// small blocks: a launch is a fraction of the mesh, and the box walks are uneven
+	kernelAccumulateFacePhoto<<<numBlocks, AccumulateBlockSize, 0, stream>>>(
+		vertices, faces, ownerList, ownerOffsets, idxView, faceMap, pixelGrad, mask,
+		faceAcc, facePixels, faceFoot, vertexStamp, photoCount, direction, camA);
 }
 
 void LaunchFaceHistogram(const uint32_t* faceMap, uint32_t* hist, uint32_t numPixels)
@@ -952,22 +1184,15 @@ void LaunchReduceFaceAreasPair(const uint32_t* histA, const uint32_t* histB, uin
 	kernelReduceFaceAreasPair<<<numBlocks, blockSize>>>(histA, histB, maxAreas, numFaces);
 }
 
-void LaunchCountSeenVertices(uint8_t* vertexSeen, float* photoCount, uint32_t numVertices)
-{
-	const int blockSize = 256;
-	const int numBlocks = ((int)numVertices + blockSize - 1) / blockSize;
-	kernelCountSeenVertices<<<numBlocks, blockSize>>>(vertexSeen, photoCount, numVertices);
-}
-
 void LaunchGatherVertexPhoto(
 	const Point3u* faces, const Point3* normals,
 	const uint32_t* vertFaces, const uint32_t* vertFaceSizes, const uint32_t* vertFacePointers,
 	const float* faceAcc, const float* facePixels, const float* faceFoot,
-	Point3* photoGrad, float* footprint, uint32_t numVertices)
+	Point3* photoGrad, float* footprint, uint32_t numVertices, cudaStream_t stream)
 {
 	const int blockSize = 256;
 	const int numBlocks = ((int)numVertices + blockSize - 1) / blockSize;
-	kernelGatherVertexPhoto<<<numBlocks, blockSize>>>(
+	kernelGatherVertexPhoto<<<numBlocks, blockSize, 0, stream>>>(
 		faces, normals, vertFaces, vertFaceSizes, vertFacePointers,
 		faceAcc, facePixels, faceFoot, photoGrad, footprint, numVertices);
 }

--- a/libs/MVS/SceneRefineCUDA.cu
+++ b/libs/MVS/SceneRefineCUDA.cu
@@ -42,9 +42,8 @@ namespace CUDA {
 
 // D E V I C E   H E L P E R S ////////////////////////////////////////
 
-// read a float pixel from a 32F image surface (the images and the warped image are stored in
-// float exactly like the CPU's Image32F: half floats lose too much in low-variance ZNCC windows
-// and at grazing pixels)
+// read a pixel of a 32F surface (the images are float like the CPU's Image32F: half floats lose
+// too much in low-variance ZNCC windows and at grazing pixels)
 __device__ inline float readSurfFloat(cudaSurfaceObject_t surf, int x, int y) {
 	float v;
 	surf2Dread(&v, surf, x * (int)sizeof(float), y);
@@ -56,17 +55,9 @@ __device__ inline float readSurfFloat(cudaSurfaceObject_t surf, int x, int y) {
 
 // K E R N E L S ////////////////////////////////////////////////////
 
-// Project a face's 3 vertices into the camera; false if a vertex is behind the camera or the
-// face is back-facing (culled). CPU (MeshRefine::RasterMesh::ProjectVertex) accepts a vertex as
-// soon as it is in front of the camera and lets RasterizeTriangleBary clip the triangle to the
-// image -- a face straddling the near-plane itself (as opposed to merely straddling the image
-// border, which both backends handle via bbox clipping) is rare on a coarse refinement mesh, so
-// it is simply dropped here rather than near-plane clipped.
-// The CPU's SEACAVE::EdgeFunction(x0,x1,x2) = (x2-x0).cross(x1-x0) = (x2-x0).x*(x1-x0).y -
-// (x2-x0).y*(x1-x0).x (Util.inl, TPoint2::cross), evaluated with the same four subtractions,
-// two products and one subtraction, every one explicitly rounded so nvcc cannot fuse any of
-// them into an fma: the CPU (MSVC /fp:precise) does not, and the two backends' pixel coverage
-// must agree bit for bit -- see pixelBary.
+// SEACAVE::EdgeFunction (Util.inl): the same subtractions and products in the same order, each
+// explicitly rounded so that nvcc cannot fuse an fma the CPU (/fp:precise) does not; the two
+// backends' pixel coverage has to agree bit for bit (see pixelBary)
 __device__ inline float edgeFunction(const Point2& x0, const Point2& x1, const Point2& x2)
 {
 	const float ax = __fsub_rn(x2.x(), x0.x()), ay = __fsub_rn(x2.y(), x0.y());
@@ -74,17 +65,16 @@ __device__ inline float edgeFunction(const Point2& x0, const Point2& x1, const P
 	return __fsub_rn(__fmul_rn(ax, by), __fmul_rn(ay, bx));
 }
 
-// back-face cull exactly as TImage::RasterizeTriangleBary (CULL=true): a triangle is kept iff
-// its EdgeFunction(p0,p1,p2) > 0 (outward face orientation, y-down pixel coordinates)
+// a face projected into a view, kept iff every vertex is in front of the camera and
+// EdgeFunction(p0,p1,p2) > 0 (front-facing in y-down pixel coordinates), exactly the CPU's
+// RasterMesh::ProjectVertex and TImage::RasterizeTriangleBary(CULL=true); a face straddling
+// the near plane is dropped, not clipped, on both backends
 struct ProjectedFace {
 	float z0, z1, z2;  // camera-space depths of the vertices
 	Point2 p0, p1, p2; // image-space vertices
-	float invArea;     // 1 / EdgeFunction(p0,p1,p2), positive for a kept (front) face
+	float invArea;     // 1 / EdgeFunction(p0,p1,p2)
 };
-// MeshRefine::RasterMesh::ProjectVertex (SceneRefine.cpp): camera-space point, rejected if
-// behind the camera, then its pixel coordinates. The CPU does this in double and casts to
-// float; the float path here gives the same face maps on Tiny pixel for pixel (raw maps of
-// view 3: 0 of 197,624 covered pixels differ), so no double copy of the camera is carried.
+// float where the CPU projects in double and casts: the face maps are still pixel-identical
 __device__ inline bool projectVertex(const Camera& camera, const Point3& X, Point2& pti, float& z)
 {
 	const Point3 Xc = camera.pose.TransformPointW2C(X);
@@ -105,18 +95,11 @@ __device__ inline bool projectFace(const Point3* __restrict__ vertices, const Po
 	return true;
 }
 
-// Perspective-correct barycentric coordinates and depth of pixel (ix,iy) in a projected face;
-// false if the pixel centre is outside the triangle. This is TImage::RasterizeTriangleBary's
-// inclusion test, expression for expression: each barycentric is the edge function of the pixel
-// against the two OTHER vertices times 1/area, rejected as soon as one is negative (the CPU's
-// formulation, so the two backends' coverage decisions are the same arithmetic; on Tiny the
-// resulting face maps are identical to the CPU's pixel for pixel). Then
-// SEACAVE::PerspectiveCorrectBarycentricCoordinates (Util.inl): pb_i = b_i*z_j*z_k, each
-// divided by their sum, and MeshRefine::RasterMesh::ComputeDepth (Mesh.h): the left-to-right
-// blend of the 3 vertex depths. Every operation is an explicit-rounding intrinsic: nvcc may
-// contract a*b+c into an fma differently per kernel (the two rasterizer passes below need the
-// bit-identical depth for the same (ix,iy,face); an earlier per-pixel resolve kernel missed
-// the key by an ulp for that reason) and the CPU (MSVC /fp:precise) does not contract.
+// perspective-correct barycentrics and depth of pixel (ix,iy) in a projected face, false if the
+// pixel centre is outside it: TImage::RasterizeTriangleBary's inclusion test,
+// SEACAVE::PerspectiveCorrectBarycentricCoordinates and RasterMesh::ComputeDepth expression
+// for expression, every operation an explicit-rounding intrinsic so that the rasterizer's two
+// passes and the accumulation compute the identical depth for the same pixel and face
 __device__ inline bool pixelBary(int ix, int iy, const ProjectedFace& pf, float& nb0, float& nb1, float& nb2, float& depth)
 {
 	const Point2 p((float)ix, (float)iy);
@@ -136,16 +119,10 @@ __device__ inline bool pixelBary(int ix, int iy, const ProjectedFace& pf, float&
 	return true;
 }
 
-// The projected face's bounding box with ±0.5 padding, clamped to the shared border margin
-// (Refine::Border, the same margin the per-pixel window-statistics kernels require -- was a
-// hardcoded 5px border); the accepted pixel range is [Border, size-Border) exactly as the CPU's
-// per-pixel test in MeshRefine::RasterMesh::Raster (SceneRefine.cpp), so the inclusive bbox ends
-// at size-Border-1 (an inclusive clamp at size-Border rasterised one extra row/column the CPU
-// rejects, and the warped values it put there leaked into every 7x7 window statistic within
-// HalfSize of it). false if the clipped box is empty. The rasterizer and the face-parallel
-// photometric accumulation share it so that the second visits exactly the pixels the first could
-// have covered -- and, since Border == HalfSize, the photometric kernel's old per-pixel border
-// test is implied by the box rather than repeated.
+// the projected face's bounding box padded by 0.5 px and clamped to [Border, size-Border-1],
+// the pixel range the CPU's RasterMesh::Raster accepts; false if empty. The rasterizer and the
+// accumulation walk the same box, and Border == HalfSize keeps the window kernels' margin
+// implicit in it
 __device__ inline bool faceBBox(const ProjectedFace& pf, const Camera& camera,
 	int& ixMin, int& ixMax, int& iyMin, int& iyMax)
 {
@@ -157,25 +134,16 @@ __device__ inline bool faceBBox(const ProjectedFace& pf, const Camera& camera,
 	return ixMin <= ixMax && iyMin <= iyMax;
 }
 
-// 1. ProjectMesh — 1D, one thread per mesh face, launched twice. Pass 1 (RESOLVE=false):
-// every covered pixel receives one 64-bit key (depth bits << 32 | face id) through a single
-// atomicMin, so the nearest face wins and, at exactly equal depth, the lower face id. Pass 2
-// (RESOLVE=true): the same threads redo the same arithmetic and the one whose key is the pixel's
-// winner writes depth/face/bary -- one writer per pixel, no payload race, hence a deterministic
-// face map. The whole mesh is rasterized into every view: a face behind the camera or off the
-// image costs its thread three projections and an early exit, cheaper than the host-side
-// frustum cull that used to shortlist the faces (an octree over the mesh rebuilt for every
-// evaluation, plus one face-list upload per view, while the GPU sat idle). The CPU's RasterMesh
-// keeps the first face it rasterises in that cull's (octree-traversal) order, so the two
-// backends can differ only on an exact depth tie: a pixel centre exactly on a shared edge, where
-// either face hands the pixel to the same two vertices.
-// Pass 2 also leaves, per view, one bit per face -- set iff the face wrote at least one pixel
-// -- collected by a warp ballot (no atomics): the photometric accumulation of every
-// pair-direction that has this view as its reference reads them to skip the faces the view does
-// not see before touching them at all, which in a scene of hundreds of views is most of the mesh
-// for every view. The barycentrics are not stored: the accumulation recomputes them (pixelBary,
-// the same arithmetic) where it needs them, in float like the CPU's BaryMap, instead of the
-// half-precision map that used to cost 8 bytes per pixel of every view.
+// 1. ProjectMesh — 1D, one thread per face, launched twice per view. Pass 1 (RESOLVE=false)
+// atomicMin's a 64-bit (depth bits << 32 | face id) key into every covered pixel, so the nearest
+// face wins and, at equal depth, the lower id; pass 2 redoes the same arithmetic and the key's
+// owner writes depth and face: one writer per pixel, a deterministic face map (the CPU's can
+// differ only on an exact depth tie on a shared edge, where the pixel goes to the same two
+// vertices either way). The whole mesh goes into every view, the faces it does not see exiting
+// early, cheaper than a host-side frustum cull per evaluation. Pass 2 also ballots, per view,
+// one bit per face set iff the face wrote a pixel: the owner bits the photometric accumulation
+// is restricted to (kernelCompactOwners). The barycentrics are not stored, the accumulation
+// recomputes them with pixelBary.
 template <bool RESOLVE>
 __global__ void kernelProjectMesh(
 	const Point3* __restrict__ vertices,
@@ -223,10 +191,9 @@ __global__ void kernelProjectMesh(
 
 
 #ifdef _DEBUG
-// 2. CheckProjection — 2D, 1 thread per pixel, Debug only, after both ProjectMesh passes: every
-// covered pixel must hold the payload of exactly the face that produced its winning key (the
-// host presets faceMap to NO_ID and depthMap to 0 before pass 2, so a stale value from the
-// previous evaluation cannot satisfy this by accident)
+// 2. CheckProjection — 2D, one thread per pixel, Debug only, after both ProjectMesh passes:
+// every covered pixel holds the payload of the face that won its key (the host presets faceMap
+// to NO_ID and depthMap to 0 before pass 2, so a stale payload cannot pass)
 __global__ void kernelCheckProjection(
 	const unsigned long long* __restrict__ projKey,
 	const float* __restrict__ depthMap,
@@ -248,23 +215,15 @@ __global__ void kernelCheckProjection(
 #endif
 
 
-// 3. CompactOwners — the dense per-view lists of the faces the rasterizer's owner bits mark,
-// built once per evaluation after every view is rasterized: kernelCountOwners (one block per
-// view) popcounts the view's words, kernelScanViewCounts (one block) turns the counts into the
+// 3. CompactOwners — the dense per-view lists of the faces whose owner bit is set, built once
+// per evaluation after every view is rasterized: kernelCountOwners (one block per view)
+// popcounts the view's words, kernelScanViewCounts (one block) prefix-sums the counts into the
 // views' offsets into one packed list (numViews+1 entries, the last the total the host sizes
-// the list by), and kernelCompactOwners (one block per view) writes the face ids, in face order.
-// The per-direction accumulation then runs one thread per OWNER face of its reference view
-// instead of one per mesh face exiting on the bit: a view owns a fraction of the faces (a
-// quarter to a third on Ignatius at level 1, where the cameras ring one object; less in a scene
-// of hundreds of views along a path), and the exits left the warps that did reach the pixel
-// loop 4-5 active lanes of 32 (Nsight Compute, Ignatius level 1, both scales: 4.4 threads per
-// warp-instruction, 13 of 20 warp cycles stalled on the scattered loads, compute 27 % and
-// memory 37 % of peak, the kernel 55 % of the GPU time); with the lists, 9.4/7.7 lanes and 2.3x
-// fewer instructions issued.
-// The list order does not touch the result -- a face still reduces its own pixels in raster
-// order into its own slot, and the fold order across directions is the launch order -- and
-// face order is kept because consecutive faces are neighbours on the mesh, so a warp's 32
-// boxes land near one another in the image.
+// the list by), and kernelCompactOwners (one block per view) writes the face ids in face order.
+// The accumulation then runs one thread per face its reference view owns, a fraction of the
+// mesh, instead of one per face exiting on the bit, which left its warps nearly empty. The list
+// order does not touch the result: a face folds its own pixels, in raster order, into its own
+// slot.
 
 // exclusive prefix sum of one value per thread over the block (blockDim.x a multiple of 32, at
 // most 1024): returns the thread's exclusive prefix and leaves the block total in `total`;
@@ -357,15 +316,11 @@ __global__ void kernelCompactOwners(
 }
 
 
-// 4. SortOwnersTile — one block per view, right after the compaction: the view's owner list
-// reordered by the image tile (2^tileShiftX x 2^tileShiftY pixels, row-major) the face's
-// clipped box starts in, so that the 32 lanes of a warp of the accumulation walk boxes a tile
-// or two apart at most. In face order the lanes' boxes were scattered over the image and every
-// load fetched its own lines (Nsight Compute: 4 of 32 bytes of every sector used, L1 hit 52-54 %,
-// 18-21 of 25-28 warp cycles on the long scoreboard even with a chunk's loads in flight). The
-// projection is the accumulation's own (projectFace + faceBBox). A counting sort in shared
-// memory: the bucket histogram, its exclusive scan, and a scatter whose order WITHIN a bucket is
-// the atomics' -- the result does not depend on the list order (see kernelCompactOwners).
+// 4. SortOwnersTile — one block per view, after the compaction: the view's list reordered by
+// the image tile (2^tileShiftX x 2^tileShiftY pixels, row-major) the face's clipped box starts
+// in, so that the 32 lanes of an accumulation warp walk boxes that share cache lines instead of
+// boxes scattered over the image. A counting sort in shared memory: histogram, exclusive scan,
+// atomic scatter; the order within a tile is the atomics', which the result does not depend on.
 __global__ void kernelSortOwnersTile(
 	const Point3* __restrict__ vertices,
 	const Point3u* __restrict__ faces,
@@ -414,7 +369,8 @@ __global__ void kernelSortOwnersTile(
 }
 
 
-// 5. ImageMeshWarp — 2D, texture + 2 surfaces
+// 5. ImageMeshWarp — 2D, one thread per pixel of A: image B warped into A through the mesh,
+// with the mask of the pixels that made it (the CPU's MeshRefine::ImageMeshWarp)
 __global__ void kernelImageMeshWarp(
 	const float* __restrict__ depthMapA,
 	const float* __restrict__ depthMapB,
@@ -431,13 +387,12 @@ __global__ void kernelImageMeshWarp(
 	if (x >= camA.size.x() || y >= camA.size.y()) return;
 
 	const int pixIdx = y * camA.size.x() + x;
-	// invalid pixels stay 0: kernelComputeWindowStats masks them out of every window sum, so their
-	// value is never read -- the CPU's imageAB is zero-filled for the same reason
+	// a rejected pixel stays 0 like the CPU's zero-filled imageAB: kernelComputeWindowStats
+	// masks it out of every window sum
 	float convergePix = 0.f;
 	uint8_t convergeMask = 0;
 
-	// a masked-out pixel of A never seeds a warp sample, before any back-projection work -- same
-	// test as the CPU's MeshRefine::ImageMeshWarp
+	// a masked-out pixel of A never seeds a sample
 	if (!keepA || keepA[pixIdx]) {
 		const float depthA = depthMapA[pixIdx];
 		if (depthA > 0.f) {
@@ -448,13 +403,10 @@ __global__ void kernelImageMeshWarp(
 			if (pz > 0.f) {
 				const Point2 projB = camB.model.TransformPointC2I(Xc_B);
 				const float xB = projB.x(), yB = projB.y();
-				// B-side border rule shared with the CPU (MeshRefine::IsDepthSimilar): the rounded
-				// nearest tap read below must be inside the Refine::Border margin the per-pixel window
-				// statistics need around it; the bound is one pixel tighter than the tap itself needs
-				// so that any accepted xB/yB rounds into the margin. The test is in FLOAT, before the
-				// int conversion: pz can be positive but arbitrarily small at a grazing projection,
-				// making xB/yB huge, and __float2int_rd saturates to INT_MAX, which an int test would
-				// overflow past; this form rejects huge values and NaN instead of wrapping
+				// the B-side border rule shared with the CPU (MeshRefine::IsDepthSimilar): the
+				// rounded tap read below must lie inside the Refine::Border margin, tested in
+				// float before the int conversion, which saturates on the huge coordinates a
+				// grazing projection produces
 				if (xB >= (float)Refine::Border && yB >= (float)Refine::Border &&
 					xB < (float)(camB.size.x() - Refine::Border - 1) &&
 					yB < (float)(camB.size.y() - Refine::Border - 1)) {
@@ -467,14 +419,12 @@ __global__ void kernelImageMeshWarp(
 					const int k((xB-ixB >= 0.5f ? 1 : 0) + (yB-iyB >= 0.5f ? 2 : 0));
 					const int tapIdxB(idxB + (k & 1) + (k >> 1) * widthB);
 					const float depthB(depthMapB[tapIdxB]);
-					// the same rounded tap read above (shared with the CPU's IsDepthSimilar) also
-					// gates the B-side keep-mask
+					// the same rounded tap gates the B-side keep-mask
 					const bool consistent(depthB > 0.f && depthB*1.0002f >= pz && (!keepB || keepB[tapIdxB]));
 
 					if (consistent) {
-						// +0.5: tex2D with non-normalised coords + linear filtering samples texel
-						// centres at integer+0.5; CPU TImage::sample treats integer coords as pixel
-						// centres, so every tex2D fetch at a CPU-convention coordinate needs this offset
+						// +0.5: tex2D with non-normalised coordinates samples texel centres at
+						// integer+0.5, the CPU's TImage::sample at integers
 						convergePix = tex2D<float>(texImageB, xB + 0.5f, yB + 0.5f);
 						convergeMask = 1;
 					}
@@ -488,8 +438,8 @@ __global__ void kernelImageMeshWarp(
 }
 
 
-// fetch one texel of a float texture at its exact centre (tex2D pixel-centre convention, +0.5),
-// or 0 for a tap outside the image -- the out-of-range rule BilinearGradient below matches
+// one texel of a float texture at its centre, 0 outside the image (the CPU's
+// MeshRefine::BilinearGradient convention)
 __device__ inline float texelOrZero(cudaTextureObject_t tex, int x, int y, int width, int height)
 {
 	if (x < 0 || x >= width || y < 0 || y >= height)
@@ -497,12 +447,9 @@ __device__ inline float texelOrZero(cudaTextureObject_t tex, int x, int y, int w
 	return tex2D<float>(tex, (float)x + 0.5f, (float)y + 0.5f);
 }
 
-// derivative of the bilinear reconstruction of the image texture at (px,py), from four
-// point-sampled texel fetches (never the texture's own linear filtering, which would blend
-// VALUES rather than give the four taps a derivative is built from) -- the same taps, weights
-// and out-of-range convention (a tap outside the image contributes nothing) as the CPU's
-// MeshRefine::BilinearGradient (SceneRefine.cpp), so this is the derivative of the exact value
-// the warp itself samples with the Linear sampler, not of a smoothed stencil estimate of it
+// the derivative of the bilinear interpolant of the image at (px,py) from four point-sampled
+// texels: the same taps, weights and out-of-range rule as the CPU's MeshRefine::BilinearGradient,
+// i.e. the derivative of the value the warp samples, not of a smoothed stencil estimate of it
 __device__ inline void bilinearGradient(cudaTextureObject_t texImage, int width, int height, float px, float py, float& gx, float& gy)
 {
 	const int x0 = __float2int_rd(px), y0 = __float2int_rd(py);
@@ -516,12 +463,11 @@ __device__ inline void bilinearGradient(cudaTextureObject_t texImage, int width,
 }
 
 // the per-pixel half of the photometric gradient: g, the scalar the covering face's three
-// corners share before their barycentrics (the CPU's sg). A PURE FUNCTION OF THE PIXEL: nothing
-// it returns depends on which thread computes it or in what order, which is what lets the
-// face-parallel accumulation be atomic-free and bit-reproducible. The caller has already
-// established that this pixel is inside the valid border, masked in, and covered by the face
-// whose normal it passes in; dz is the pixel's ZNCC derivative. Returns false if the pixel
-// contributes nothing (the surface is seen at a grazing angle).
+// corners share before their barycentrics (the CPU's sg). A pure function of the pixel, which
+// is what lets the face-parallel accumulation be atomic-free and reproducible. The caller has
+// established that the pixel is inside the border, masked in and covered by the face whose
+// normal it passes; dz is the pixel's ZNCC derivative. False if the surface is seen at a grazing
+// angle and the pixel contributes nothing.
 __device__ inline bool computePhotoPixel(
 	int x, int y, float depth, const Point3& normal, float dz,
 	const Camera& camA,
@@ -547,9 +493,7 @@ __device__ inline bool computePhotoPixel(
 	const Point3 Xc_B = camB.pose.TransformPointW2C(X_world);
 	const float pz = Xc_B.z();
 
-	// mask==1 means the warp already ran this exact back-/forward-projection chain for this pixel
-	// and rejected a non-positive depth in B, so pz can only be positive here; the producer is the
-	// warp on both backends (kernelImageMeshWarp above, MeshRefine::ImageMeshWarp on the CPU)
+	// the warp ran this same chain for the pixel and masked it in only for a positive depth in B
 	ASSERT(pz > 0.f);
 	const Point2 projB = camB.model.TransformPointC2I(Xc_B);
 
@@ -562,12 +506,9 @@ __device__ inline bool computePhotoPixel(
 	const Point3 dudX = (KR.row(0).transpose() * pz - KR.row(2).transpose() * p.x()) / pz2;
 	const Point3 dvdX = (KR.row(1).transpose() * pz - KR.row(2).transpose() * p.y()) / pz2;
 
-	// Image derivatives at the projected point: either bilinear samples of the precomputed
-	// gradient images (ComputeRefineImageGradient, the CPU's estimator and sampling exactly;
-	// forward differences of the image texture used to give a per-pixel magnitude that differed
-	// from the CPU by a factor of 0.6-5), or (bBilinearGrad) the derivative of the bilinear
-	// interpolant of the raw image itself, with no precomputed stencil to sample
-	// (+0.5: tex2D pixel-centre convention, see ImageMeshWarp)
+	// image derivatives at the projected point: the precomputed gradient images, sampled
+	// bilinearly like the CPU (+0.5: tex2D pixel-centre convention, see ImageMeshWarp), or the
+	// derivative of the bilinear interpolant of the image itself
 	float dx, dy;
 	if (bBilinearGrad) {
 		bilinearGradient(texImageB, camB.size.x(), camB.size.y(), projB.x(), projB.y(), dx, dy);
@@ -588,16 +529,11 @@ __device__ inline bool computePhotoPixel(
 }
 
 
-// 6. ComputeWindowStats — 2D, one thread per pixel: the six MASKED window sums, the two
-// rejection gates, ZNCC, its derivative, this pair-direction's reliability sums and the pixel's
-// photometric term, all in one pass over the 7x7 window. Replaces the former five kernels
-// (mean/var/cov/zncc/dzncc) and the six full-image buffers they exchanged. Only successfully
-// warped pixels enter the sums, so a window straddling an occlusion boundary is described by the
-// pixels that actually matched instead of by image A's own values (the old unmasked statistics
-// drove ZNCC towards 1 exactly there). Writes maskOut rather than editing mask in place: the
-// window loop of a neighbouring thread is still reading mask. The photometric term used to be
-// computed by the face-parallel accumulation kernel, one thread walking every pixel of its face:
-// a warp there waits for its largest face, while here every pixel is one thread of equal work.
+// 6. ComputeWindowStats — 2D, one thread per pixel: the six masked window sums, the two
+// rejection gates, ZNCC and its derivative, this pair-direction's reliability partials and the
+// pixel's photometric term, in one pass over the 7x7 window. Only warped pixels enter the sums,
+// so a window on an occlusion boundary is described by the pixels that matched. maskOut is a
+// second buffer: the window loops of the neighbouring threads still read mask.
 __global__ void kernelComputeWindowStats(
 	const uint8_t* __restrict__ mask,
 	uint8_t* __restrict__ maskOut, // the pixels that contribute a photometric term
@@ -621,10 +557,8 @@ __global__ void kernelComputeWindowStats(
 	const int x = blockIdx.x * blockDim.x + threadIdx.x;
 	const int y = blockIdx.y * blockDim.y + threadIdx.y;
 
-	// the 7x7 windows of the 16x16 threads of a block overlap heavily, so the (image A, warped
-	// image B, mask) triple of the 22x22 tile they span is staged in shared memory once instead
-	// of being re-read 49 times per thread from global/surface memory -- the naive version cost
-	// 1.4-1.8x the wall of the five separate kernels this one replaces
+	// the 7x7 windows of the block's 16x16 threads overlap, so the (image A, warped B, mask)
+	// triple of the 22x22 tile they span is staged in shared memory once
 	constexpr int Block = 16;
 	constexpr int Tile = Block + 2*Refine::HalfSize;
 	__shared__ float sA[Tile*Tile], sB[Tile*Tile], sW[Tile*Tile];
@@ -634,8 +568,7 @@ __global__ void kernelComputeWindowStats(
 	for (int i = threadIdx.y * Block + threadIdx.x; i < Tile*Tile; i += Block*Block) {
 		const int gx = x0 + i % Tile, gy = y0 + i / Tile;
 		float a(0.f), b(0.f), w(0.f);
-		// invalid samples are staged as zeros so the accumulation below needs no branch: they
-		// contribute nothing to any of the six sums, which is exactly what masking them means
+		// an invalid sample is staged as zeros: it contributes nothing to any of the six sums
 		if (gx >= 0 && gy >= 0 && gx < width && gy < height && mask[gy * width + gx] == 1) {
 			a = readSurfFloat(surfImageA, gx, gy);
 			b = readSurfFloat(surfImageProj, gx, gy);
@@ -644,10 +577,8 @@ __global__ void kernelComputeWindowStats(
 		}
 		sA[i] = a; sB[i] = b; sW[i] = w;
 	}
-	// a tile without a single masked sample -- the warp reaches none of its pixels, the common
-	// case in a scene of hundreds of views each seeing a small part of the surface -- contributes
-	// nothing: its outputs are the zeros the loops below would produce, written here instead;
-	// the vote is a barrier of its own, so the block leaves together
+	// a tile without a single masked sample (most tiles, in a scene of many small views) writes
+	// its zeros and leaves; the vote is a barrier of its own, so the block leaves together
 	if (!__syncthreads_or(any)) {
 		if (x < width && y < height) {
 			pixelGrad[y * width + x] = 0.f;
@@ -662,10 +593,9 @@ __global__ void kernelComputeWindowStats(
 	}
 	__syncthreads();
 
-	// per-thread contribution to this block's reliability sums; stays 0 for every pixel outside
-	// the image (the grid is rounded up to the block size), outside the valid border, unmasked or
-	// gated -- exactly the pixels the CPU's ScoreMesh S skips; no early "return" here so every
-	// thread in the block reaches the reduction below
+	// this thread's contribution to the block's reliability sums: 0 outside the image, the
+	// border, the mask or the gates, exactly the pixels the CPU's ScoreMesh S skips; no early
+	// return, every thread reaches the reduction below
 	float contribR(0.f), contribRZ(0.f);
 	if (x < width && y < height) {
 		const int pixIdx = y * width + x;
@@ -690,9 +620,8 @@ __global__ void kernelComputeWindowStats(
 				Refine::ZnccAndDerivative(s, n, sA[centre], sB[centre], zn, dz, cf);
 				contribR = cf;
 				contribRZ = cf * (1.f - zn);
-				// mask==1 means the rasterizer covered this pixel (the warp seeds nothing where
-				// depthMap is 0), so faceMap holds the covering face; a grazing view of it
-				// contributes to S (above, like the CPU) but no photometric term
+				// mask==1 means the rasterizer covered this pixel, so faceMap holds the covering
+				// face; a grazing view of it contributes to S (like the CPU) but no photometric term
 				const float depth = depthMap[pixIdx];
 				ASSERT(depth > 0.f);
 				if (computePhotoPixel(x, y, depth, normals[faceMap[pixIdx]], dz,
@@ -704,10 +633,9 @@ __global__ void kernelComputeWindowStats(
 		maskOut[pixIdx] = contributes;
 	}
 
-	// shared-memory block reduction (a fixed tree over a fixed thread mapping, so its result does
-	// not depend on the schedule); sized for the 16x16 block LaunchComputeWindowStats always
-	// launches. The block's two partials go to its OWN slot rather than into a global atomicAdd,
-	// and kernelReduceBlockSums below folds the slots in order, so S is reproducible too.
+	// a fixed tree over a fixed thread mapping into the block's OWN slot (sized for the 16x16
+	// block LaunchComputeWindowStats launches), folded in slot order by kernelReduceBlockSums:
+	// no atomics, so S is reproducible
 	__shared__ float sSumR[256];
 	__shared__ float sSumRZ[256];
 	const int tid = threadIdx.y * blockDim.x + threadIdx.x;
@@ -729,11 +657,9 @@ __global__ void kernelComputeWindowStats(
 }
 
 
-// 7. ReduceBlockSums — a single block, once per ScoreMesh() after every pair-direction: adds
-// the per-block partials of all of them (each direction's blocks occupy their own slots, in
-// launch order) into the two accumulators S is computed from, in a fixed order (each thread walks
-// a strided, fixed subset of the slots, then a fixed shared-memory tree), so S is the same number
-// on every run.
+// 7. ReduceBlockSums — one block, once per evaluation after every pair-direction: the per-block
+// partials of all of them (each direction's blocks in their own slots, in launch order) folded
+// into the two sums S is computed from, in a fixed order, so S is the same number on every run
 __global__ void kernelReduceBlockSums(
 	const float* __restrict__ blockSums,
 	uint32_t numSlots,
@@ -766,35 +692,24 @@ __global__ void kernelReduceBlockSums(
 }
 
 
-// see kernelAccumulateFacePhoto's tail: stamp vertex v with this direction and count it once
+// the direction counts once per vertex it reaches (the CPU's photoGradNorm += 1 per
+// pair-direction): of the vertex's faces contributing to this direction, exactly one gets the
+// previous stamp back from the exchange, so the count grows by an integer 1 whatever the schedule
 __device__ inline void countDirection(uint32_t* __restrict__ vertexStamp, float* __restrict__ photoCount, uint32_t v, uint32_t direction)
 {
 	if (atomicExch(&vertexStamp[v], direction) != direction)
 		photoCount[v] += 1.f;
 }
 
-// 8. AccumulateFacePhoto — 1D, one thread per face the reference view OWNS (its slice of the
-// list kernelCompactOwners built and kernelSortOwnersTile ordered); the per-pair-direction half
-// of the atomic-free photometric accumulation. Each thread reduces ITS OWN face's pixels into
-// registers and folds them into its private slots, so there is not a single atomic and not a
-// single float sum whose order depends on the schedule -- float addition is not associative,
-// and an atomicAdd scatter gives a different per-vertex gradient on every run. The slots
-// accumulate across the pair-directions of one ScoreMesh() (one writer per face, in launch
-// order, so that too is a fixed sequence), which lets the per-vertex gather run once per
-// ScoreMesh() instead of once per direction.
-//
-// A face this view does not see -- behind the camera, off the image, back-facing or occluded --
-// is not in the list (kernelProjectMesh pass 2 left its owner bit clear). The rest project their
-// face and walk its clipped bounding box exactly as kernelProjectMesh did, keeping the pixels
-// whose faceMap entry is this face (faceMap only ever holds ids the rasterizer wrote); a kept
-// pixel's barycentrics and depth are recomputed from the same projection, the same arithmetic
-// the rasterizer keyed the pixel with, so they are the rasterizer's bit for bit, in a fixed
-// row-then-column order. The per-pixel term itself comes
-// from kernelComputeWindowStats, one balanced thread per pixel; here it is only weighted by the
-// barycentrics. (Eight lanes sharing a face, each taking every eighth pixel of the box with a
-// fixed shuffle tree over their partials, was measured at 49/88 us per launch against 26/64 us
-// for this form on Ignatius at level 1, scales 0/1: on the small boxes most lanes idle, and the
-// extra threads and shuffles cost more than the divergence they remove.)
+// 8. AccumulateFacePhoto — 1D, one thread per face the reference view owns (its slice of the
+// tile-sorted owner list): the per-pair-direction half of the atomic-free photometric
+// accumulation. The thread reduces its own face's pixels, in raster order, into registers and
+// folds them into the face's private slots, which persist across the directions of one
+// evaluation (one writer per face, in launch order), so no float sum depends on the schedule
+// and the per-vertex gather runs once per evaluation. The face is projected again exactly as
+// the rasterizer did, and a pixel whose faceMap entry is this face gets its barycentrics and
+// depth from the same pixelBary call, bit for bit. The per-pixel term comes from
+// kernelComputeWindowStats; here it is only weighted by the barycentrics.
 __device__ inline void accumulateFacePhoto(
 	uint32_t tid, // the face, one of the reference view's owners
 	const Point3* __restrict__ vertices,
@@ -820,11 +735,8 @@ __device__ inline void accumulateFacePhoto(
 	float pixels = 0.f, foot = FLT_MAX;
 	const int width = camA.size.x();
 	// the box row by row, in chunks of RowChunk pixels whose face ids, mask bytes and terms are
-	// loaded together before any is tested, so that a chunk's loads are in flight at once: one
-	// load per pixel between branches paid a full memory round trip per pixel (Nsight Compute:
-	// 21 of 28 warp cycles per instruction on the long scoreboard, the lanes' boxes being
-	// scattered over the image). The pixels are still folded in raster order, so the sums are
-	// the same sequence of float additions
+	// loaded together before any is tested, so that a chunk's loads are in flight at once; the
+	// pixels are still folded in raster order
 	constexpr int RowChunk = 4;
 	for (int iy = iyMin; iy <= iyMax; ++iy) {
 		for (int ix0 = ixMin; ix0 <= ixMax; ix0 += RowChunk) {
@@ -842,20 +754,16 @@ __device__ inline void accumulateFacePhoto(
 			for (int k = 0; k < RowChunk; ++k) {
 				if (f[k] != tid || m[k] != 1)
 					continue;
-				// this pixel's winning rasterizer key was this face's, computed by pixelBary
-				// from this very projection, so the same call reproduces its
-				// perspective-correct barycentrics and depth
+				// the pixel's winning key was this face's, computed by pixelBary from this very
+				// projection, so the same call reproduces its barycentrics and depth
 				float nb0, nb1, nb2, depth;
 				const bool inside(pixelBary(ix0 + k, iy, pf, nb0, nb1, nb2, depth));
 				ASSERT(inside); (void)inside;
 				sum0 += g[k] * nb0;
 				sum1 += g[k] * nb1;
 				sum2 += g[k] * nb2;
-				// per-vertex footprint at camera A, scene units per pixel
-				// (Camera::GetFootprintWorld = depth/focalLength): min over every contributing
-				// pixel of every pair-direction, matching the CPU's min-of-mins
-				// (MeshRefine::ComputePhotometricGradient/ThProcessPair); min is exact and
-				// associative, so this half of it is reproducible for free
+				// footprint at camera A (Camera::GetFootprintWorld = depth/focalLength), min over
+				// every contributing pixel of every pair-direction like the CPU's min-of-mins
 				foot = fminf(foot, depth / camA.model.f.x());
 				pixels += 1.f;
 			}
@@ -868,12 +776,6 @@ __device__ inline void accumulateFacePhoto(
 	faceAcc[tid*3 + 2] += sum2;
 	facePixels[tid] += pixels;
 	faceFoot[tid] = fminf(faceFoot[tid], foot);
-	// the direction counts once per vertex it reaches (the CPU's `photoGradNorm[idxVert] += 1.f`
-	// per pair-direction): of the faces of the vertex contributing to this direction, exactly
-	// one thread gets the previous stamp back from the exchange and counts, so the count grows
-	// by an integer 1 exactly once per direction whatever the schedule -- reproducible, and no
-	// per-direction kernel over the vertices (one launch in four, host-bound at the coarse
-	// scales) to clear the marks and count them
 	countDirection(vertexStamp, photoCount, face.x(), direction);
 	countDirection(vertexStamp, photoCount, face.y(), direction);
 	countDirection(vertexStamp, photoCount, face.z(), direction);
@@ -896,9 +798,8 @@ __global__ void kernelAccumulateFacePhoto(
 	Camera camA)
 {
 	// the view's slice is read here, not passed: the launch is recorded once per scale into a
-	// graph (MeshRefineCUDA::ScoreMesh) while the slices move with the mesh, so the grid is the
-	// slice's size at the recording with a margin, and the stride loop covers whatever it has
-	// grown to since
+	// graph (MeshRefineCUDA::ScoreMesh) while the slices move with the mesh, so the grid is
+	// sized at the recording with a margin and the stride loop covers whatever the slice holds
 	const uint32_t off = ownerOffsets[idxView], numOwners = ownerOffsets[idxView+1] - off;
 	for (uint32_t idx = blockIdx.x * blockDim.x + threadIdx.x; idx < numOwners; idx += gridDim.x * blockDim.x)
 		accumulateFacePhoto(ownerList[off + idx], vertices, faces, faceMap, pixelGrad, mask,
@@ -906,16 +807,12 @@ __global__ void kernelAccumulateFacePhoto(
 }
 
 
-// 9. GatherVertexPhoto — 1D, one thread per vertex, once per ScoreMesh() after every
-// pair-direction. It walks the vertex's incident faces in the fixed order Mesh::ListIncidentFaces
-// produced (uploaded per scale, see MeshRefineCUDA::ListVertexFacesPost) and folds in each
-// face's slots, so a vertex's sum is a fixed sequence of float additions. The footprint sentinel
-// is resolved here: 0 exactly where no face contributed, which is exactly where no direction
-// counted the vertex (contract: footprint[v] > 0 iff photoCount[v] > 0, matches CPU ScoreMesh).
-//
-// Every corner whose vertex id matches is folded in, not just the first: a degenerate face
-// listing the same vertex twice handed that vertex both corners' shares under the old scatter,
-// and vertexFaces lists such a face only once.
+// 9. GatherVertexPhoto — 1D, one thread per vertex, once per evaluation after every
+// pair-direction: the vertex's incident faces walked in the fixed order Mesh::ListIncidentFaces
+// produced and their slots folded in, a fixed sequence of float additions. Every corner whose
+// vertex id matches counts (a degenerate face may list the vertex twice). The footprint
+// sentinel resolves to 0 exactly where no face contributed, i.e. where no direction counted the
+// vertex (contract: footprint[v] > 0 iff photoCount[v] > 0, like the CPU's ScoreMesh).
 __global__ void kernelGatherVertexPhoto(
 	const Point3u* __restrict__ faces,
 	const Point3* __restrict__ normals,
@@ -941,8 +838,7 @@ __global__ void kernelGatherVertexPhoto(
 		const uint32_t idxFace = vertFaces[ptr + i];
 		const Point3u& face = faces[idxFace];
 		const uint32_t fv[3] = { face.x(), face.y(), face.z() };
-		// the adjacency is the transpose of the face list: a face this vertex is incident to must
-		// name it back, or the two uploads describe different meshes
+		// the adjacency is the transpose of the face list: an incident face must name the vertex
 		ASSERT(fv[0] == (uint32_t)tid || fv[1] == (uint32_t)tid || fv[2] == (uint32_t)tid);
 		if (facePixels[idxFace] == 0.f)
 			continue; // nothing was accumulated, so every other slot of this face is a zero
@@ -958,7 +854,8 @@ __global__ void kernelGatherVertexPhoto(
 }
 
 
-// 10. ComputeSmoothnessGradient — 1D
+// 10. ComputeSmoothnessGradient — 1D, one thread per vertex: (1/N)*sum(neighbors - vertex), the
+// CPU's MeshRefine::ComputeSmoothnessGradient1/2; mode != 0 adds the valence weighting of level 2
 __global__ void kernelComputeSmoothnessGradient(
 	const Point3* __restrict__ vertices,
 	const uint32_t* __restrict__ vertVertices,
@@ -972,11 +869,8 @@ __global__ void kernelComputeSmoothnessGradient(
 	const int tid = blockIdx.x * blockDim.x + threadIdx.x;
 	if (tid >= (int)numVertices) return;
 
-	// a boundary vertex's own gradient is zeroed (matches CPU
-	// MeshRefine::ComputeSmoothnessGradient1/2, SceneRefine.cpp); vertSizes[] always holds the
-	// TRUE valence for every vertex (boundary or not) so that OTHER vertices' valence-weighted
-	// sum below stays correct when one of their neighbours happens to be a boundary vertex, whose
-	// valence the weight term divides by
+	// a boundary vertex's own gradient is zero, but vertSizes[] holds its TRUE valence, which
+	// the valence-weighted sum of its neighbours divides by
 	if (vertBoundary[tid]) {
 		smoothGrad[tid] = Point3::Zero();
 		return;
@@ -989,9 +883,8 @@ __global__ void kernelComputeSmoothnessGradient(
 	}
 	const uint32_t ptr = vertPointers[tid];
 
-	// (1/N)*sum(neighbors - vertex), the CPU's sign convention (ComputeSmoothnessGradient1/2) and
-	// its accumulation of differences rather than of coordinates, which would lose precision to
-	// the subtraction of the centre afterwards; the stepper mixes it with the bi-laplacian by rho
+	// differences rather than coordinates, which would lose precision to the subtraction of the
+	// centre afterwards
 	const float invN = 1.f / (float)numNeighbors;
 	const Point3 center = vertices[tid];
 	Point3 result = Point3::Zero();
@@ -1000,8 +893,7 @@ __global__ void kernelComputeSmoothnessGradient(
 		const uint32_t ni = vertVertices[ptr + i];
 		result += vertices[ni] - center;
 		if (mode != 0) {
-			// Valence-weighted: accumulate 1/(Ni*N) where Ni = TRUE valence of neighbor
-			// (boundary neighbours are included, exactly as CPU's vertexVertices[ni].GetSize());
+			// 1/(Ni*N), Ni the neighbour's true valence (boundary neighbours included); the
 			// adjacency is symmetric, so a neighbour lists this vertex back and Ni >= 1
 			ASSERT(vertSizes[ni] > 0);
 			totalWeight += invN / (float)vertSizes[ni];
@@ -1014,7 +906,7 @@ __global__ void kernelComputeSmoothnessGradient(
 }
 
 
-// 11. ComputeFaceNormal — 1D, 1 thread per face
+// 11. ComputeFaceNormal — 1D, one thread per face
 __global__ void kernelComputeFaceNormal(
 	const Point3* __restrict__ vertices,
 	const Point3u* __restrict__ faces,
@@ -1032,14 +924,10 @@ __global__ void kernelComputeFaceNormal(
 	const Point3 n = e1.cross(e2);
 	normals[tid] = n.normalized();
 }
-/*----------------------------------------------------------------*/
 
 
-// H O S T   L A U N C H E R S ////////////////////////////////////////
-
-// 12. FaceHistogram -- 1D over the pixels of one view, after the rasterization: the rasterized
-// area of every face in it, in pixels, exactly the pixel count the host's ListFaceAreas took
-// from the downloaded face map; integer atomics, so the counts are exact whatever the schedule
+// 12. FaceHistogram — 1D over the pixels of one view's face map: the rasterized area of every
+// face in it, in pixels (integer atomics, exact whatever the schedule)
 __global__ void kernelFaceHistogram(
 	const uint32_t* __restrict__ faceMap,
 	uint32_t* __restrict__ hist,
@@ -1053,10 +941,9 @@ __global__ void kernelFaceHistogram(
 }
 
 
-// 13. ReduceFaceAreasPair -- 1D, one thread per face, once per pair: the smaller of the face's
-// two rasterized areas in the pair (a pair resolves a face only as well as its worse view) folded
-// into the largest over the pairs, exactly ReduceFaceAreasOverPairs (SceneRefineCommon.cpp), the
-// truncation to 16 bits included (the host counts in uint16_t)
+// 13. ReduceFaceAreasPair — 1D, one thread per face, once per pair: the smaller of the face's
+// two rasterized areas in the pair folded into the largest over the pairs, exactly
+// ReduceFaceAreasOverPairs (SceneRefineCommon.cpp), the truncation to 16 bits included
 __global__ void kernelReduceFaceAreasPair(
 	const uint32_t* __restrict__ histA,
 	const uint32_t* __restrict__ histB,
@@ -1070,7 +957,10 @@ __global__ void kernelReduceFaceAreasPair(
 	if (maxAreas[f] < pairArea)
 		maxAreas[f] = pairArea;
 }
+/*----------------------------------------------------------------*/
 
+
+// H O S T   L A U N C H E R S ////////////////////////////////////////
 
 void LaunchProjectMesh(
 	const Point3* vertices, const Point3u* faces,
@@ -1095,6 +985,27 @@ void LaunchCheckProjection(
 	kernelCheckProjection<<<grid, block>>>(projKey, depthMap, faceMap, width, height);
 }
 #endif
+
+void LaunchCountOwners(const uint32_t* ownerBits, uint32_t* counts, uint32_t* offsets, uint32_t numWords, uint32_t numViews)
+{
+	kernelCountOwners<<<numViews, 1024>>>(ownerBits, counts, numWords);
+	kernelScanViewCounts<<<1, 1024>>>(counts, offsets, numViews);
+}
+
+void LaunchCompactOwners(const uint32_t* ownerBits, const uint32_t* offsets, uint32_t* ownerList, uint32_t numWords, uint32_t numViews)
+{
+	kernelCompactOwners<<<numViews, 1024>>>(ownerBits, offsets, ownerList, numWords);
+}
+
+void LaunchSortOwnersTile(
+	const Point3* vertices, const Point3u* faces, const Camera* cameras,
+	const uint32_t* offsets, const uint32_t* listIn, uint32_t* keys, uint32_t* listOut,
+	int tileShiftX, int tileShiftY, uint32_t maxBuckets, uint32_t numViews)
+{
+	ASSERT(maxBuckets <= 8192); // static limit of the dynamic shared memory
+	kernelSortOwnersTile<<<numViews, 1024, sizeof(uint32_t)*(maxBuckets + 32)>>>(
+		vertices, faces, cameras, offsets, listIn, keys, listOut, tileShiftX, tileShiftY);
+}
 
 void LaunchImageMeshWarp(
 	const float* depthMapA, const float* depthMapB,
@@ -1126,62 +1037,26 @@ uint32_t LaunchComputeWindowStats(
 	return grid.x*grid.y;
 }
 
-void LaunchReduceBlockSums(const float* blockSums, uint32_t numSlots, float* sumR, float* sumRZ, cudaStream_t stream)
-{
-	kernelReduceBlockSums<<<1, 1024, 0, stream>>>(blockSums, numSlots, sumR, sumRZ);
-}
-
-void LaunchCountOwners(const uint32_t* ownerBits, uint32_t* counts, uint32_t numWords, uint32_t numViews)
-{
-	kernelCountOwners<<<numViews, 1024>>>(ownerBits, counts, numWords);
-}
-
-void LaunchScanViewCounts(const uint32_t* counts, uint32_t* offsets, uint32_t numViews)
-{
-	kernelScanViewCounts<<<1, 1024>>>(counts, offsets, numViews);
-}
-
-void LaunchCompactOwners(const uint32_t* ownerBits, const uint32_t* offsets, uint32_t* ownerList, uint32_t numWords, uint32_t numViews)
-{
-	kernelCompactOwners<<<numViews, 1024>>>(ownerBits, offsets, ownerList, numWords);
-}
-
-void LaunchSortOwnersTile(
-	const Point3* vertices, const Point3u* faces, const Camera* cameras,
-	const uint32_t* offsets, const uint32_t* listIn, uint32_t* keys, uint32_t* listOut,
-	int tileShiftX, int tileShiftY, uint32_t maxBuckets, uint32_t numViews)
-{
-	ASSERT(maxBuckets <= 8192); // static limit of the dynamic shared memory
-	kernelSortOwnersTile<<<numViews, 1024, sizeof(uint32_t)*(maxBuckets + 32)>>>(
-		vertices, faces, cameras, offsets, listIn, keys, listOut, tileShiftX, tileShiftY);
-}
-
 void LaunchAccumulateFacePhoto(
 	const Point3* vertices, const Point3u* faces,
 	const uint32_t* ownerList, const uint32_t* ownerOffsets, uint32_t idxView,
 	const uint32_t* faceMap, const float* pixelGrad, const uint8_t* mask,
 	float* faceAcc, float* facePixels, float* faceFoot,
 	uint32_t* vertexStamp, float* photoCount, uint32_t direction,
-	const Camera& camA, uint32_t numBlocks, cudaStream_t stream)
+	const Camera& camA, uint32_t numOwners, cudaStream_t stream)
 {
-	// small blocks: a launch is a fraction of the mesh, and the box walks are uneven
-	kernelAccumulateFacePhoto<<<numBlocks, AccumulateBlockSize, 0, stream>>>(
+	// small blocks, the box walks being uneven; the grid covers the slice with a 25 % margin for
+	// the evaluations replaying this launch from the graph
+	constexpr uint32_t blockSize = 128;
+	const uint32_t numBlocks = (numOwners + numOwners/4 + blockSize - 1) / blockSize;
+	kernelAccumulateFacePhoto<<<numBlocks ? numBlocks : 1u, blockSize, 0, stream>>>(
 		vertices, faces, ownerList, ownerOffsets, idxView, faceMap, pixelGrad, mask,
 		faceAcc, facePixels, faceFoot, vertexStamp, photoCount, direction, camA);
 }
 
-void LaunchFaceHistogram(const uint32_t* faceMap, uint32_t* hist, uint32_t numPixels)
+void LaunchReduceBlockSums(const float* blockSums, uint32_t numSlots, float* sumR, float* sumRZ, cudaStream_t stream)
 {
-	const int blockSize = 256;
-	const int numBlocks = ((int)numPixels + blockSize - 1) / blockSize;
-	kernelFaceHistogram<<<numBlocks, blockSize>>>(faceMap, hist, numPixels);
-}
-
-void LaunchReduceFaceAreasPair(const uint32_t* histA, const uint32_t* histB, uint16_t* maxAreas, uint32_t numFaces)
-{
-	const int blockSize = 256;
-	const int numBlocks = ((int)numFaces + blockSize - 1) / blockSize;
-	kernelReduceFaceAreasPair<<<numBlocks, blockSize>>>(histA, histB, maxAreas, numFaces);
+	kernelReduceBlockSums<<<1, 1024, 0, stream>>>(blockSums, numSlots, sumR, sumRZ);
 }
 
 void LaunchGatherVertexPhoto(
@@ -1212,6 +1087,20 @@ void LaunchComputeFaceNormal(
 	const int blockSize = 256;
 	const int numBlocks = ((int)numFaces + blockSize - 1) / blockSize;
 	kernelComputeFaceNormal<<<numBlocks, blockSize>>>(vertices, faces, normals, numFaces);
+}
+
+void LaunchFaceHistogram(const uint32_t* faceMap, uint32_t* hist, uint32_t numPixels)
+{
+	const int blockSize = 256;
+	const int numBlocks = ((int)numPixels + blockSize - 1) / blockSize;
+	kernelFaceHistogram<<<numBlocks, blockSize>>>(faceMap, hist, numPixels);
+}
+
+void LaunchReduceFaceAreasPair(const uint32_t* histA, const uint32_t* histB, uint16_t* maxAreas, uint32_t numFaces)
+{
+	const int blockSize = 256;
+	const int numBlocks = ((int)numFaces + blockSize - 1) / blockSize;
+	kernelReduceFaceAreasPair<<<numBlocks, blockSize>>>(histA, histB, maxAreas, numFaces);
 }
 /*----------------------------------------------------------------*/
 

--- a/libs/MVS/SceneRefineCUDA.cu
+++ b/libs/MVS/SceneRefineCUDA.cu
@@ -32,7 +32,6 @@
 #include "SceneRefineCUDA.inl"
 #include "SceneRefineCommon.h"
 
-#include <cuda_fp16.h>
 #include <float.h>
 
 
@@ -170,6 +169,13 @@ __device__ inline bool faceBBox(const ProjectedFace& pf, const Camera& camera,
 // keeps the first face it rasterises in that cull's (octree-traversal) order, so the two
 // backends can differ only on an exact depth tie: a pixel centre exactly on a shared edge, where
 // either face hands the pixel to the same two vertices.
+// Pass 2 also leaves, per view, one bit per face -- set iff the face wrote at least one pixel
+// -- collected by a warp ballot (no atomics): the photometric accumulation of every
+// pair-direction that has this view as its reference reads them to skip the faces the view does
+// not see before touching them at all, which in a scene of hundreds of views is most of the mesh
+// for every view. The barycentrics are not stored: the accumulation recomputes them (pixelBary,
+// the same arithmetic) where it needs them, in float like the CPU's BaryMap, instead of the
+// half-precision map that used to cost 8 bytes per pixel of every view.
 template <bool RESOLVE>
 __global__ void kernelProjectMesh(
 	const Point3* __restrict__ vertices,
@@ -177,38 +183,41 @@ __global__ void kernelProjectMesh(
 	unsigned long long* __restrict__ projKey,
 	float* __restrict__ depthMap,
 	uint32_t* __restrict__ faceMap,
-	ushort4* __restrict__ baryMap,
+	uint32_t* __restrict__ ownerBits, // RESOLVE only, may be NULL: bit f set iff face f wrote at least one pixel
 	Camera camera,
 	uint32_t numFaces)
 {
 	const int tid = blockIdx.x * blockDim.x + threadIdx.x;
-	if (tid >= (int)numFaces) return;
-
+	// no early return before the ballot at the end: every lane of the warp has to reach it
+	bool owner = false;
 	ProjectedFace pf;
-	if (!projectFace(vertices, faces[tid], camera, pf)) return;
-
 	int ixMin, ixMax, iyMin, iyMax;
-	if (!faceBBox(pf, camera, ixMin, ixMax, iyMin, iyMax)) return;
-
-	const int width = camera.size.x();
-	for (int iy = iyMin; iy <= iyMax; ++iy) {
-		for (int ix = ixMin; ix <= ixMax; ++ix) {
-			float nb0, nb1, nb2, depth;
-			if (!pixelBary(ix, iy, pf, nb0, nb1, nb2, depth)) continue;
-			// depth > 0 (all three z's are), so its bit pattern orders like the float itself
-			const unsigned long long key = ((unsigned long long)__float_as_uint(depth) << 32) | (unsigned)tid;
-			const int pixIdx = iy * width + ix;
-			if (RESOLVE) {
-				if (projKey[pixIdx] != key) continue;
-				depthMap[pixIdx] = depth;
-				faceMap[pixIdx] = (uint32_t)tid;
-				// the three barycentrics in one 8-byte store (three 2-byte ones cost three transactions)
-				baryMap[pixIdx] = make_ushort4(
-					__half_as_ushort(__float2half(nb0)), __half_as_ushort(__float2half(nb1)), __half_as_ushort(__float2half(nb2)), 0);
-			} else {
-				atomicMin(&projKey[pixIdx], key);
+	if (tid < (int)numFaces && projectFace(vertices, faces[tid], camera, pf) && faceBBox(pf, camera, ixMin, ixMax, iyMin, iyMax)) {
+		const int width = camera.size.x();
+		for (int iy = iyMin; iy <= iyMax; ++iy) {
+			for (int ix = ixMin; ix <= ixMax; ++ix) {
+				float nb0, nb1, nb2, depth;
+				if (!pixelBary(ix, iy, pf, nb0, nb1, nb2, depth)) continue;
+				// depth > 0 (all three z's are), so its bit pattern orders like the float itself
+				const unsigned long long key = ((unsigned long long)__float_as_uint(depth) << 32) | (unsigned)tid;
+				const int pixIdx = iy * width + ix;
+				if (RESOLVE) {
+					if (projKey[pixIdx] != key) continue;
+					depthMap[pixIdx] = depth;
+					faceMap[pixIdx] = (uint32_t)tid;
+					owner = true;
+				} else {
+					atomicMin(&projKey[pixIdx], key);
+				}
 			}
 		}
+	}
+	if (RESOLVE && ownerBits) {
+		// one word per warp of 32 consecutive faces, stored by lane 0: the buffer holds
+		// (numFaces+31)/32 words per view, so the warps past the last face store nothing
+		const unsigned ballot = __ballot_sync(0xffffffffu, owner);
+		if ((tid & 31) == 0 && tid < (int)numFaces)
+			ownerBits[tid >> 5] = ballot;
 	}
 }
 
@@ -455,6 +464,7 @@ __global__ void kernelComputeWindowStats(
 	__shared__ float sA[Tile*Tile], sB[Tile*Tile], sW[Tile*Tile];
 	const int x0 = blockIdx.x * Block - Refine::HalfSize;
 	const int y0 = blockIdx.y * Block - Refine::HalfSize;
+	bool any = false; // this thread staged a masked sample
 	for (int i = threadIdx.y * Block + threadIdx.x; i < Tile*Tile; i += Block*Block) {
 		const int gx = x0 + i % Tile, gy = y0 + i / Tile;
 		float a(0.f), b(0.f), w(0.f);
@@ -464,8 +474,25 @@ __global__ void kernelComputeWindowStats(
 			a = readSurfFloat(surfImageA, gx, gy);
 			b = readSurfFloat(surfImageProj, gx, gy);
 			w = 1.f;
+			any = true;
 		}
 		sA[i] = a; sB[i] = b; sW[i] = w;
+	}
+	// a tile without a single masked sample -- the warp reaches none of its pixels, the common
+	// case in a scene of hundreds of views each seeing a small part of the surface -- contributes
+	// nothing: its outputs are the zeros the loops below would produce, written here instead;
+	// the vote is a barrier of its own, so the block leaves together
+	if (!__syncthreads_or(any)) {
+		if (x < width && y < height) {
+			pixelGrad[y * width + x] = 0.f;
+			maskOut[y * width + x] = 0;
+		}
+		if (threadIdx.x == 0 && threadIdx.y == 0) {
+			const int idxBlock = blockIdx.y * gridDim.x + blockIdx.x;
+			blockSums[idxBlock*2 + 0] = 0.f;
+			blockSums[idxBlock*2 + 1] = 0.f;
+		}
+		return;
 	}
 	__syncthreads();
 
@@ -582,18 +609,23 @@ __global__ void kernelReduceBlockSums(
 // fixed sequence), which lets the per-vertex gather run once per ScoreMesh() instead of once
 // per direction.
 //
-// The thread projects its face and walks its clipped bounding box exactly as kernelProjectMesh
-// did, in a fixed row-then-column order, and keeps the pixels whose faceMap entry is this face:
-// faceMap only ever holds ids the rasterizer wrote, and a face this view does not see exits
-// after its three projections. The per-pixel term itself comes from kernelComputeWindowStats,
-// one balanced thread per pixel; here it is only weighted by the barycentrics, so the imbalance
-// between large and small faces costs little.
+// A face this view does not see -- behind the camera, off the image, back-facing or occluded --
+// exits on its owner bit (kernelProjectMesh, pass 2), one coalesced word per warp, before its
+// face or vertices are read. The rest project their face and walk its clipped bounding box
+// exactly as kernelProjectMesh did, keeping the pixels whose faceMap entry is this face (faceMap
+// only ever holds ids the rasterizer wrote); a kept pixel's barycentrics and depth are recomputed
+// from the same projection, the same arithmetic the rasterizer keyed the pixel with, so they are
+// the rasterizer's bit for bit, in a fixed row-then-column order. The per-pixel term itself comes
+// from kernelComputeWindowStats, one balanced thread per pixel; here it is only weighted by the
+// barycentrics. (Eight lanes sharing a face, each taking every eighth pixel of the box with a
+// fixed shuffle tree over their partials, was measured at 49/88 us per launch against 26/64 us
+// for this form on Ignatius at level 1, scales 0/1: on the small boxes most lanes idle, and the
+// extra threads and shuffles cost more than the divergence they remove.)
 __global__ void kernelAccumulateFacePhoto(
 	const Point3* __restrict__ vertices,
 	const Point3u* __restrict__ faces,
-	const float* __restrict__ depthMap,
+	const uint32_t* __restrict__ ownerBits, // this view's, from the rasterizer: bit f set iff face f owns a pixel
 	const uint32_t* __restrict__ faceMap,
-	const ushort4* __restrict__ baryMap,
 	const float* __restrict__ pixelGrad,
 	const uint8_t* __restrict__ mask,
 	float* __restrict__ faceAcc, // 3 per face: Sum over the face's pixels of g_p*b_c, one per corner
@@ -605,12 +637,14 @@ __global__ void kernelAccumulateFacePhoto(
 {
 	const int tid = blockIdx.x * blockDim.x + threadIdx.x;
 	if (tid >= (int)numFaces) return;
+	if (!((ownerBits[tid >> 5] >> (tid & 31)) & 1u)) return;
 
+	// it owns a pixel, so the rasterizer's projection of it succeeded
 	const Point3u face = faces[tid];
 	ProjectedFace pf;
-	int ixMin, ixMax, iyMin, iyMax;
-	if (!projectFace(vertices, face, camA, pf) || !faceBBox(pf, camA, ixMin, ixMax, iyMin, iyMax))
-		return;
+	int ixMin(0), ixMax(-1), iyMin(0), iyMax(-1);
+	const bool seen(projectFace(vertices, face, camA, pf) && faceBBox(pf, camA, ixMin, ixMax, iyMin, iyMax));
+	ASSERT(seen); (void)seen;
 	float sum0 = 0.f, sum1 = 0.f, sum2 = 0.f;
 	float pixels = 0.f, foot = FLT_MAX;
 	const int width = camA.size.x();
@@ -619,18 +653,21 @@ __global__ void kernelAccumulateFacePhoto(
 			const int pixIdx = iy * width + ix;
 			if (faceMap[pixIdx] != (uint32_t)tid || mask[pixIdx] != 1)
 				continue;
-			// this pixel's winning rasterizer key was this face's, so its payload is this face's
-			// perspective-correct depth and barycentrics
+			// this pixel's winning rasterizer key was this face's, computed by pixelBary from
+			// this very projection, so the same call reproduces its perspective-correct
+			// barycentrics and depth
+			float nb0, nb1, nb2, depth;
+			const bool inside(pixelBary(ix, iy, pf, nb0, nb1, nb2, depth));
+			ASSERT(inside); (void)inside;
 			const float g = pixelGrad[pixIdx];
-			const ushort4 bary = baryMap[pixIdx];
-			sum0 += g * __half2float(__ushort_as_half(bary.x));
-			sum1 += g * __half2float(__ushort_as_half(bary.y));
-			sum2 += g * __half2float(__ushort_as_half(bary.z));
+			sum0 += g * nb0;
+			sum1 += g * nb1;
+			sum2 += g * nb2;
 			// per-vertex footprint at camera A, scene units per pixel (Camera::GetFootprintWorld =
 			// depth/focalLength): min over every contributing pixel of every pair-direction,
 			// matching the CPU's min-of-mins (MeshRefine::ComputePhotometricGradient/ThProcessPair);
 			// min is exact and associative, so this half of it is reproducible for free
-			foot = fminf(foot, depthMap[pixIdx] / camA.model.f.x());
+			foot = fminf(foot, depth / camA.model.f.x());
 			pixels += 1.f;
 		}
 	}
@@ -796,17 +833,52 @@ __global__ void kernelComputeFaceNormal(
 
 // H O S T   L A U N C H E R S ////////////////////////////////////////
 
+// 9. FaceHistogram -- 1D over the pixels of one view, after the rasterization: the rasterized
+// area of every face in it, in pixels, exactly the pixel count the host's ListFaceAreas took
+// from the downloaded face map; integer atomics, so the counts are exact whatever the schedule
+__global__ void kernelFaceHistogram(
+	const uint32_t* __restrict__ faceMap,
+	uint32_t* __restrict__ hist,
+	uint32_t numPixels)
+{
+	const uint32_t p = blockIdx.x * blockDim.x + threadIdx.x;
+	if (p >= numPixels) return;
+	const uint32_t f = faceMap[p];
+	if (f != (uint32_t)-1)
+		atomicAdd(&hist[f], 1u);
+}
+
+
+// 10. ReduceFaceAreasPair -- 1D, one thread per face, once per pair: the smaller of the face's
+// two rasterized areas in the pair (a pair resolves a face only as well as its worse view) folded
+// into the largest over the pairs, exactly ReduceFaceAreasOverPairs (SceneRefineCommon.cpp), the
+// truncation to 16 bits included (the host counts in uint16_t)
+__global__ void kernelReduceFaceAreasPair(
+	const uint32_t* __restrict__ histA,
+	const uint32_t* __restrict__ histB,
+	uint16_t* __restrict__ maxAreas,
+	uint32_t numFaces)
+{
+	const uint32_t f = blockIdx.x * blockDim.x + threadIdx.x;
+	if (f >= numFaces) return;
+	const uint16_t a = (uint16_t)histA[f], b = (uint16_t)histB[f];
+	const uint16_t pairArea = a < b ? a : b;
+	if (maxAreas[f] < pairArea)
+		maxAreas[f] = pairArea;
+}
+
+
 void LaunchProjectMesh(
 	const Point3* vertices, const Point3u* faces,
-	unsigned long long* projKey, float* depthMap, uint32_t* faceMap, ushort4* baryMap,
+	unsigned long long* projKey, float* depthMap, uint32_t* faceMap, uint32_t* ownerBits,
 	const Camera& camera, uint32_t numFaces, bool resolve)
 {
 	const int blockSize = 256;
 	const int numBlocks = ((int)numFaces + blockSize - 1) / blockSize;
 	if (resolve)
-		kernelProjectMesh<true><<<numBlocks, blockSize>>>(vertices, faces, projKey, depthMap, faceMap, baryMap, camera, numFaces);
+		kernelProjectMesh<true><<<numBlocks, blockSize>>>(vertices, faces, projKey, depthMap, faceMap, ownerBits, camera, numFaces);
 	else
-		kernelProjectMesh<false><<<numBlocks, blockSize>>>(vertices, faces, projKey, depthMap, faceMap, baryMap, camera, numFaces);
+		kernelProjectMesh<false><<<numBlocks, blockSize>>>(vertices, faces, projKey, depthMap, faceMap, NULL, camera, numFaces);
 }
 
 #ifdef _DEBUG
@@ -854,17 +926,30 @@ void LaunchReduceBlockSums(const float* blockSums, uint32_t numSlots, float* sum
 }
 
 void LaunchAccumulateFacePhoto(
-	const Point3* vertices, const Point3u* faces,
-	const float* depthMap, const uint32_t* faceMap, const ushort4* baryMap,
-	const float* pixelGrad, const uint8_t* mask,
+	const Point3* vertices, const Point3u* faces, const uint32_t* ownerBits,
+	const uint32_t* faceMap, const float* pixelGrad, const uint8_t* mask,
 	float* faceAcc, float* facePixels, float* faceFoot, uint8_t* vertexSeen,
 	const Camera& camA, uint32_t numFaces)
 {
 	const int blockSize = 256;
 	const int numBlocks = ((int)numFaces + blockSize - 1) / blockSize;
 	kernelAccumulateFacePhoto<<<numBlocks, blockSize>>>(
-		vertices, faces, depthMap, faceMap, baryMap, pixelGrad, mask,
+		vertices, faces, ownerBits, faceMap, pixelGrad, mask,
 		faceAcc, facePixels, faceFoot, vertexSeen, camA, numFaces);
+}
+
+void LaunchFaceHistogram(const uint32_t* faceMap, uint32_t* hist, uint32_t numPixels)
+{
+	const int blockSize = 256;
+	const int numBlocks = ((int)numPixels + blockSize - 1) / blockSize;
+	kernelFaceHistogram<<<numBlocks, blockSize>>>(faceMap, hist, numPixels);
+}
+
+void LaunchReduceFaceAreasPair(const uint32_t* histA, const uint32_t* histB, uint16_t* maxAreas, uint32_t numFaces)
+{
+	const int blockSize = 256;
+	const int numBlocks = ((int)numFaces + blockSize - 1) / blockSize;
+	kernelReduceFaceAreasPair<<<numBlocks, blockSize>>>(histA, histB, maxAreas, numFaces);
 }
 
 void LaunchCountSeenVertices(uint8_t* vertexSeen, float* photoCount, uint32_t numVertices)

--- a/libs/MVS/SceneRefineCUDA.inl
+++ b/libs/MVS/SceneRefineCUDA.inl
@@ -48,12 +48,14 @@ namespace CUDA {
 
 // rasterizer over the whole mesh, one thread per face, launched twice: resolve=false does an
 // atomicMin of the (depth, face id) key into projKey (one 64-bit word per pixel, pre-filled with
-// ~0ull); resolve=true lets the thread holding each pixel's winning key write depth/face/bary
-// (faceMap pre-filled with NO_ID, depthMap with 0). In Debug, LaunchCheckProjection then asserts
-// every covered pixel received its payload.
+// ~0ull); resolve=true lets the thread holding each pixel's winning key write depth/face (faceMap
+// pre-filled with NO_ID, depthMap with 0) and, when ownerBits is not NULL, sets bit f of it for
+// every face f that wrote a pixel ((numFaces+31)/32 words, every word written, no clearing
+// needed) -- the bits LaunchAccumulateFacePhoto skips the unseen faces by. In Debug,
+// LaunchCheckProjection then asserts every covered pixel received its payload.
 void LaunchProjectMesh(
 	const Point3* vertices, const Point3u* faces,
-	unsigned long long* projKey, float* depthMap, uint32_t* faceMap, ushort4* baryMap,
+	unsigned long long* projKey, float* depthMap, uint32_t* faceMap, uint32_t* ownerBits,
 	const Camera& camera, uint32_t numFaces, bool resolve);
 
 #ifdef _DEBUG
@@ -96,16 +98,17 @@ uint32_t LaunchComputeWindowStats(
 void LaunchReduceBlockSums(const float* blockSums, uint32_t numSlots, float* sumR, float* sumRZ);
 
 // the photometric accumulation, atomic-free so that the per-vertex sums are bit-reproducible run
-// to run (float addition is not associative). Per pair-direction: one thread per MESH face (not
-// per face of this view -- see kernelAccumulateFacePhoto) folds that face's contributing pixels
-// into its private slots -- faceAcc, 3 floats per face (one per corner: Sum g_p*b_c),
-// facePixels, the contributing pixel count, and faceFoot, the min footprint (only read where
-// facePixels > 0) -- accumulated ACROSS the pair-directions of one ScoreMesh() (cleared by the
-// host once per call), and marks the face's three vertices in vertexSeen.
+// to run (float addition is not associative). Per pair-direction: one thread per MESH face,
+// exiting on the reference view's owner bit (LaunchProjectMesh) unless the face owns a pixel
+// there, folds that face's contributing pixels -- barycentrics and depth recomputed from its
+// projection, see kernelAccumulateFacePhoto -- into its private slots -- faceAcc, 3 floats per
+// face (one per corner: Sum g_p*b_c), facePixels, the contributing pixel count, and faceFoot,
+// the min footprint (only read where facePixels > 0) -- accumulated ACROSS the pair-directions
+// of one ScoreMesh() (cleared by the host once per call), and marks the face's three vertices in
+// vertexSeen.
 void LaunchAccumulateFacePhoto(
-	const Point3* vertices, const Point3u* faces,
-	const float* depthMap, const uint32_t* faceMap, const ushort4* baryMap,
-	const float* pixelGrad, const uint8_t* mask,
+	const Point3* vertices, const Point3u* faces, const uint32_t* ownerBits,
+	const uint32_t* faceMap, const float* pixelGrad, const uint8_t* mask,
 	float* faceAcc, float* facePixels, float* faceFoot, uint8_t* vertexSeen,
 	const Camera& camA, uint32_t numFaces);
 
@@ -133,6 +136,12 @@ void LaunchComputeSmoothnessGradient(
 void LaunchComputeFaceNormal(
 	const Point3* vertices, const Point3u* faces,
 	Point3* normals, uint32_t numFaces);
+// the preparation's projected face areas (MeshRefineCUDA::ListFaceAreas): hist, zeroed by the
+// caller, receives the rasterized pixel count of every face in one view's face map ...
+void LaunchFaceHistogram(const uint32_t* faceMap, uint32_t* hist, uint32_t numPixels);
+// ... and maxAreas, zeroed once by the caller, the largest over the pairs of the smaller of a
+// pair's two counts, truncated to 16 bits like the host's uint16_t counters
+void LaunchReduceFaceAreasPair(const uint32_t* histA, const uint32_t* histB, uint16_t* maxAreas, uint32_t numFaces);
 /*----------------------------------------------------------------*/
 
 } // namespace CUDA

--- a/libs/MVS/SceneRefineCUDA.inl
+++ b/libs/MVS/SceneRefineCUDA.inl
@@ -44,31 +44,43 @@ namespace MVS {
 
 namespace CUDA {
 
-// Launcher function declarations for all mesh refinement CUDA kernels
+// Launchers of the mesh refinement kernels (see the kernels in SceneRefineCUDA.cu for the
+// contracts). Those taking a stream are the ones MeshRefineCUDA::ScoreMesh records into the
+// evaluation graph; the others run on the legacy stream.
 
-// rasterizer over the whole mesh, one thread per face, launched twice: resolve=false does an
-// atomicMin of the (depth, face id) key into projKey (one 64-bit word per pixel, pre-filled with
-// ~0ull); resolve=true lets the thread holding each pixel's winning key write depth/face (faceMap
+// the rasterizer over the whole mesh, launched twice per view: resolve=false does an atomicMin
+// of the (depth, face id) key into projKey (one 64-bit word per pixel, pre-filled with ~0ull);
+// resolve=true lets the thread holding each pixel's winning key write depth/face (faceMap
 // pre-filled with NO_ID, depthMap with 0) and, when ownerBits is not NULL, sets bit f of it for
-// every face f that wrote a pixel ((numFaces+31)/32 words, every word written, no clearing
-// needed) -- the bits LaunchCompactOwners packs into the per-view owner lists. In Debug,
-// LaunchCheckProjection then asserts every covered pixel received its payload.
+// every face f that wrote a pixel ((numFaces+31)/32 words, every word written)
 void LaunchProjectMesh(
 	const Point3* vertices, const Point3u* faces,
 	unsigned long long* projKey, float* depthMap, uint32_t* faceMap, uint32_t* ownerBits,
 	const Camera& camera, uint32_t numFaces, bool resolve);
 
 #ifdef _DEBUG
+// after both passes: every covered pixel received its payload
 void LaunchCheckProjection(
 	const unsigned long long* projKey,
 	const float* depthMap, const uint32_t* faceMap, int width, int height);
 #endif
 
-// The per-pair-direction launchers below and the two that follow the directions take the
-// stream they are issued on: MeshRefineCUDA::ScoreMesh records them into a CUDA graph.
+// the dense per-view owner lists, once per evaluation after every view is rasterized: counts
+// receives per view the popcount of its numWords owner words and offsets (numViews+1 entries)
+// their exclusive prefix sum then the total; ownerList (sized by the host to that total)
+// receives every view's owner faces in face order from its offset on; then every view's slice
+// of listIn is reordered into listOut by the image tile (2^tileShiftX x 2^tileShiftY pixels)
+// the face's box starts in, keys being scratch of the same size, with at most maxBuckets tiles
+// in any view, cameras one Camera per view
+void LaunchCountOwners(const uint32_t* ownerBits, uint32_t* counts, uint32_t* offsets, uint32_t numWords, uint32_t numViews);
+void LaunchCompactOwners(const uint32_t* ownerBits, const uint32_t* offsets, uint32_t* ownerList, uint32_t numWords, uint32_t numViews);
+void LaunchSortOwnersTile(
+	const Point3* vertices, const Point3u* faces, const Camera* cameras,
+	const uint32_t* offsets, const uint32_t* listIn, uint32_t* keys, uint32_t* listOut,
+	int tileShiftX, int tileShiftY, uint32_t maxBuckets, uint32_t numViews);
 
-// keepA/keepB are the per-pixel keep-masks of image A/B (one byte per pixel, non-zero = keep),
-// NULL if disabled -- see kernelImageMeshWarp
+// image B warped into A through the mesh, and mask, the pixels that made it; keepA/keepB are
+// the per-pixel keep-masks (one byte per pixel, non-zero = keep), NULL if disabled
 void LaunchImageMeshWarp(
 	const float* depthMapA, const float* depthMapB,
 	const uint8_t* keepA, const uint8_t* keepB, uint8_t* mask,
@@ -77,19 +89,14 @@ void LaunchImageMeshWarp(
 	cudaSurfaceObject_t surfImageProj,
 	cudaStream_t stream);
 
-// masked window statistics, rejection gates, ZNCC, its derivative and the pixel's photometric
-// term in one pass: pixelGrad receives g_p, the scalar the covering face's three corners share
-// before their barycentrics (computePhotoPixel), and maskOut the pixels that contribute one -- a
-// SECOND mask buffer (the window loops still read mask), pruned of the pixels whose window held
-// fewer than Refine::MinWindowCount valid samples, that failed a gate or that see the surface at
-// a grazing angle; kernelAccumulateFacePhoto reads both. blockSums receives this pair-direction's
-// per-block partials of the two reliability sums S is reduced from, 2 floats per 16x16 block from
-// slot 0 of the passed pointer on; the number of blocks written is returned, and
-// LaunchReduceBlockSums folds every direction's slots once per ScoreMesh() in slot order, so
-// that S is a fixed sequence of additions. texImageB is sampled directly (four texel fetches)
+// the masked window statistics, rejection gates, ZNCC, its derivative and the pixel's
+// photometric term in one pass: pixelGrad receives g_p, the scalar the covering face's corners
+// share before their barycentrics, and maskOut (a second buffer, the window loops still read
+// mask) the pixels that contribute one. blockSums receives this pair-direction's per-block
+// partials of the two reliability sums S is reduced from, 2 floats per 16x16 block from slot 0
+// of the passed pointer on; returns the number of blocks written. texImageB is sampled directly
 // when bBilinearGrad asks for the derivative of the bilinear interpolant instead of the
-// precomputed gradient stencil (OPTREFINE::nImageGradient == 3, where texGradXB/texGradYB carry
-// no texture and are unused).
+// precomputed stencil textures (OPTREFINE::nImageGradient == 3, texGradXB/texGradYB unused).
 uint32_t LaunchComputeWindowStats(
 	const uint8_t* mask, uint8_t* maskOut, float* pixelGrad, float* blockSums,
 	cudaSurfaceObject_t surfImageA, cudaSurfaceObject_t surfImageProj,
@@ -99,49 +106,28 @@ uint32_t LaunchComputeWindowStats(
 	bool bBilinearGrad, float regScale, float gateMeanDiff, float gateVarRatio, int width, int height,
 	cudaStream_t stream);
 
-// sumR/sumRZ receive the sums of the numSlots partials
-void LaunchReduceBlockSums(const float* blockSums, uint32_t numSlots, float* sumR, float* sumRZ, cudaStream_t stream);
-
-// the dense per-view owner lists, once per evaluation after every view is rasterized (see
-// kernelCompactOwners): counts receives per view the popcount of its numWords owner words,
-// offsets (numViews+1 entries) their exclusive prefix sum and, last, the total, and ownerList
-// (sized by the host to that total) every view's owner faces in face order from its offset on
-void LaunchCountOwners(const uint32_t* ownerBits, uint32_t* counts, uint32_t numWords, uint32_t numViews);
-void LaunchScanViewCounts(const uint32_t* counts, uint32_t* offsets, uint32_t numViews);
-void LaunchCompactOwners(const uint32_t* ownerBits, const uint32_t* offsets, uint32_t* ownerList, uint32_t numWords, uint32_t numViews);
-// then every view's slice of listIn reordered into listOut by the image tile (2^tileShiftX x
-// 2^tileShiftY pixels) the face's box starts in, keys being scratch of the same size, with at
-// most maxBuckets tiles in any view (see kernelSortOwnersTile); cameras is one Camera per view
-void LaunchSortOwnersTile(
-	const Point3* vertices, const Point3u* faces, const Camera* cameras,
-	const uint32_t* offsets, const uint32_t* listIn, uint32_t* keys, uint32_t* listOut,
-	int tileShiftX, int tileShiftY, uint32_t maxBuckets, uint32_t numViews);
-
-// the photometric accumulation, atomic-free so that the per-vertex sums are bit-reproducible run
-// to run (float addition is not associative). Per pair-direction: one thread per face the
-// reference view idxView OWNS (its slice of ownerList, LaunchSortOwnersTile's list, read from
-// ownerOffsets on the device; numBlocks blocks of AccumulateBlockSize threads stride over it)
-// folds that face's contributing pixels -- barycentrics and depth recomputed from its
-// projection, see kernelAccumulateFacePhoto -- into its private slots -- faceAcc, 3 floats per
-// face (one per corner: Sum g_p*b_c), facePixels, the contributing pixel count, and faceFoot,
-// the min footprint (only read where facePixels > 0) -- accumulated ACROSS the pair-directions
-// of one ScoreMesh() (cleared by the host once per call), and counts the direction once in
-// photoCount for each of the face's three vertices (exactly the CPU's
-// `photoGradNorm[idxVert] += 1.f` per pair-direction) through vertexStamp, one word per vertex
-// the host sets to ~0u once per ScoreMesh() -- direction is this pair-direction's index in it.
-constexpr int AccumulateBlockSize = 128;
+// the atomic-free photometric accumulation of one pair-direction: one thread per face the
+// reference view idxView owns (its slice of ownerList, read from ownerOffsets on the device;
+// numOwners sizes the grid, with a margin, for the evaluations that replay the launch) folds
+// its contributing pixels into its private slots, faceAcc (3 floats per face, one per corner:
+// Sum g_p*b_c), facePixels (the contributing pixel count) and faceFoot (the min footprint, read
+// only where facePixels > 0), accumulated across the directions of one evaluation (cleared by
+// the host once per evaluation), and counts the direction once per vertex in photoCount through
+// vertexStamp (one word per vertex, set to ~0u by the host once per evaluation)
 void LaunchAccumulateFacePhoto(
 	const Point3* vertices, const Point3u* faces,
 	const uint32_t* ownerList, const uint32_t* ownerOffsets, uint32_t idxView,
 	const uint32_t* faceMap, const float* pixelGrad, const uint8_t* mask,
 	float* faceAcc, float* facePixels, float* faceFoot,
 	uint32_t* vertexStamp, float* photoCount, uint32_t direction,
-	const Camera& camA, uint32_t numBlocks, cudaStream_t stream);
+	const Camera& camA, uint32_t numOwners, cudaStream_t stream);
 
-// once per ScoreMesh(), after every pair-direction: one thread per vertex folds its incident
-// faces' slots in the fixed order Mesh::ListIncidentFaces produced (vertFaces/vertFaceSizes/
-// vertFacePointers, the same flattening as vertVertices) into photoGrad and footprint, the latter
-// 0 exactly where no face contributed (contract: footprint[v] > 0 iff photoCount[v] > 0)
+// once per evaluation after every pair-direction: sumR/sumRZ receive the sums of the numSlots
+// partials, in slot order ...
+void LaunchReduceBlockSums(const float* blockSums, uint32_t numSlots, float* sumR, float* sumRZ, cudaStream_t stream);
+// ... and one thread per vertex folds its incident faces' slots, in the fixed order of
+// vertFaces/vertFaceSizes/vertFacePointers (Mesh::ListIncidentFaces, flattened like
+// vertVertices), into photoGrad and footprint, the latter 0 exactly where no face contributed
 void LaunchGatherVertexPhoto(
 	const Point3u* faces, const Point3* normals,
 	const uint32_t* vertFaces, const uint32_t* vertFaceSizes, const uint32_t* vertFacePointers,
@@ -158,6 +144,7 @@ void LaunchComputeSmoothnessGradient(
 void LaunchComputeFaceNormal(
 	const Point3* vertices, const Point3u* faces,
 	Point3* normals, uint32_t numFaces);
+
 // the preparation's projected face areas (MeshRefineCUDA::ListFaceAreas): hist, zeroed by the
 // caller, receives the rasterized pixel count of every face in one view's face map ...
 void LaunchFaceHistogram(const uint32_t* faceMap, uint32_t* hist, uint32_t numPixels);

--- a/libs/MVS/SceneRefineCUDA.inl
+++ b/libs/MVS/SceneRefineCUDA.inl
@@ -51,7 +51,7 @@ namespace CUDA {
 // ~0ull); resolve=true lets the thread holding each pixel's winning key write depth/face (faceMap
 // pre-filled with NO_ID, depthMap with 0) and, when ownerBits is not NULL, sets bit f of it for
 // every face f that wrote a pixel ((numFaces+31)/32 words, every word written, no clearing
-// needed) -- the bits LaunchAccumulateFacePhoto skips the unseen faces by. In Debug,
+// needed) -- the bits LaunchCompactOwners packs into the per-view owner lists. In Debug,
 // LaunchCheckProjection then asserts every covered pixel received its payload.
 void LaunchProjectMesh(
 	const Point3* vertices, const Point3u* faces,
@@ -64,6 +64,9 @@ void LaunchCheckProjection(
 	const float* depthMap, const uint32_t* faceMap, int width, int height);
 #endif
 
+// The per-pair-direction launchers below and the two that follow the directions take the
+// stream they are issued on: MeshRefineCUDA::ScoreMesh records them into a CUDA graph.
+
 // keepA/keepB are the per-pixel keep-masks of image A/B (one byte per pixel, non-zero = keep),
 // NULL if disabled -- see kernelImageMeshWarp
 void LaunchImageMeshWarp(
@@ -71,7 +74,8 @@ void LaunchImageMeshWarp(
 	const uint8_t* keepA, const uint8_t* keepB, uint8_t* mask,
 	const Camera& camA, const Camera& camB,
 	cudaTextureObject_t texImageB,
-	cudaSurfaceObject_t surfImageProj);
+	cudaSurfaceObject_t surfImageProj,
+	cudaStream_t stream);
 
 // masked window statistics, rejection gates, ZNCC, its derivative and the pixel's photometric
 // term in one pass: pixelGrad receives g_p, the scalar the covering face's three corners share
@@ -92,29 +96,47 @@ uint32_t LaunchComputeWindowStats(
 	const Point3* normals, const uint32_t* faceMap, const float* depthMap,
 	const Camera& camA, const Camera& camB,
 	cudaTextureObject_t texImageB, cudaTextureObject_t texGradXB, cudaTextureObject_t texGradYB,
-	bool bBilinearGrad, float regScale, float gateMeanDiff, float gateVarRatio, int width, int height);
+	bool bBilinearGrad, float regScale, float gateMeanDiff, float gateVarRatio, int width, int height,
+	cudaStream_t stream);
 
 // sumR/sumRZ receive the sums of the numSlots partials
-void LaunchReduceBlockSums(const float* blockSums, uint32_t numSlots, float* sumR, float* sumRZ);
+void LaunchReduceBlockSums(const float* blockSums, uint32_t numSlots, float* sumR, float* sumRZ, cudaStream_t stream);
+
+// the dense per-view owner lists, once per evaluation after every view is rasterized (see
+// kernelCompactOwners): counts receives per view the popcount of its numWords owner words,
+// offsets (numViews+1 entries) their exclusive prefix sum and, last, the total, and ownerList
+// (sized by the host to that total) every view's owner faces in face order from its offset on
+void LaunchCountOwners(const uint32_t* ownerBits, uint32_t* counts, uint32_t numWords, uint32_t numViews);
+void LaunchScanViewCounts(const uint32_t* counts, uint32_t* offsets, uint32_t numViews);
+void LaunchCompactOwners(const uint32_t* ownerBits, const uint32_t* offsets, uint32_t* ownerList, uint32_t numWords, uint32_t numViews);
+// then every view's slice of listIn reordered into listOut by the image tile (2^tileShiftX x
+// 2^tileShiftY pixels) the face's box starts in, keys being scratch of the same size, with at
+// most maxBuckets tiles in any view (see kernelSortOwnersTile); cameras is one Camera per view
+void LaunchSortOwnersTile(
+	const Point3* vertices, const Point3u* faces, const Camera* cameras,
+	const uint32_t* offsets, const uint32_t* listIn, uint32_t* keys, uint32_t* listOut,
+	int tileShiftX, int tileShiftY, uint32_t maxBuckets, uint32_t numViews);
 
 // the photometric accumulation, atomic-free so that the per-vertex sums are bit-reproducible run
-// to run (float addition is not associative). Per pair-direction: one thread per MESH face,
-// exiting on the reference view's owner bit (LaunchProjectMesh) unless the face owns a pixel
-// there, folds that face's contributing pixels -- barycentrics and depth recomputed from its
+// to run (float addition is not associative). Per pair-direction: one thread per face the
+// reference view idxView OWNS (its slice of ownerList, LaunchSortOwnersTile's list, read from
+// ownerOffsets on the device; numBlocks blocks of AccumulateBlockSize threads stride over it)
+// folds that face's contributing pixels -- barycentrics and depth recomputed from its
 // projection, see kernelAccumulateFacePhoto -- into its private slots -- faceAcc, 3 floats per
 // face (one per corner: Sum g_p*b_c), facePixels, the contributing pixel count, and faceFoot,
 // the min footprint (only read where facePixels > 0) -- accumulated ACROSS the pair-directions
-// of one ScoreMesh() (cleared by the host once per call), and marks the face's three vertices in
-// vertexSeen.
+// of one ScoreMesh() (cleared by the host once per call), and counts the direction once in
+// photoCount for each of the face's three vertices (exactly the CPU's
+// `photoGradNorm[idxVert] += 1.f` per pair-direction) through vertexStamp, one word per vertex
+// the host sets to ~0u once per ScoreMesh() -- direction is this pair-direction's index in it.
+constexpr int AccumulateBlockSize = 128;
 void LaunchAccumulateFacePhoto(
-	const Point3* vertices, const Point3u* faces, const uint32_t* ownerBits,
+	const Point3* vertices, const Point3u* faces,
+	const uint32_t* ownerList, const uint32_t* ownerOffsets, uint32_t idxView,
 	const uint32_t* faceMap, const float* pixelGrad, const uint8_t* mask,
-	float* faceAcc, float* facePixels, float* faceFoot, uint8_t* vertexSeen,
-	const Camera& camA, uint32_t numFaces);
-
-// right after it: one thread per vertex counts this pair-direction in photoCount for every
-// marked vertex and clears the mark (exactly the CPU's `photoGradNorm[idxVert] += 1.f`)
-void LaunchCountSeenVertices(uint8_t* vertexSeen, float* photoCount, uint32_t numVertices);
+	float* faceAcc, float* facePixels, float* faceFoot,
+	uint32_t* vertexStamp, float* photoCount, uint32_t direction,
+	const Camera& camA, uint32_t numBlocks, cudaStream_t stream);
 
 // once per ScoreMesh(), after every pair-direction: one thread per vertex folds its incident
 // faces' slots in the fixed order Mesh::ListIncidentFaces produced (vertFaces/vertFaceSizes/
@@ -124,7 +146,7 @@ void LaunchGatherVertexPhoto(
 	const Point3u* faces, const Point3* normals,
 	const uint32_t* vertFaces, const uint32_t* vertFaceSizes, const uint32_t* vertFacePointers,
 	const float* faceAcc, const float* facePixels, const float* faceFoot,
-	Point3* photoGrad, float* footprint, uint32_t numVertices);
+	Point3* photoGrad, float* footprint, uint32_t numVertices, cudaStream_t stream);
 
 // mode selects the level (0 - level 1, over vertex positions; nonzero - level 2, over
 // smoothGrad1)

--- a/libs/MVS/SceneRefineCUDA.inl
+++ b/libs/MVS/SceneRefineCUDA.inl
@@ -46,19 +46,19 @@ namespace CUDA {
 
 // Launcher function declarations for all mesh refinement CUDA kernels
 
-// rasterizer, per visible face, launched twice: resolve=false does an atomicMin of the
-// (depth, position-in-faceIDs) key into projKey (one 64-bit word per pixel, pre-filled with
+// rasterizer over the whole mesh, one thread per face, launched twice: resolve=false does an
+// atomicMin of the (depth, face id) key into projKey (one 64-bit word per pixel, pre-filled with
 // ~0ull); resolve=true lets the thread holding each pixel's winning key write depth/face/bary
 // (faceMap pre-filled with NO_ID, depthMap with 0). In Debug, LaunchCheckProjection then asserts
 // every covered pixel received its payload.
 void LaunchProjectMesh(
-	const Point3* vertices, const Point3u* faces, const uint32_t* faceIDs,
-	unsigned long long* projKey, float* depthMap, uint32_t* faceMap, uint16_t* baryMap,
-	const Camera& camera, uint32_t numFacesView, bool resolve);
+	const Point3* vertices, const Point3u* faces,
+	unsigned long long* projKey, float* depthMap, uint32_t* faceMap, ushort4* baryMap,
+	const Camera& camera, uint32_t numFaces, bool resolve);
 
 #ifdef _DEBUG
 void LaunchCheckProjection(
-	const uint32_t* faceIDs, const unsigned long long* projKey,
+	const unsigned long long* projKey,
 	const float* depthMap, const uint32_t* faceMap, int width, int height);
 #endif
 
@@ -71,49 +71,57 @@ void LaunchImageMeshWarp(
 	cudaTextureObject_t texImageB,
 	cudaSurfaceObject_t surfImageProj);
 
-// masked window statistics, rejection gates, ZNCC and its derivative in one pass; maskOut is a
+// masked window statistics, rejection gates, ZNCC, its derivative and the pixel's photometric
+// term in one pass: pixelGrad receives g_p, the scalar the covering face's three corners share
+// before their barycentrics (computePhotoPixel), and maskOut the pixels that contribute one -- a
 // SECOND mask buffer (the window loops still read mask), pruned of the pixels whose window held
-// fewer than Refine::MinWindowCount valid samples or that failed a gate -- every consumer
-// downstream reads maskOut. sumR/sumRZ are the device scalars ScoreMesh reduces into S, and
-// blockSums is the scratch this launch's two kernels hand them over in -- 2 floats per 16x16
-// block of the largest view, so that S is a fixed sequence of additions.
-void LaunchComputeWindowStats(
-	const uint8_t* mask, uint8_t* maskOut, float* dzncc,
+// fewer than Refine::MinWindowCount valid samples, that failed a gate or that see the surface at
+// a grazing angle; kernelAccumulateFacePhoto reads both. blockSums receives this pair-direction's
+// per-block partials of the two reliability sums S is reduced from, 2 floats per 16x16 block from
+// slot 0 of the passed pointer on; the number of blocks written is returned, and
+// LaunchReduceBlockSums folds every direction's slots once per ScoreMesh() in slot order, so
+// that S is a fixed sequence of additions. texImageB is sampled directly (four texel fetches)
+// when bBilinearGrad asks for the derivative of the bilinear interpolant instead of the
+// precomputed gradient stencil (OPTREFINE::nImageGradient == 3, where texGradXB/texGradYB carry
+// no texture and are unused).
+uint32_t LaunchComputeWindowStats(
+	const uint8_t* mask, uint8_t* maskOut, float* pixelGrad, float* blockSums,
 	cudaSurfaceObject_t surfImageA, cudaSurfaceObject_t surfImageProj,
-	float* sumR, float* sumRZ, float* blockSums, float gateMeanDiff, float gateVarRatio, int width, int height);
-
-// the photometric accumulation, in two atomic-free halves so that the per-vertex sums are
-// bit-reproducible run to run (float addition is not associative). First half: one thread per
-// MESH face (not per face of this view -- see kernelAccumulateFacePhoto), reducing that face's
-// pixels into private per-face slots; every thread writes its slots, so no buffer needs clearing
-// between pair-directions. faceAcc holds 3 floats per face (one per corner), facePixels/faceFoot
-// one; faceFoot is only read where facePixels > 0. texImageB is the image B texture, sampled
-// directly (four texel fetches) when bBilinearGrad asks for the derivative of the bilinear
-// interpolant instead of the precomputed gradient stencil (OPTREFINE::nImageGradient == 3, where
-// texGradXB/texGradYB carry no texture and are unused).
-void LaunchAccumulateFacePhoto(
-	const Point3* vertices, const Point3u* faces, const Point3* normals,
-	const float* depthMap, const uint32_t* faceMap, const uint16_t* baryMap,
-	const float* dzncc, const uint8_t* mask,
-	float* faceAcc, float* facePixels, float* faceFoot,
+	const Point3* normals, const uint32_t* faceMap, const float* depthMap,
 	const Camera& camA, const Camera& camB,
 	cudaTextureObject_t texImageB, cudaTextureObject_t texGradXB, cudaTextureObject_t texGradYB,
-	bool bBilinearGrad, float regScale,
-	uint32_t numFaces);
+	bool bBilinearGrad, float regScale, float gateMeanDiff, float gateVarRatio, int width, int height);
 
-// Second half: one thread per vertex, folding its incident faces' slots in the fixed order
-// Mesh::ListIncidentFaces produced (vertFaces/vertFaceSizes/vertFacePointers, the same flattening
-// as vertVertices). It also does this pair-direction's photoGradNorm += 1 bookkeeping.
+// sumR/sumRZ receive the sums of the numSlots partials
+void LaunchReduceBlockSums(const float* blockSums, uint32_t numSlots, float* sumR, float* sumRZ);
+
+// the photometric accumulation, atomic-free so that the per-vertex sums are bit-reproducible run
+// to run (float addition is not associative). Per pair-direction: one thread per MESH face (not
+// per face of this view -- see kernelAccumulateFacePhoto) folds that face's contributing pixels
+// into its private slots -- faceAcc, 3 floats per face (one per corner: Sum g_p*b_c),
+// facePixels, the contributing pixel count, and faceFoot, the min footprint (only read where
+// facePixels > 0) -- accumulated ACROSS the pair-directions of one ScoreMesh() (cleared by the
+// host once per call), and marks the face's three vertices in vertexSeen.
+void LaunchAccumulateFacePhoto(
+	const Point3* vertices, const Point3u* faces,
+	const float* depthMap, const uint32_t* faceMap, const ushort4* baryMap,
+	const float* pixelGrad, const uint8_t* mask,
+	float* faceAcc, float* facePixels, float* faceFoot, uint8_t* vertexSeen,
+	const Camera& camA, uint32_t numFaces);
+
+// right after it: one thread per vertex counts this pair-direction in photoCount for every
+// marked vertex and clears the mark (exactly the CPU's `photoGradNorm[idxVert] += 1.f`)
+void LaunchCountSeenVertices(uint8_t* vertexSeen, float* photoCount, uint32_t numVertices);
+
+// once per ScoreMesh(), after every pair-direction: one thread per vertex folds its incident
+// faces' slots in the fixed order Mesh::ListIncidentFaces produced (vertFaces/vertFaceSizes/
+// vertFacePointers, the same flattening as vertVertices) into photoGrad and footprint, the latter
+// 0 exactly where no face contributed (contract: footprint[v] > 0 iff photoCount[v] > 0)
 void LaunchGatherVertexPhoto(
 	const Point3u* faces, const Point3* normals,
 	const uint32_t* vertFaces, const uint32_t* vertFaceSizes, const uint32_t* vertFacePointers,
 	const float* faceAcc, const float* facePixels, const float* faceFoot,
-	Point3* photoGrad, float* photoGradNorm, float* footprint,
-	uint32_t numVertices);
-
-// once per ScoreMesh(), after every pair-direction: resolves the footprint sentinel now that
-// photoGradNorm holds its final per-vertex count for this ScoreMesh() call.
-void LaunchFinalizePhotoGrad(const float* photoGradNorm, float* footprint, uint32_t numVertices);
+	Point3* photoGrad, float* footprint, uint32_t numVertices);
 
 // mode selects the level (0 - level 1, over vertex positions; nonzero - level 2, over
 // smoothGrad1)

--- a/libs/MVS/SceneRefineCommon.cpp
+++ b/libs/MVS/SceneRefineCommon.cpp
@@ -422,8 +422,7 @@ MeshRefineStep::Action MeshRefineStep::Evaluate(const Terms& terms, Mesh::Vertex
 	// proportional to eta, and eta is the bold driver's own state -- a rejection halves it while
 	// an acceptance only grows it by 1.1, so an accept/reject oscillation around a plateau
 	// ratchets eta down by 0.55 per cycle and would otherwise report convergence while the
-	// direction field is still large (measured on Truck: eta collapsed 0.605 -> 0.101 px over
-	// five evaluations and the scale stopped at 0.023 px with S improved by only 0.4%)
+	// direction field is still large
 	if (numAccepted >= MinIters && stats.medianPx*(StepMax/step) < StepStop)
 		return STOP;
 	return APPLY;

--- a/libs/MVS/SceneRefineCommon.h
+++ b/libs/MVS/SceneRefineCommon.h
@@ -72,7 +72,7 @@ namespace Refine {
 
 // window used to compute local image statistics (mean/variance/ZNCC) during
 // photo-consistency optimization; shared by both backends so a 7x7 window is
-// what each one sees (CUDA used to run its own HalfSize=2, i.e. 5x5)
+// what each one sees
 constexpr int HalfSize = 3;
 constexpr int Border = HalfSize;
 constexpr int WindowSize = HalfSize*2+1;
@@ -482,8 +482,7 @@ public:
 	static constexpr float StepMax = 1.f; // eta never exceeds this, px
 	// StepGrow is tied to the pre-blur sigma the caller passes to InitImages(): sharpening the
 	// images makes the objective more locally rugged, and 1.1 then over-steps it. The two move
-	// together or not at all -- reverting either one alone measures WORSE than reverting both
-	// (design document, the default-parameter sweep)
+	// together or not at all (see the design document)
 	static constexpr float StepGrow = 1.05f; // eta *= this after an accepted evaluation
 	static constexpr float StepShrink = 0.5f; // eta *= this after a rejected one
 	static constexpr float ProgressTol = 1e-3f; // relative decrease of S at or below which an evaluation counts as stalled

--- a/ports/halfmesh/portfile.cmake
+++ b/ports/halfmesh/portfile.cmake
@@ -3,18 +3,17 @@ if(VCPKG_TARGET_IS_WINDOWS)
 endif()
 
 # 0.3.0 carries the mesh-repair, rect-packing and selected-fill work that this
-# port used to apply as patches, so no patch is needed any more.
-# REF is a develop commit and not a tag on purpose: the per-vertex decimation error bound
-# (Simplify(..., vertexMaxError)) and the caller-supplied remesh sizing field
-# (RemeshParams::vertexSizing) -- what --simplify-tolerance and --adaptive-face-size are built
-# on -- are merged upstream but not released, so halfmesh still declares 0.3.0 and its
-# CMakeLists fails the configure if the version below disagrees with it. Point REF at the tag
-# once a release carrying them is cut; bump port-version whenever REF moves.
+# port used to apply as patches, so no patch is needed any more. 0.4.0 releases the
+# per-vertex decimation error bound (Simplify(..., vertexMaxError)) and the caller-supplied
+# remesh sizing field (RemeshParams::vertexSizing) -- what --simplify-tolerance and
+# --adaptive-face-size are built on -- which this port used to reach by pinning a develop
+# commit. halfmesh's CMakeLists fails the configure if the version in vcpkg.json disagrees
+# with the one it declares, so the two move together.
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cdcseacave/halfmesh
-    REF 90778de1d9b18dccbd39a7df684efb75204265af
-    SHA512 4a17d4e0be93236fbdab4c7971a70b9c829de37e3622f11d36618cd3b2b022ca827d00dc6988eca904bfed0f822d547cb55b7f4b43e53c4721985cd19aa75294
+    REF v${VERSION}
+    SHA512 cbbaaa30a03b0de94c64a6744e95a1d5d0ececcf18db0b54479ef11eb8d0b678f0db052acd2ef7d742110a1ca0c19c69e62f098aa90862f118fd9439d0103966
     HEAD_REF develop
 )
 

--- a/ports/halfmesh/vcpkg.json
+++ b/ports/halfmesh/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "halfmesh",
-  "version": "0.3.0",
-  "port-version": 9,
+  "version": "0.4.0",
   "description": "Fast, compact half-edge triangle mesh processing library",
   "homepage": "https://github.com/cdcseacave/halfmesh",
   "license": "MIT",


### PR DESCRIPTION
Closes the RefineMesh campaign branch. The refinement now sizes and decimates
the mesh against a single measurement, two of the campaign's arms become
defaults, and the instrumentation that measured them is gone.

## What ships

- **`--simplify-tolerance` 0.25 px, on by default.** The refined mesh is
  decimated within a reprojection tolerance once the last scale ends,
  roughly halving the face count at unchanged accuracy. Measured on the
  threshold-free EPFL metrics rather than F1-at-tau, which is blind to a pass
  whose whole point is to stay inside tau.
- **`--adaptive-face-size`, on by default.** The preparation grades each face
  to the area it projects to in the pair that refines it, instead of one
  world-space density for the whole mesh. Neutral where the camera-to-surface
  distance is constant, which is most of this benchmark; correct where it is
  not.
- **`--fast`** = `--max-face-area 32 --simplify-tolerance 0.5`, a preset that
  fills in only what the command line did not state itself.
- **`--remove-unseen-faces` moves to TransformScene**, where it belongs.
- Four places asked "how big does this face project?" and three agreed;
  the post-refinement decimation now reads the same tightest-pair rasterized
  areas as the split rule and the sizing field.

## Measurements

Every number is in `docs/design/MeshRefinement.md`, including the rejected
ideas (section 4, 46 rows) and why each was rejected.

Shipped defaults against the previous behaviour on Tanks & Temples: +0.0009
mean F1 at 0.83x faces and 0.90x wall, no scene below -0.0012.

CPU/CUDA on the shipped defaults is below, under *Against the CPU backend*.

## Removed

The CPU/CUDA side-by-side export found six defects during the campaign and
has nothing left to find, so it goes, along with the buffers and CUDA kernels
that existed only to be compared against. The combined gradient goes with
them on the stepper's path: only the Ceres arm and the planar-vertex hook
read it, and the stepper reads the per-vertex terms separately.

## Also in here

`--ignore-mask-label` was assigned to `OPTREFINE` unconditionally, so its CLI
default (-1) silently undid `nIgnoreMaskLabel` set in a `--refine-config-file`
— a correctly spelled key, so the unknown-key check below it never fired
either. It now follows the same `.defaulted()` rule as the two options beside
it. Pre-existing (it came in with #1299), unrelated to the CUDA work, folded in
here because it is one line in a file this branch already touches. Verified
with the `< -1` validator as a probe: a config setting -5 now reaches the
validator and is rejected, while `--ignore-mask-label 0` on the command line
still overrides the file.

## Note for review

The halfmesh port is on the **0.4.0 release**, back on a tag (`REF v${VERSION}`,
which halfmesh's own version guard keeps honest) after pinning a develop commit
for the per-vertex decimation error bound and the remesh sizing field that
`--simplify-tolerance` and `--adaptive-face-size` need — 0.4.0 releases both.

The only upstream change since that pinned commit is atlas/unwrap work. It
lands in `PackAtlas`, which OpenMVS never calls; the public `PackRectangles`
that `SceneTexture` uses fills its new per-rect padding array with the uniform
value and is unchanged by construction. `RectPacking.h`, `TextureBake.h` and
`InteropOpenMVS.h` are untouched and no dependency moved. Verified by building
against 0.4.0 and running the full `Tests.exe` suite plus `Tests.exe 2 2`, both
exit 0.

## CUDA speedup, end to end

Three rounds of GPU work land on this branch (detailed below). Against the
first CUDA build of the branch — the same source otherwise, the same defaults,
the same RTX 4070 — the shipped backend is **2.3-3.0x faster end to end** on
the many-view Tanks & Temples scenes:

| scene | first CUDA build | shipped | end to end |
|---|---|---|---|
| Barn | 241.6 s | 81.5 s | **3.0x** |
| Ignatius | 75.3 s | 32.3 s | **2.4x** |
| Truck | 85.2 s | 38.5 s | **2.3x** |
| Meetingroom | 110.7 s | 67.9 s | 1.6x (**2.4x** per scale-1 evaluation) |

Walls are only comparable within one machine state, so each row composes two
back-to-back pairs, each measured in its own state: rounds 1→2 (§2.2 of the
design document) and rounds 2→3. Meetingroom's end-to-end wall understates the
work because the shipped build converges further (26 → 35 evaluations); per
scale-1 evaluation it is 3.6 s → 1.5 s.

Where the time went, per evaluation on Ignatius at level 1 (263 views of
960x540, 1,430 pairs = 2,860 pair-directions), first CUDA build → shipped:

| per evaluation, Ignatius level 1 | first build | shipped |
|---|---|---|
| GPU kernels, scale 0 / scale 1 | 276 / 638 ms | 102 / 246 ms |
| host gap to the next evaluation, scale 0 / scale 1 | 70 / 135 ms | 2-6 / 3-7 ms |
| `kernelAccumulateFacePhoto`, scale 0 / scale 1 | 55 / 139 us | 15 / 35 us |
| `kernelComputeWindowStats`, scale 0 / scale 1 | 10 / 24 us | 11 / 25 us |
| D2H copies per run | 1,351 / 1.68 GB | 41 / 188 MB |
| scale switch (host image preparation + upload) | 1.17 s + 0.47 s | 0.01 s + 0.44 s |
| device memory per view | 29 B/px | 21 B/px |

The kernels are 2.6-2.7x cheaper, the accumulation alone 3.7-4.0x, and the
host is no longer on the critical path. Round 3 additionally took the host's
launch API from 9.5 s to 1.1 s per run by replaying the direction loop as a
CUDA graph — at the coarse scale the ~10 us per launch under WDDM had become
the ceiling (98 ms of launch API against 103 ms of kernels).

On the 8-view EPFL scenes none of the many-view machinery matters and the
host-side mesh preparation both backends share caps the ratio (Herz-Jesu-P8:
5.3 s of the 8.4 s wall); there the refinement loop alone runs about **15x**
faster than the CPU's, and the end-to-end CPU/CUDA ratio stays near 3x.

**Accuracy is unaffected.** Round 3's output is byte-identical to round 2's on
all four scenes, and CUDA is bit-reproducible: three identical Ignatius runs
give F1 0.7730 / 0.7730 / 0.7730, 413,865 faces and 23 evaluations — a
run-to-run spread of exactly 0. Round 2's F1 moves only within the run-to-run
band of a changed trajectory (Ignatius 0.7793 → 0.7801, Truck 0.6660 → 0.6660,
Barn 0.6768 → 0.6757, Meetingroom 0.4135 → 0.4134).

### Against the CPU backend

The two backends are compared where ground truth exists — the EPFL scenes —
on the shipped defaults, each column measured in its own machine state:

| scene | F1 CPU | F1 CUDA | CPU − CUDA | evaluations CPU / CUDA | wall CPU / CUDA | speedup |
|---|---|---|---|---|---|---|
| Herz-Jesu-P8 | 0.45111 | 0.45110 | +0.0000 | 57 / 51 | 25.5 s / 9.0 s | **2.8x** |
| fountain-P11 | 0.34520 | 0.34655 | −0.0014 | 54 / 59 | 35.9 s / 11.4 s | **3.2x** |

**Same surface.** Herz-Jesu-P8 agrees to the fifth decimal. fountain-P11's
−0.0014 is not a regression: the evaluation counts no longer match (54 vs 59),
so the two surfaces are compared at slightly different stopping points, and F1
tracks the iteration count closely enough (§2.4) to account for the gap on its
own. The backends stopped agreeing to the fifth decimal only when the GPU
rework moved CUDA *toward* the CPU — the rasterizer's tie-break, the summation
order and the float barycentrics are now the CPU's own.

**Speed.** ~3x end to end is the floor, not the ceiling: on 8-view scenes the
host-side mesh preparation both backends share dominates the wall (5.3 s of the
8.4 s on Herz-Jesu-P8) and no GPU work can touch it. The refinement loop alone
runs about **15x** faster — 1.1 s for 50 evaluations against the CPU's 0.33 s
per evaluation. The many-view Tanks & Temples scenes were measured on CUDA
only, which is why the end-to-end table above is against the branch's first
CUDA build rather than against the CPU.

**Only CUDA is bit-reproducible.** Three identical Ignatius runs give a
run-to-run F1 spread of exactly 0. The CPU merges each pair's contribution
under a lock at the end of `ThProcessPair`, so the summation order — and the
float result — varies run to run unless `--max-threads 1`; its noise floor is
0.0001-0.0009 depending on the scene (mean 0.00028). Both differences above
sit at or inside that floor.

### CUDA backend: the GPU no longer waits for the host (6fc0df7a)

Profiled with Nsight Systems (Herz-Jesu-P8, RTX 4070): the GPU sat idle 27 % of the refinement loop on a host octree rebuilt every evaluation plus per-view face-list alloc/upload/free and five pageable downloads, and 60 % of the kernel time was one divergent face-parallel kernel. Now: whole-mesh rasterization per view, the per-pixel photometric term in the window-statistics kernel, per-face slots persisting across pair-directions with one gather and one pinned download per evaluation. Per evaluation 39+11 ms → 23+2.3 ms (scale 1); refinement loop 1.95 → 1.10 s; F1 parity kept (Herz 0.45216 vs CPU 0.45111, fountain 0.34638 vs 0.34520). Details in `docs/design/MeshRefinement.md` §1.6.1.

### CUDA backend, round 2: hundreds of views (ede46d8b)

Profiled on Ignatius at level 1 (263 views, 2,860 pair-directions per evaluation) instead of the 8-view EPFL scenes: every face-parallel kernel was O(faces x views), the preparation downloaded every view's face map (1.68 GB of D2H per run) and each scale switch reloaded every image on the host while the GPU waited.

- per-view **owner bits** from the rasterizer's second pass (warp ballot); `kernelAccumulateFacePhoto` exits on the bit before touching the face
- **no per-pixel barycentric map**: recomputed in float from the same projection (bit-identical to the rasterizer's, and the CPU's precision); 29 -> 21 bytes per pixel per view
- **`ListFaceAreas` on the GPU** (face histograms + pair reduce, uint16 truncation like the host; a Debug oracle recomputes the host path and asserts equality on every face); D2H per run 1.68 GB -> 188 MB
- the **next scale's images prepared on a thread** (half the cores) while the current scale runs
- window-statistics blocks with no masked sample leave before the window loops

Same machine state, previous CUDA build -> this one: Ignatius 75.3 s -> 34.9 s (36 evaluations both, F1 0.7793 -> 0.7801), Truck 85.2 -> 39.9 s (0.6660 -> 0.6660), Barn 241.6 -> 89.2 s (0.6768 -> 0.6757), Meetingroom 110.7 -> 79.9 s with 35 vs 26 evaluations (2.4x per evaluation); Herz-Jesu-P8 / fountain-P11 back to back 10.0 -> 8.4 s / 16.8 -> 14.4 s, F1 0.45110 (CPU 0.45111) / 0.34655 (CPU 0.34520). Debug `Tests.exe 2 2` with `_HEADLESS_DEBUG`: exit 0, stderr empty; synthetic CUDA/CPU ratio 1.00027. Eight lanes per face was measured (49/88 us vs 26/64 us) and rejected. Ignatius at level 0 still does not fit 12 GB; §1.6.1 of the design document records view streaming as the next step.

### CUDA backend, round 3: the accumulation over owner lists, the evaluation as a graph (6a63d324)

Nsight Compute on `kernelAccumulateFacePhoto` (Ignatius level 1, 55 % of the GPU time): 4.4 active lanes per warp-instruction, 13 of 20 warp cycles stalled on scattered loads, compute 27 % / memory 37 % of peak. The per-face early exit on the owner bit left the warps nearly empty and every lane's box somewhere else in the image.

- the owner bits are packed once per evaluation into **dense per-view lists** (`kernelCountOwners` / `kernelScanViewCounts` / `kernelCompactOwners`) and each view's slice is **sorted by 64x8 image tile** (`kernelSortOwnersTile`, a shared-memory counting sort keyed by the face's clipped box): one thread per owner face, a warp's boxes sharing cache lines (L1 hit 52 -> 78 %); the box rows are walked in chunks whose loads are in flight together
- `kernelCountSeenVertices` is folded into the accumulation through a **per-vertex direction stamp** (`atomicExch`, an integer count, still reproducible): one launch in four gone
- the whole direction loop -- thousands of launches, every argument a constant of the scale -- is **recorded once per scale into a CUDA graph** and replayed by one launch per evaluation (the accumulation reads its slice offsets on the device); the host's ~10 us per launch under WDDM had become the ceiling at the coarse scale (98 ms of launch API for 103 ms of kernels)

Ignatius level 1, per evaluation: accumulation 26 -> 15 us (scale 0), 64 -> 35 us (scale 1); kernels 138 -> 102 ms and 327 -> 246 ms; rasterization to rasterization 160 -> 109 ms and 420 -> 295 ms; host launch API per run 9.5 -> 1.1 s. Walls back to back in one machine state, round 2 -> round 3: Ignatius 35.3 -> 32.3 s, Truck 41.5 -> 38.5, Barn 90.1 -> 81.5, Meetingroom 80.4 -> 67.9 (the mesh preparation dominates the rest). **The output is byte-identical to round 2 on all four scenes**, so the F1 column above stands; Debug `Tests.exe 2 2` exit 0, stderr empty, synthetic ratio 1.00027; the Debug build checks the compaction against the bits and the sort against the compaction on every evaluation. Measured and dropped: a launch bound to 64 registers (spills, +2 ms per evaluation), 128x16 tiles (1.4-2.6 % slower), and a per-pair octree/BVH face preselection (the rasterizer's owner bits already give the exact visible set, occlusion included, for 1-2 ms per evaluation). Details in `docs/design/MeshRefinement.md` §1.6.1.

### Release review (4877fed4)

The CUDA refinement comments carried the history and the measurements of the three rounds above; they now state the contracts only, and `docs/design/MeshRefinement.md` §1.6.1 is rewritten from a changelog of the rounds into what one evaluation does as shipped, one before/after table and one list of what was measured and dropped. Comments elsewhere in the refinement that justified a rule by a benchmark number now state the rule and point to the design document. Two launcher tidy-ups without behaviour change (the owner count and scan issued together; the accumulation sizing its own grid). Verified: Debug `Tests.exe 2 2` exit 0, stderr empty, synthetic ratio 1.00027; the RelWithDebInfo Ignatius level-1 output is byte-identical to 6a63d324's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)






